### PR TITLE
Move abstract types out of AliasData

### DIFF
--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -345,8 +345,7 @@ fn get_return_type(env: &TypeEnv, alias_type: &ArcType, arg_count: usize) -> Arc
                 match alias_type.as_alias() {
                     Some((id, alias_args)) => {
                         let (args, typ) = match env.find_type_info(&id).map(Alias::deref) {
-                            Some(&AliasData { ref args, typ: Some(ref typ), .. }) => (args, typ),
-                            Some(&AliasData { .. }) => panic!("ICE: '{:?}' does not exist", id),
+                            Some(&AliasData { ref args, ref typ, .. }) => (args, typ),
                             None => panic!("Unexpected type {:?} is not a function", alias_type),
                         };
 

--- a/base/src/instantiate.rs
+++ b/base/src/instantiate.rs
@@ -110,10 +110,8 @@ pub fn maybe_remove_alias(env: &TypeEnv, typ: &ArcType) -> Result<Option<ArcType
 ///     result = | Err Error | Ok (Option a)
 pub fn type_of_alias(alias: &AliasData<Symbol, ArcType>, args: &[ArcType]) -> Option<ArcType> {
     let alias_args = &alias.args;
-    let mut typ = match alias.typ {
-        Some(ref typ) => typ.clone(),
-        None => return None,
-    };
+    let mut typ = alias.typ.clone();
+
     // It is ok to take the aliased type only if the alias is fully applied or if it
     // the missing argument only appear in order at the end of the alias
     // i.e
@@ -122,8 +120,7 @@ pub fn type_of_alias(alias: &AliasData<Symbol, ArcType>, args: &[ArcType]) -> Op
     // Test a b == Type (a Int) b
     // Test a == Type (a Int)
     // Test == ??? (Impossible to do a sane substitution)
-
-    let ok_substitution = match *typ.clone() {
+    match *typ.clone() {
         Type::App(ref d, ref arg_types) => {
             let allowed_missing_args = arg_types.iter()
                 .rev()
@@ -142,25 +139,25 @@ pub fn type_of_alias(alias: &AliasData<Symbol, ArcType>, args: &[ArcType]) -> Op
                     .cloned()
                     .collect();
                 typ = Type::app(d.clone(), arg_types);
-                true
             } else {
-                false
+                return None;
             }
         }
-        _ => args.len() == alias_args.len(),
-    };
-    if !ok_substitution {
-        return None;
+        _ => {
+            if args.len() != alias_args.len() {
+                return None;
+            }
+        }
     }
-    let typ = instantiate(typ, |gen| {
+
+    Some(instantiate(typ, |gen| {
         // Replace the generic variable with the type from the list
         // or if it is not found the make a fresh variable
         alias_args.iter()
             .zip(args)
             .find(|&(arg, _)| arg.id == gen.id)
             .map(|(_, typ)| typ.clone())
-    });
-    Some(typ)
+    }))
 }
 
 #[derive(Debug, Default)]

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -315,12 +315,15 @@ pub enum Type<Id, T = ArcType<Id>> {
     Builtin(BuiltinType),
     /// A record type
     Record(T),
+    /// The empty row
     EmptyRow,
+    /// Row extension
     ExtendRow {
         /// The associated types of this record type
         types: Vec<Field<Id, Alias<Id, T>>>,
         /// The fields of this record type
         fields: Vec<Field<Id, T>>,
+        /// The rest of the row
         rest: T,
     },
     /// An identifier type. Anything that is not a builtin type.

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -279,8 +279,8 @@ pub struct AliasData<Id, T> {
     pub name: Id,
     /// Arguments to the alias
     pub args: Vec<Generic<Id>>,
-    /// The type which is being aliased or `None` if the type is abstract
-    pub typ: Option<T>,
+    /// The type that is being aliased
+    pub typ: T,
 }
 
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
@@ -299,6 +299,8 @@ pub struct Field<Id, T = ArcType<Id>> {
 pub enum Type<Id, T = ArcType<Id>> {
     /// An unbound type `_`, awaiting ascription.
     Hole,
+    /// An opaque type
+    Opaque,
     /// An application with multiple arguments.
     /// `Map String Int` would be represented as `App(Map, [String, Int])`
     App(T, Vec<T>),
@@ -336,6 +338,10 @@ impl<Id, T> Type<Id, T>
 {
     pub fn hole() -> T {
         T::from(Type::Hole)
+    }
+
+    pub fn opaque() -> T {
+        T::from(Type::Opaque)
     }
 
     pub fn array(typ: T) -> T {
@@ -410,7 +416,7 @@ impl<Id, T> Type<Id, T>
         T::from(Type::Alias(AliasData {
             name: name,
             args: args,
-            typ: Some(typ),
+            typ: typ,
         }))
     }
 
@@ -814,6 +820,7 @@ impl<'a, I, T, E> DisplayType<'a, I, T, E>
         let p = self.prec;
         match *self.typ {
             Type::Hole => arena.text("_"),
+            Type::Opaque => arena.text("<opaque>"),
             Type::Variable(ref var) => arena.text(format!("{}", var.id)),
             Type::Generic(ref gen) => arena.text(gen.id.as_ref()),
             Type::App(ref t, ref args) => {
@@ -893,13 +900,8 @@ impl<'a, I, T, E> DisplayType<'a, I, T, E>
                             arena.concat(field.typ.args.iter().map(|arg| {
                                 arena.text(self.env.string(&arg.id)).append(" ").into()
                             })),
-                            match field.typ.typ {
-                                Some(ref typ) => {
-                                    arena.text("= ")
-                                        .append(top(self.env, typ).pretty(arena))
-                                }
-                                None => arena.text("= <abstract>"),
-                            },
+                            arena.text("= ")
+                                 .append(top(self.env, &field.typ.typ).pretty(arena)),
                             if i + 1 != types.len() || !fields.is_empty() {
                                 arena.text(",")
                             } else {
@@ -1010,11 +1012,8 @@ pub fn walk_type_<I, T, F: ?Sized>(typ: &T, f: &mut F)
         Type::Record(ref row) => f.walk(row),
         Type::ExtendRow { ref types, ref fields, ref rest } => {
             for field in types {
-                if let Some(ref typ) = field.typ.typ {
-                    f.walk(typ);
-                }
+                f.walk(&field.typ.typ);
             }
-
             for field in fields {
                 f.walk(&field.typ);
             }
@@ -1026,6 +1025,7 @@ pub fn walk_type_<I, T, F: ?Sized>(typ: &T, f: &mut F)
             }
         }
         Type::Hole |
+        Type::Opaque |
         Type::Builtin(_) |
         Type::Variable(_) |
         Type::Generic(_) |
@@ -1180,6 +1180,7 @@ pub fn walk_move_type_opt<F: ?Sized, I, T>(typ: &Type<I, T>, f: &mut F) -> Optio
                 .map(Type::variants)
         }
         Type::Hole |
+        Type::Opaque |
         Type::Builtin(_) |
         Type::Variable(_) |
         Type::Generic(_) |

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -162,7 +162,7 @@ impl<'a> KindCheck<'a> {
 
     fn kindcheck(&mut self, typ: &ArcType) -> Result<(ArcKind, ArcType)> {
         match **typ {
-            Type::Hole => Ok((self.subs.new_var(), typ.clone())),
+            Type::Hole | Type::Opaque => Ok((self.subs.new_var(), typ.clone())),
             Type::Generic(ref gen) => {
                 let mut gen = gen.clone();
                 gen.kind = try!(self.find(&gen.id));

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -142,13 +142,12 @@ pub fn rename(symbols: &mut SymbolModule,
 
         fn stack_type(&mut self, id: Symbol, span: Span<BytePos>, alias: &Alias<Symbol, ArcType>) {
             // Insert variant constructors into the local scope
-            if let Some(ref real_type) = alias.typ {
-                if let Type::Variants(ref variants) = **real_type {
-                    for &(ref name, ref typ) in variants {
-                        self.env.stack.insert(name.clone(), (name.clone(), span, typ.clone()));
-                    }
+            if let Type::Variants(ref variants) = *alias.typ {
+                for &(ref name, ref typ) in variants {
+                    self.env.stack.insert(name.clone(), (name.clone(), span, typ.clone()));
                 }
             }
+
             // FIXME: Workaround so that both the types name in this module and its global
             // name are imported. Without this aliases may not be traversed properly
             self.env.stack_types.insert(alias.name.clone(), alias.clone());

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -78,7 +78,7 @@ impl KindEnv for MockEnv {
 impl TypeEnv for MockEnv {
     fn find_type(&self, id: &SymbolRef) -> Option<&ArcType> {
         match id.as_ref() {
-            "False" | "True" => Some(&self.bool.typ.as_ref().unwrap()),
+            "False" | "True" => Some(&self.bool.typ),
             _ => None,
         }
     }
@@ -97,7 +97,7 @@ impl TypeEnv for MockEnv {
 
 impl PrimitiveEnv for MockEnv {
     fn get_bool(&self) -> &ArcType {
-        self.bool.typ.as_ref().unwrap()
+        &self.bool.typ
     }
 }
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -330,8 +330,8 @@ impl<'input, I> Lexer<'input, I>
             ident: Identifier {
                 start: letter().or(char('_')),
                 rest: alpha_num()
-                        .or(char('_'))
-                        .or(char('\'')),
+                    .or(char('_'))
+                    .or(char('\'')),
                 // ["if", "then", "else", "let", "and", "in", "type", "case", "of"]
                 // .iter()
                 // .map(|x| (*x).into())

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -674,9 +674,9 @@ fn quote_in_identifier() {
     let _ = ::env_logger::init();
     let e = parse_new!("let f' = \\x y -> x + y in f' 1 2");
     let a = let_("f'",
-                lambda("",
-                    vec![intern("x"), intern("y")],
-                    binop(id("x"), "+", id("y"))),
-                app(id("f'"), vec![int(1), int(2)]));
+                 lambda("",
+                        vec![intern("x"), intern("y")],
+                        binop(id("x"), "+", id("y"))),
+                 app(id("f'"), vec![int(1), int(2)]));
     assert_eq!(e, a);
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -54,12 +54,7 @@ fn find_info(args: WithVM<RootStr>) -> IO<Result<String, String>> {
                 for g in &alias.args {
                     try!(write!(&mut buffer, " {}", g.id))
                 }
-                try!(write!(&mut buffer, " = "));
-                match alias.typ {
-                    Some(ref typ) => try!(write!(&mut buffer, "{}", typ)),
-                    None => try!(write!(&mut buffer, "<abstract>")),
-                }
-                Ok(())
+                write!(&mut buffer, " = {}", alias.typ)
             };
             fmt().unwrap();
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,9 +31,9 @@ fn find_kind(args: WithVM<RootStr>) -> IO<Result<String, String>> {
     let args = args.value.trim();
     IO::Value(match vm.find_type_info(args) {
         Ok(ref alias) => {
-            let kind = alias.args.iter().rev().fold(Kind::typ(), |acc, arg| {
-                Kind::function(arg.kind.clone(), acc)
-            });
+            let kind =
+                alias.args.iter().rev().fold(Kind::typ(),
+                                             |acc, arg| Kind::function(arg.kind.clone(), acc));
             Ok(format!("{}", kind))
         }
         Err(err) => Err(format!("{}", err)),

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -1179,7 +1179,9 @@ pub mod record {
         fn from_value(vm: &'vm Thread, values: &[Value]) -> Option<Self> {
             let head = unsafe { H::from_value(vm, Variants::new(&values[0])) };
             head.and_then(|head| {
-                T::from_value(vm, &values[1..]).map(move |tail| HList((F::default(), head), tail))
+                T::from_value(vm, &values[1..]).map(move |tail| {
+                    HList((F::default(), head), tail)
+                })
             })
         }
     }
@@ -1347,7 +1349,9 @@ impl<'vm> Pushable<'vm> for CPrimitive {
             // The VM guarantess that it only ever calls this function with itself which should
             // make sure that ignoring the lifetime is safe
             transmute::<Box<Fn(&'vm Thread) -> Status + Send + Sync>,
-                        Box<Fn(&Thread) -> Status + Send + Sync>>(Box::new(move |vm| function(vm)))
+                        Box<Fn(&Thread) -> Status + Send + Sync>>(Box::new(move |vm| {
+                function(vm)
+            }))
         };
         let value = try!(context.alloc_with(thread,
                                             Move(ExternFunction {

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -256,16 +256,14 @@ impl CompilerEnv for TypeInfos {
         self.id_to_type
             .iter()
             .filter_map(|(_, ref alias)| {
-                alias.typ.as_ref().and_then(|typ| {
-                    match **typ {
-                        Type::Variants(ref variants) => {
-                            variants.iter()
-                                .enumerate()
-                                .find(|&(_, v)| v.0 == *id)
-                        }
-                        _ => None,
+                match *alias.typ {
+                    Type::Variants(ref variants) => {
+                        variants.iter()
+                            .enumerate()
+                            .find(|&(_, v)| v.0 == *id)
                     }
-                })
+                    _ => None,
+                }
             })
             .next()
             .map(|(tag, &(_, ref typ))| {
@@ -735,8 +733,7 @@ impl<'a> Compiler<'a> {
             Expr::TypeBindings(ref type_bindings, ref expr) => {
                 for bind in type_bindings {
                     self.stack_types.insert(bind.alias.name.clone(), bind.alias.clone());
-                    let typ = bind.alias.typ.as_ref().expect("TypeBinding type").clone();
-                    self.stack_constructors.insert(bind.name.clone(), typ);
+                    self.stack_constructors.insert(bind.name.clone(), bind.alias.typ.clone());
                 }
                 return Ok(Some(expr));
             }
@@ -792,10 +789,8 @@ impl<'a> Compiler<'a> {
                     // name are imported. Without this aliases may not be traversed properly
                     self.stack_types.insert(alias.name.clone(), alias.clone());
                     self.stack_types.insert(name.clone(), alias.clone());
-                    if let Some(ref typ) = alias.typ {
-                        self.stack_constructors.insert(alias.name.clone(), typ.clone());
-                        self.stack_constructors.insert(name.clone(), typ.clone());
-                    }
+                    self.stack_constructors.insert(alias.name.clone(), alias.typ.clone());
+                    self.stack_constructors.insert(name.clone(), alias.typ.clone());
                 });
                 match *typ {
                     Type::Record(_) => {

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -173,14 +173,10 @@ impl TypeEnv for TypeInfos {
         self.id_to_type
             .iter()
             .filter_map(|(_, ref alias)| {
-                alias.typ.as_ref().and_then(|typ| {
-                    match **typ {
-                        Type::Variants(ref variants) => {
-                            variants.iter().find(|v| v.0.as_ref() == id)
-                        }
-                        _ => None,
-                    }
-                })
+                match *alias.typ {
+                    Type::Variants(ref variants) => variants.iter().find(|v| v.0.as_ref() == id),
+                    _ => None,
+                }
             })
             .next()
             .map(|x| &x.1)
@@ -196,22 +192,17 @@ impl TypeEnv for TypeInfos {
         self.id_to_type
             .iter()
             .find(|&(_, alias)| {
-                alias.typ
-                    .as_ref()
-                    .map(|typ| {
-                        match **typ {
-                            Type::Record(_) => {
-                                fields.iter().all(|name| {
-                                    typ.field_iter().any(|f| f.name.as_ref() == name.as_ref())
-                                })
-                            }
-                            _ => false,
-                        }
-                    })
-                    .unwrap_or(false)
+                match *alias.typ {
+                    Type::Record(_) => {
+                        fields.iter().all(|name| {
+                            alias.typ.field_iter().any(|f| f.name.as_ref() == name.as_ref())
+                        })
+                    }
+                    _ => false,
+                }
             })
             .and_then(|t| {
-                let typ = t.1.typ.as_ref().unwrap();
+                let typ = &t.1.typ;
                 self.type_to_id.get(typ).map(|id_type| (id_type, typ))
             })
     }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -659,9 +659,8 @@ unsafe impl<'a> DataDef for &'a ValueArray {
         unsafe {
             let result = &mut *result.as_mut_ptr();
             result.repr = self.repr;
-            on_array!(self, |array: &Array<_>| {
-                result.unsafe_array_mut().initialize(array.iter().cloned())
-            });
+            on_array!(self,
+                      |array: &Array<_>| result.unsafe_array_mut().initialize(array.iter().cloned()));
             result
         }
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -139,16 +139,12 @@ impl TypeEnv for VmEnv {
                     .id_to_type
                     .values()
                     .filter_map(|alias| {
-                        alias.typ
-                            .as_ref()
-                            .and_then(|typ| {
-                                match **typ {
-                                    Type::Variants(ref ctors) => {
-                                        ctors.iter().find(|ctor| *ctor.0 == *id).map(|t| &t.1)
-                                    }
-                                    _ => None,
-                                }
-                            })
+                        match *alias.typ {
+                            Type::Variants(ref ctors) => {
+                                ctors.iter().find(|ctor| *ctor.0 == *id).map(|t| &t.1)
+                            }
+                            _ => None,
+                        }
                     })
                     .next()
                     .map(|ctor| ctor)
@@ -166,9 +162,8 @@ impl TypeEnv for VmEnv {
 impl PrimitiveEnv for VmEnv {
     fn get_bool(&self) -> &ArcType {
         self.find_type_info("std.types.Bool")
-            .ok()
-            .and_then(|alias| match alias {
-                Cow::Borrowed(alias) => alias.typ.as_ref(),
+            .map(|alias| match alias {
+                Cow::Borrowed(alias) => &alias.typ,
                 Cow::Owned(_) => panic!("Expected to be able to retrieve a borrowed bool type"),
             })
             .expect("std.types.Bool")
@@ -342,7 +337,7 @@ impl GlobalVmState {
                                              Alias::from(AliasData {
                                                  name: Symbol::from(name),
                                                  args: Vec::new(),
-                                                 typ: None,
+                                                 typ: Type::opaque(),
                                              }));
         }
 
@@ -439,7 +434,7 @@ impl GlobalVmState {
                                          Alias::from(AliasData {
                                              name: n,
                                              args: args,
-                                             typ: None,
+                                             typ: Type::opaque(),
                                          }));
             Ok(t)
         }


### PR DESCRIPTION
This cleans up a bunch of `Option` juggling and makes things a bit easier to understand!