### PR TITLE
Remove the io monad

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -9,22 +9,20 @@ use vm::{Result, Variants};
 use vm::gc::{Gc, Traverseable};
 use vm::types::*;
 use vm::thread::ThreadInternal;
-use vm::thread::{Thread, Status, RootStr};
-use vm::api::{Array, Generic, VMType, Getable, Pushable, IO, WithVM, Userdata, primitive};
-use vm::api::generic::{A, B};
+use vm::thread::{Thread, Status};
+use vm::api::{Array, Generic, VMType, Getable, Pushable, MaybeError, WithVM, Userdata, primitive};
+use vm::api::generic::A;
 
 use vm::internal::Value;
 
 use super::Compiler;
 
-fn print_int(i: VMInt) -> IO<()> {
+fn print_int(i: VMInt) {
     print!("{}", i);
-    IO::Value(())
 }
 
-fn print(s: RootStr) -> IO<()> {
+fn print(s: &str) {
     println!("{}", &*s);
-    IO::Value(())
 }
 
 struct GluonFile(Mutex<File>);
@@ -43,14 +41,14 @@ impl Traverseable for GluonFile {
     fn traverse(&self, _: &mut Gc) {}
 }
 
-fn open_file(s: &str) -> IO<Userdata<GluonFile>> {
+fn open_file(s: &str) -> MaybeError<Userdata<GluonFile>, String> {
     match File::open(s) {
-        Ok(f) => IO::Value(Userdata(GluonFile(Mutex::new(f)))),
-        Err(err) => IO::Exception(format!("{}", err)),
+        Ok(f) => MaybeError::Ok(Userdata(GluonFile(Mutex::new(f)))),
+        Err(err) => MaybeError::Err(format!("{}", err)),
     }
 }
 
-fn read_file<'vm>(file: WithVM<'vm, &GluonFile>, count: usize) -> IO<Array<'vm, u8>> {
+fn read_file<'vm>(file: WithVM<'vm, &GluonFile>, count: usize) -> MaybeError<Array<'vm, u8>, String> {
     let WithVM { vm, value: file } = file;
     let mut file = file.0.lock().unwrap();
     let mut buffer = Vec::with_capacity(count);
@@ -62,57 +60,54 @@ fn read_file<'vm>(file: WithVM<'vm, &GluonFile>, count: usize) -> IO<Array<'vm, 
                     let stack = vm.get_stack();
                     vm.alloc(&stack, &buffer[..bytes_read])
                 };
-                IO::Value(Getable::from_value(vm, Variants::new(&Value::Array(value)))
+                MaybeError::Ok(Getable::from_value(vm, Variants::new(&Value::Array(value)))
                               .expect("Array"))
             }
-            Err(err) => IO::Exception(format!("{}", err)),
+            Err(err) => MaybeError::Err(format!("{}", err)),
         }
     }
 }
 
-fn read_file_to_string(s: &str) -> IO<String> {
+fn read_file_to_string(s: &str) -> MaybeError<String, String> {
     let mut buffer = String::new();
     match File::open(s).and_then(|mut file| file.read_to_string(&mut buffer)) {
-        Ok(_) => IO::Value(buffer),
+        Ok(_) => MaybeError::Ok(buffer),
         Err(err) => {
             use std::fmt::Write;
             buffer.clear();
             let _ = write!(&mut buffer, "{}", err);
-            IO::Exception(buffer)
+            MaybeError::Err(buffer)
         }
     }
 }
 
-fn read_char() -> IO<char> {
+fn read_char() -> MaybeError<char, String> {
     match stdin().bytes().next() {
         Some(result) => {
             match result {
-                Ok(b) => {
-                    ::std::char::from_u32(b as u32)
-                        .map(IO::Value)
-                        .unwrap_or_else(|| IO::Exception("Not a valid char".into()))
-                }
-                Err(err) => IO::Exception(format!("{}", err)),
+                Ok(b) => ::std::char::from_u32(b as u32).map(MaybeError::Ok)
+                        .unwrap_or_else(|| MaybeError::Err("Not a valid char".into())),
+                Err(err) => MaybeError::Err(format!("{}", err)),
             }
         }
-        None => IO::Exception("No read".into()),
+        None => MaybeError::Err("No read".into()),
     }
 }
 
-fn read_line() -> IO<String> {
+fn read_line() -> MaybeError<String, String> {
     let mut buffer = String::new();
     match stdin().read_line(&mut buffer) {
-        Ok(_) => IO::Value(buffer),
+        Ok(_) => MaybeError::Ok(buffer),
         Err(err) => {
             use std::fmt::Write;
             buffer.clear();
             let _ = write!(&mut buffer, "{}", err);
-            IO::Exception(buffer)
+            MaybeError::Err(buffer)
         }
     }
 }
 
-/// IO a -> (String -> IO a) -> IO a
+/// (() -> a) -> (String -> a) -> a
 fn catch_io(vm: &Thread) -> Status {
     let mut stack = vm.current_frame();
     let frame_level = stack.stack.get_frames().len();
@@ -134,7 +129,7 @@ fn catch_io(vm: &Thread) -> Status {
             let fmt = format!("{}", err);
             fmt.push(vm, &mut stack.stack);
             0.push(vm, &mut stack.stack);
-            match vm.call_function(stack, 2) {
+            match vm.call_function(stack, 1) {
                 Ok(_) => Status::Ok,
                 Err(err) => {
                     stack = vm.current_frame();
@@ -147,7 +142,7 @@ fn catch_io(vm: &Thread) -> Status {
     }
 }
 
-fn run_expr(expr: WithVM<RootStr>) -> IO<String> {
+fn run_expr(expr: WithVM<&str>) -> MaybeError<String, String> {
     let WithVM { vm, value: expr } = expr;
     let mut stack = vm.current_frame();
     let frame_level = stack.stack.get_frames().len();
@@ -155,22 +150,22 @@ fn run_expr(expr: WithVM<RootStr>) -> IO<String> {
     let run_result: StdResult<Generic<A>, _> = Compiler::new().run_expr(vm, "<top>", &expr);
     stack = vm.current_frame();
     match run_result {
-        Ok(value) => IO::Value(format!("{:?}", value.0)),
+        Ok(value) => MaybeError::Ok(format!("{:?}", value.0)),
         Err(err) => {
             let trace = stack.stacktrace(frame_level);
             let fmt = format!("{}\n{}", err, trace);
             while stack.stack.get_frames().len() > frame_level {
                 match stack.exit_scope() {
                     Some(new_stack) => stack = new_stack,
-                    None => return IO::Exception(fmt),
+                    None => return MaybeError::Err(fmt),
                 }
             }
-            IO::Exception(fmt)
+            MaybeError::Err(fmt)
         }
     }
 }
 
-fn load_script(name: WithVM<RootStr>, expr: RootStr) -> IO<String> {
+fn load_script(name: WithVM<&str>, expr: &str) -> MaybeError<String, String> {
     let WithVM { vm, value: name } = name;
     let mut stack = vm.current_frame();
     let frame_level = stack.stack.get_frames().len();
@@ -178,37 +173,24 @@ fn load_script(name: WithVM<RootStr>, expr: RootStr) -> IO<String> {
     let run_result = Compiler::new().load_script(vm, &name[..], &expr);
     stack = vm.current_frame();
     match run_result {
-        Ok(()) => IO::Value(format!("Loaded {}", &name[..])),
+        Ok(()) => MaybeError::Ok(format!("Loaded {}", &name[..])),
         Err(err) => {
             let trace = stack.stacktrace(frame_level);
             let fmt = format!("{}\n{}", err, trace);
             while stack.stack.get_frames().len() > frame_level {
                 match stack.exit_scope() {
                     Some(new_stack) => stack = new_stack,
-                    None => return IO::Exception(fmt),
+                    None => return MaybeError::Err(fmt),
                 }
             }
-            IO::Exception(fmt)
+            MaybeError::Err(fmt)
         }
     }
 }
 
 pub fn load(vm: &Thread) -> Result<()> {
-
     try!(vm.register_type::<GluonFile>("File", &[]));
 
-    // io_bind m f (): IO a -> (a -> IO b) -> IO b
-    //     = f (m ())
-    let io_bind = vec![Pop(1), Push(0), PushInt(0), Call(1), PushInt(0), TailCall(2)];
-    let io_bind_type = <fn (IO<A>, fn (A) -> IO<B>) -> IO<B> as VMType>::make_type(vm);
-    vm.add_bytecode("io_bind", io_bind_type, 3, io_bind);
-
-
-    vm.add_bytecode("io_return",
-                    <fn(A) -> IO<A> as VMType>::make_type(vm),
-                    2,
-                    vec![Pop(1)]);
-    // IO functions
     try!(vm.define_global("io",
                           record!(
         print_int => primitive!(1 print_int),
@@ -219,7 +201,7 @@ pub fn load(vm: &Thread) -> Result<()> {
         read_line => primitive!(0 read_line),
         print => primitive!(1 print),
         catch =>
-            primitive::<fn (IO<A>, fn (StdString) -> IO<A>) -> IO<A>>("io.catch", catch_io),
+            primitive::<fn (fn (()) -> A, fn (StdString) -> A) -> A>("io.catch", catch_io),
         run_expr => primitive!(1 run_expr),
         load_script => primitive!(2 load_script)
     )));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use base::metadata::Metadata;
 
 use vm::Variants;
 use vm::api::generic::A;
-use vm::api::{Getable, VMType, Generic, IO};
+use vm::api::{Getable, VMType, Generic};
 use vm::Error as VMError;
 use vm::compiler::CompiledFunction;
 use vm::thread::{RootedValue, ThreadInternal};
@@ -466,18 +466,6 @@ impl Compiler {
         where T: Getable<'vm> + VMType
     {
         let expected = T::make_type(vm);
-        let (value, actual) = try!(self.run_expr_(vm, name, expr_str, Some(&expected)));
-        unsafe {
-            T::from_value(vm, Variants::new(&value))
-                .ok_or_else(move || Error::from(VMError::WrongType(expected, actual)))
-        }
-    }
-
-    pub fn run_io_expr<'vm, T>(&mut self, vm: &'vm Thread, name: &str, expr_str: &str) -> Result<T>
-        where T: Getable<'vm> + VMType,
-              T::Type: Sized
-    {
-        let expected = IO::<T>::make_type(vm);
         let (value, actual) = try!(self.run_expr_(vm, name, expr_str, Some(&expected)));
         unsafe {
             T::from_value(vm, Variants::new(&value))

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -400,11 +400,6 @@ let monad_List: Monad List = {
     return = \x -> Cons x Nil
 }
 
-let monad_IO: Monad IO = {
-    (>>=) = io_bind,
-    return = io_return
-}
-
 let make_Monad m =
     let { (>>=), return } = m
     let (>>) l r = l >>= \_ -> r
@@ -422,16 +417,6 @@ let make_Monad m =
         lift2 = \f lm rm -> lm >>= \l -> rm >>= \r -> f l r,
         forM_
     }
-
-let functor_IO: Functor IO = {
-    map = \f m1 -> monad_IO.(>>=) m1 (\x -> monad_IO.return (f x))
-}
-
-let applicative_IO: Applicative IO = {
-    (<*>) = \f x ->
-            monad_IO.(>>=) f (\g -> monad_IO.(>>=) x (\y -> monad_IO.return (g y))),
-    pure = monad_IO.return
-}
 
 /// `Show a` represents a conversion function from `a` to a readable string.
 type Show a = {
@@ -504,11 +489,11 @@ let show_Result: Show e -> Show t -> Show (Result e t) = \e t ->
     monoid_Function, monoid_List, monoid_Option,
     monoid_Int_Add, monoid_Int_Mul, monoid_Float_Add, monoid_Float_Mul,
     num_Int, num_Float,
-    functor_Option, functor_Result, functor_List, functor_IO,
-    applicative_Option, applicative_Result, applicative_List, applicative_IO,
+    functor_Option, functor_Result, functor_List,
+    applicative_Option, applicative_Result, applicative_List,
     alternative_Option, alternative_List,
     make_Alternative,
-    monad_Option, monad_List, monad_IO,
+    monad_Option, monad_List,
     make_Monad,
     show_Unit, show_Bool, show_Int, show_Float, show_List, show_Option, show_Result
 }

--- a/std/repl.glu
+++ b/std/repl.glu
@@ -2,8 +2,7 @@ let prelude = import "std/prelude.glu"
 let map = import "std/map.glu"
 let string = import "std/string.glu"
 let { Map } = map
-let { (>>=), return, (>>), join, map = fmap, lift2, forM_ } = prelude.make_Monad prelude.monad_IO
-let { Eq, Option, Result, Monoid } = prelude
+let { Eq, Option, Result, Monoid, List, id } = prelude
 let { (==) } = string.eq
 let (++) = string.monoid.(<>)
 let { singleton, find, insert, monoid, to_list }
@@ -11,95 +10,118 @@ let { singleton, find, insert, monoid, to_list }
 let { (<>), empty } = monoid
 
 
-let load_file filename: String -> IO String =
+let load_file filename: String -> String =
     let last_slash =
         match string.rfind filename "/" with
             | None -> 0
             | Some i -> i + 1
     let modulename = string.slice filename last_slash (string.length filename - 3)
-    let read_result = io.catch (io.read_file_to_string filename >>= \x -> return (Ok x)) (\err -> return (Err err))
-    read_result >>= \result ->
-        match result with
-            | Ok expr -> io.load_script modulename expr
-            | Err msg -> return msg
+    let read_result =
+        io.catch (\_ ->
+            let x = io.read_file_to_string filename
+            Ok x)
+            (\err -> Err err)
+    match read_result with
+    | Ok expr -> io.load_script modulename expr
+    | Err msg -> msg
 
-type Cmd = { info: String, action: String -> IO Bool }
+let for xs f =
+    match xs with
+    | Cons y ys ->
+        f y
+        for ys f
+    | Nil -> ()
+
+type Cmd = { info: String, action: String -> Bool }
 
 let commands: Map String Cmd =
     let commands = ref empty
     let cmds =
-        singleton "q" { info = "Quit the REPL", action = \_ -> return False }
+        singleton "q" { info = "Quit the REPL", action = \_ -> False }
             <> singleton "t" {
                 info = "Prints the type with an expression",
-                action = \arg -> repl_prim.type_of_expr arg >>= \result ->
+                action = \arg ->
+                    let result = repl_prim.type_of_expr arg
                     match result with
                     | Ok x -> io.print x
                     | Err x -> io.print x
-                        >> return True
+                    True
             }
             <> singleton "i" {
                 info = "Prints information about the given name",
-                action = \arg -> repl_prim.find_info arg >>= \result ->
+                action = \arg ->
+                    let result = repl_prim.find_info arg
                     match result with
                     | Ok x -> io.print x
                     | Err x -> io.print x
-                        >> return True
+                    True
             }
             <> singleton "k" {
                 info = "Prints the kind with the given type",
-                action = \arg -> repl_prim.find_kind arg >>= \result ->
+                action = \arg ->
+                    let result = repl_prim.find_kind arg
                     match result with
                     | Ok x -> io.print x
                     | Err x -> io.print x
-                        >> return True
+                    True
             }
             <> singleton "l" {
                 info = "Loads the file at 'folder/module.ext' and stores it at 'module'",
-                action = \arg -> load_file arg >>= io.print >> return True
+                action = \arg ->
+                    let contents = load_file arg
+                    io.print contents
+                    True
             }
-            <> singleton "h" {
+            <>  singleton "h" {
                 info = "Print this help",
                 action = \_ ->
-                    io.print "Available commands\n" >>
-                        forM_ (to_list (load commands)) (\cmd ->
-                            //FIXME This type declaration should not be needed
-                            let cmd: { key: String, value: Cmd } = cmd
-                            io.print ("    :" ++ cmd.key ++ " " ++ cmd.value.info)
-                        ) >>
-                        return True
-            }
+                    io.print "Available commands\n"
+                    for (to_list (load commands)) (\cmd ->
+                        //FIXME This type declaration should not be needed
+                        let cmd: { key: String, value: Cmd } = cmd
+                        io.print ("    :" ++ cmd.key ++ " " ++ cmd.value.info)
+                    )
+                    True
+            }    
     commands <- cmds
     load commands
 
-let do_command line: String -> IO Bool = 
+let do_command line: String -> Bool = 
     let cmd = string.slice line 1 2
     let arg = if string.length line >= 3 then string.trim (string.slice line 3 (string.length line)) else ""
     match find cmd commands with
-        | Some command -> command.action arg
-        | None -> io.print ("Unknown command '"  ++ cmd ++ "'") >> return True
+    | Some command -> command.action arg
+    | None ->
+        io.print ("Unknown command '"  ++ cmd ++ "'")
+        True
 
-let store line: String -> IO Bool =
+let store line: String -> Bool =
     let line = string.trim line
     match string.find line " " with
-        | Some bind_end -> 
-            let binding = string.slice line 0 bind_end
-            let expr = string.slice line bind_end (string.length line)
-            io.load_script binding expr >> return True
-        | None -> io.print "Expected binding in definition" >> return True
+    | Some bind_end -> 
+        let binding = string.slice line 0 bind_end
+        let expr = string.slice line bind_end (string.length line)
+        io.load_script binding expr
+        True
+    | None ->
+        io.print "Expected binding in definition"
+        True
 
-let loop x: () -> IO () = repl_prim.input ">>" >>= \line_opt ->
-    match line_opt with
-    | None -> loop ()
-    | Some line ->
-        (if string.starts_with line ":" then
+let loop _: () -> () =
+    let line = io.read_line
+    let continue =
+        if string.starts_with line ":" then
             do_command line
         else if string.starts_with line "def " then
             store (string.slice line 4 (string.length line))
         else
-            io.catch (io.run_expr line) return >>= io.print >> return True) >>= \continue -> 
-                if continue then
-                    loop ()
-                else
-                    return ()
+            let r = io.catch (\_ -> io.run_expr line) id
+            io.print r
+            True
+
+    if continue then
+        loop ()
+    else
+        ()
 
 loop

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -11,17 +11,16 @@ fn read_file() {
     let text = r#"
         let prelude = import "std/prelude.glu"
         let { assert } = import "std/test.glu"
-        let { (>>=), return } = prelude.monad_IO
 
-        io.open_file "Cargo.toml" >>= \file ->
-            io.read_file file 9 >>= \bytes ->
-            assert (array.length bytes == 9)
-            assert (array.index bytes 0 #Byte== 91b) // [
-            assert (array.index bytes 1 #Byte== 112b) // p
-            return (array.index bytes 8)
+        let file = io.open_file "Cargo.toml"
+        let bytes = io.read_file file 9
+        assert (array.length bytes == 9)
+        assert (array.index bytes 0 #Byte== 91b) // [
+        assert (array.index bytes 1 #Byte== 112b) // p
+        (array.index bytes 8)
         "#;
     let result = Compiler::new()
-        .run_io_expr::<u8>(&thread, "<top>", text);
+        .run_expr::<u8>(&thread, "<top>", text);
     assert!(result.is_ok(), "{}", result.unwrap_err());
     assert_eq!(result.unwrap(), b']');
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -17,7 +17,6 @@ use types::*;
 use interner::{Interner, InternedStr};
 use gc::{Gc, GcPtr, Traverseable, Move};
 use compiler::{CompiledFunction, Variable, CompilerEnv};
-use api::IO;
 use lazy::Lazy;
 
 use value::BytecodeFunction;
@@ -342,7 +341,6 @@ impl GlobalVMState {
             ids.insert(TypeId::of::<::std::string::String>(), Type::string());
             ids.insert(TypeId::of::<char>(), Type::char());
         }
-        let _ = self.register_type::<IO<Generic<A>>>("IO", &["a"]);
         let _ = self.register_type::<Lazy<Generic<A>>>("Lazy", &["a"]);
         let _ = self.register_type::<RootedThread>("Thread", &[]);
         Ok(())


### PR DESCRIPTION
This PR removes the IO monad and allows all IO functions to simply be run as normal functions. Though this makes it easier to use IO it may still be worth exploring other less heavy handed approaches.
#22
