### PR TITLE
[WIP] refactor: Remove the Kind enum by unifying it with Type

### DIFF
--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -5,7 +5,8 @@ use std::ops::Deref;
 
 use pos::Spanned;
 use symbol::Symbol;
-use types::{self, Alias, AliasData, Kind, Type, TypeEnv, TypeVariable};
+use types::{Alias, AliasData, BuiltinType, Type, TypeEnv, TypeVariable};
+use instantiate::instantiate;
 
 pub type AstType<Id> = ::types::ArcType<Id>;
 
@@ -110,7 +111,7 @@ impl<Id> TcIdent<Id> {
         TcIdent {
             typ: Type::variable(TypeVariable {
                 id: 0,
-                kind: Kind::variable(0),
+                kind: Type::builtin(BuiltinType::Type),
             }),
             name: name,
         }
@@ -467,7 +468,7 @@ fn get_return_type(env: &TypeEnv,
                             None => panic!("Unexpected type {:?} is not a function", alias_type),
                         };
 
-                        let typ = types::instantiate(typ.clone(), |gen| {
+                        let typ = instantiate(typ.clone(), |gen| {
                             // Replace the generic variable with the type from the list
                             // or if it is not found the make a fresh variable
                             args.iter()

--- a/base/src/instantiate.rs
+++ b/base/src/instantiate.rs
@@ -174,7 +174,7 @@ impl Instantiator {
     }
 
     fn variable_for(&mut self,
-                    generic: &Generic<Symbol>,
+                    generic: &Generic<Symbol, TcType>,
                     on_unbound: &mut FnMut(&Symbol) -> TcType)
                     -> TcType {
         let var = match self.named_variables.entry(generic.id.clone()) {
@@ -208,7 +208,7 @@ impl Instantiator {
 }
 
 pub fn instantiate<F>(typ: TcType, mut f: F) -> TcType
-    where F: FnMut(&Generic<Symbol>) -> Option<TcType>
+    where F: FnMut(&Generic<Symbol, TcType>) -> Option<TcType>
 {
     types::walk_move_type(typ,
                           &mut |typ| {

--- a/base/tests/types.rs
+++ b/base/tests/types.rs
@@ -15,7 +15,7 @@ fn type_con<I, T>(s: I, args: Vec<T>) -> Type<I, T>
         Ok(b) => Type::Builtin(b),
         Err(()) if is_var => {
             Type::Generic(Generic {
-                kind: RcKind::new(Kind::Type),
+                kind: Type::typ(),
                 id: s,
             })
         }
@@ -45,7 +45,7 @@ fn some_record() -> RcType<&'static str> {
                           name: "Test",
                           typ: Alias::new("Test",
                                           vec![Generic {
-                                                   kind: Kind::typ(),
+                                                   kind: Type::typ(),
                                                    id: "a",
                                                }],
                                           f.clone()),
@@ -77,7 +77,7 @@ fn show_record() {
                                     name: "Test",
                                     typ: Alias::new("Test",
                                                     vec![Generic {
-                                                             kind: Kind::typ(),
+                                                             kind: Type::typ(),
                                                              id: "a",
                                                          }],
                                                     f.clone()),
@@ -93,7 +93,7 @@ fn show_record() {
                                     name: "Test",
                                     typ: Alias::new("Test",
                                                     vec![Generic {
-                                                             kind: Kind::typ(),
+                                                             kind: Type::typ(),
                                                              id: "a",
                                                          }],
                                                     f.clone()),
@@ -112,7 +112,7 @@ fn show_record_multi_line() {
                                     name: "Test",
                                     typ: Alias::new("Test",
                                                     vec![Generic {
-                                                             kind: Kind::typ(),
+                                                             kind: Type::typ(),
                                                              id: "a",
                                                          }],
                                                     f.clone()),
@@ -168,8 +168,10 @@ fn variants() {
 
 #[test]
 fn show_kind() {
-    let two_args = Kind::function(Kind::typ(), Kind::function(Kind::typ(), Kind::typ()));
+    let two_args: AstType<&str> = Type::function(vec![Type::typ(), Type::typ()], Type::typ());
     assert_eq!(format!("{}", two_args), "Type -> Type -> Type");
-    let function_arg = Kind::function(Kind::function(Kind::typ(), Kind::typ()), Kind::typ());
+    let function_arg: AstType<&str> = Type::function(vec![Type::function(vec![Type::typ()],
+                                                                         Type::typ())],
+                                                     Type::typ());
     assert_eq!(format!("{}", function_arg), "(Type -> Type) -> Type");
 }

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -26,13 +26,13 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
 
-    use base::types::{Alias, KindEnv, RcKind, TcType, TypeEnv};
+    use base::types::{Alias, KindEnv, TcType, TypeEnv};
     use base::symbol::{Symbol, Symbols, SymbolModule, SymbolRef};
 
     pub struct MockEnv;
 
     impl KindEnv for MockEnv {
-        fn find_kind(&self, _type_name: &SymbolRef) -> Option<RcKind> {
+        fn find_kind(&self, _type_name: &SymbolRef) -> Option<TcType> {
             None
         }
     }

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -6,7 +6,7 @@ use base::error::Errors;
 use base::fnv::FnvMap;
 use base::scoped_map::ScopedMap;
 use base::symbol::{Symbol, SymbolRef, SymbolModule};
-use base::types::{self, Alias, TcType, Type, TcIdent, RcKind, KindEnv, TypeEnv};
+use base::types::{self, Alias, TcType, Type, TcIdent, KindEnv, TypeEnv};
 use unify_type::{TypeError, State};
 use unify::{Error as UnifyError, Unifier, Unifiable, UnifierState};
 
@@ -49,7 +49,7 @@ struct Environment<'b> {
 }
 
 impl<'a> KindEnv for Environment<'a> {
-    fn find_kind(&self, _type_name: &SymbolRef) -> Option<RcKind> {
+    fn find_kind(&self, _type_name: &SymbolRef) -> Option<TcType> {
         None
     }
 }

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -75,24 +75,24 @@ impl<I> fmt::Display for TypeError<I>
 
 pub type UnifierState<'a, U> = unify::UnifierState<State<'a>, U>;
 
-impl Variable for TypeVariable {
+impl<I> Variable for TypeVariable<AstType<I>> {
     fn get_id(&self) -> u32 {
         self.id
     }
 }
 
 impl<I> Substitutable for AstType<I> {
-    type Variable = TypeVariable;
+    type Variable = TypeVariable<AstType<I>>;
 
     fn new(id: u32) -> AstType<I> {
         Type::variable(TypeVariable::new(id))
     }
 
-    fn from_variable(var: TypeVariable) -> AstType<I> {
+    fn from_variable(var: TypeVariable<AstType<I>>) -> AstType<I> {
         Type::variable(var)
     }
 
-    fn get_var(&self) -> Option<&TypeVariable> {
+    fn get_var(&self) -> Option<&TypeVariable<AstType<I>>> {
         match **self {
             Type::Variable(ref var) => Some(var),
             _ => None,

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -6,7 +6,7 @@ extern crate gluon_check as check;
 
 use base::ast::{self, Expr, Pattern, Typed};
 use base::pos::{BytePos, CharPos, Location, Span};
-use base::types::{self, Field, Generic, Kind, Type};
+use base::types::{self, Field, Generic, Type};
 
 mod support;
 use support::{MockEnv, alias, intern, typ};
@@ -534,7 +534,7 @@ return 1
     };
     let test = alias("Test", &["a"], variant("Test"));
     let m = Generic {
-        kind: Kind::function(Kind::typ(), Kind::typ()),
+        kind: Type::function(vec![Type::typ()], Type::typ()),
         id: intern("m"),
     };
 
@@ -543,7 +543,7 @@ return 1
                            vec![
                                m.clone(),
                                Generic {
-                                   kind: Kind::typ(),
+                                   kind: Type::typ(),
                                    id: intern("a"),
                                },
                             ],

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -1,7 +1,7 @@
 use base::ast;
 use base::symbol::{Symbols, SymbolModule, Symbol, SymbolRef};
-use base::types::{Alias, Generic, Kind, Type, KindEnv};
-use base::types::{TcIdent, TcType, TypeEnv, PrimitiveEnv, RcKind};
+use base::types::{Alias, Generic, Type, KindEnv};
+use base::types::{TcIdent, TcType, TypeEnv, PrimitiveEnv};
 use check::typecheck::{self, Typecheck};
 use parser;
 
@@ -69,9 +69,9 @@ impl MockEnv {
 }
 
 impl KindEnv for MockEnv {
-    fn find_kind(&self, id: &SymbolRef) -> Option<RcKind> {
+    fn find_kind(&self, id: &SymbolRef) -> Option<TcType> {
         match id.as_ref() {
-            "Bool" => Some(Kind::typ()),
+            "Bool" => Some(Type::typ()),
             _ => None,
         }
     }
@@ -149,7 +149,7 @@ pub fn typ_a<T>(s: &str, args: Vec<T>) -> T
         Ok(b) => Type::builtin(b),
         Err(()) if is_var => {
             Type::generic(Generic {
-                kind: Kind::typ(),
+                kind: Type::typ(),
                 id: intern(s),
             })
         }
@@ -170,7 +170,7 @@ pub fn alias(s: &str, args: &[&str], typ: TcType) -> TcType {
                 args.iter()
                     .map(|id| {
                         Generic {
-                            kind: Kind::typ(),
+                            kind: Type::typ(),
                             id: intern(id),
                         }
                     })

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -19,7 +19,7 @@ use base::ast;
 use base::ast::*;
 use base::error::Errors;
 use base::pos::{self, Location, Located, Span};
-use base::types::{Type, Generic, Alias, Field, Kind};
+use base::types::{Type, Generic, Alias, Field};
 use base::symbol::{Name, Symbol, SymbolModule};
 
 use combine::primitives::{Consumed, Stream, StreamOnce, Error as CombineError, Info,
@@ -222,7 +222,7 @@ impl<'input, I, Id, F> ParserEnv<I, F>
                 debug!("Id: {:?}", s);
                 if typ == IdentType::Variable {
                     Type::generic(Generic {
-                        kind: Kind::variable(0),
+                        kind: Type::hole(),
                         id: s.to_id(),
                     })
                 } else {
@@ -373,7 +373,7 @@ impl<'input, I, Id, F> ParserEnv<I, F>
                 let arg_types = args.iter()
                     .map(|id| {
                         Type::generic(Generic {
-                            kind: Kind::variable(0),
+                            kind: Type::hole(),
                             id: id.clone(),
                         })
                     })
@@ -394,7 +394,7 @@ impl<'input, I, Id, F> ParserEnv<I, F>
                                               args.iter()
                                                   .map(|id| {
                                                       Generic {
-                                                          kind: Kind::variable(0),
+                                                          kind: Type::hole(),
                                                           id: id.clone(),
                                                       }
                                                   })

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -8,7 +8,7 @@ use base::ast;
 use base::ast::*;
 use base::error::Errors;
 use base::pos::{self, BytePos, CharPos, Location, Span, Spanned};
-use base::types::{Type, Generic, Alias, Field, Kind};
+use base::types::{Type, Generic, Alias, Field};
 use parser::{parse_string, Error};
 
 pub fn intern(s: &str) -> String {
@@ -87,9 +87,9 @@ fn generic_ty(s: &str) -> AstType<String> {
     Type::generic(generic(s))
 }
 
-fn generic(s: &str) -> Generic<String> {
+fn generic(s: &str) -> Generic<String, AstType<String>> {
     Generic {
-        kind: Kind::variable(0),
+        kind: Type::hole(),
         id: intern(s),
     }
 }
@@ -122,7 +122,11 @@ fn lambda(name: &str, args: Vec<String>, body: PExpr) -> PExpr {
     }))
 }
 
-fn type_decl(name: String, args: Vec<Generic<String>>, typ: AstType<String>, body: PExpr) -> PExpr {
+fn type_decl(name: String,
+             args: Vec<Generic<String, AstType<String>>>,
+             typ: AstType<String>,
+             body: PExpr)
+             -> PExpr {
     type_decls(vec![TypeBinding {
                         comment: None,
                         name: name.clone(),
@@ -510,10 +514,10 @@ fn span_field_access() {
     let _ = ::env_logger::init();
     let expr = parse_new("record.x");
     assert_eq!(expr.span,
-                Span {
-                    start: loc(1, 1, 0),
-                    end: loc(1, 9, 8),
-                });
+               Span {
+                   start: loc(1, 1, 0),
+                   end: loc(1, 9, 8),
+               });
     match expr.value {
         Expr::FieldAccess(ref e, _) => {
             assert_eq!(e.span,

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use self::rustyline::error::ReadlineError;
 
 use base::ast::Typed;
-use base::types::Kind;
+use base::types::Type;
 use vm::api::{IO, Function, WithVM, VmType, Userdata};
 use vm::gc::{Gc, Traverseable};
 use vm::thread::{Thread, RootStr};
@@ -31,9 +31,8 @@ fn find_kind(args: WithVM<RootStr>) -> IO<Result<String, String>> {
     let args = args.value.trim();
     IO::Value(match vm.find_type_info(args) {
         Ok(ref alias) => {
-            let kind = alias.args.iter().rev().fold(Kind::typ(), |acc, arg| {
-                Kind::function(arg.kind.clone(), acc)
-            });
+            let kind = Type::function(alias.args.iter().map(|arg| arg.kind.clone()).collect(),
+                                      Type::typ());
             Ok(format!("{}", kind))
         }
         Err(err) => Err(format!("{}", err)),

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -224,7 +224,7 @@ pub struct Compiler<'a> {
 }
 
 impl<'a> KindEnv for Compiler<'a> {
-    fn find_kind(&self, _type_name: &SymbolRef) -> Option<types::RcKind> {
+    fn find_kind(&self, _type_name: &SymbolRef) -> Option<TcType> {
         None
     }
 }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -144,14 +144,13 @@ pub struct TypeInfos {
 }
 
 impl KindEnv for TypeInfos {
-    fn find_kind(&self, type_name: &SymbolRef) -> Option<types::RcKind> {
+    fn find_kind(&self, type_name: &SymbolRef) -> Option<TcType> {
         let type_name = AsRef::<str>::as_ref(type_name);
         self.id_to_type
             .get(type_name)
             .map(|alias| {
-                alias.args.iter().rev().fold(types::Kind::typ(), |acc, arg| {
-                    types::Kind::function(arg.kind.clone(), acc)
-                })
+                types::Type::function(alias.args.iter().map(|arg| arg.kind.clone()).collect(),
+                                      types::Type::typ())
             })
     }
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -8,8 +8,7 @@ use std::usize;
 use base::ast::{Typed, AstType};
 use base::metadata::{Metadata, MetadataEnv};
 use base::symbol::{Name, Symbol, SymbolRef};
-use base::types::{Alias, AliasData, Generic, Type, Kind, KindEnv, TypeEnv, PrimitiveEnv, TcType,
-                  RcKind};
+use base::types::{Alias, AliasData, Generic, Type, KindEnv, TypeEnv, PrimitiveEnv, TcType};
 use base::fnv::FnvMap;
 
 use macros::MacroEnv;
@@ -119,7 +118,7 @@ impl CompilerEnv for VmEnv {
 }
 
 impl KindEnv for VmEnv {
-    fn find_kind(&self, type_name: &SymbolRef) -> Option<RcKind> {
+    fn find_kind(&self, type_name: &SymbolRef) -> Option<TcType> {
         self.type_infos
             .find_kind(type_name)
     }
@@ -412,7 +411,7 @@ impl GlobalVmState {
         }
         let g: TcType = Type::generic(Generic {
             id: Symbol::new(name),
-            kind: Kind::typ(),
+            kind: Type::typ(),
         });
         generics.insert(name.into(), g.clone());
         g


### PR DESCRIPTION
By removing the `Kind` enum we cut out a good amount of duplication as
kind unification just work through type unification. There is a slight
increase in complexity through the addition of `Type` as a builtin type
but this otherwise looks like a nice improvement.
