### PR TITLE
Use rows for variant constructors

### DIFF
--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -242,12 +242,18 @@ pub enum Type<Id, T = ArcType<Id>> {
         /// The rest of the row
         rest: T,
     },
-    /// An identifier type. Anything that is not a builtin type.
+    /// An identifier type. These are created during parsing, but should all be
+    ///resolved into `Type::Alias`es during type checking.
+    ///
+    /// Identifiers are also sometimes used inside aliased types to avoid cycles
+    /// in reference counted pointers. This is a bit of a wart at the moment and
+    /// _may_ cause spurious unification failures.
     Ident(Id),
-    /// Representation for type variables
+    /// An unbound type variable that may be unified with other types. These
+    /// will eventually be converted into `Type::Generic`s during generalization.
     Variable(TypeVariable),
-    /// Variant for "generic" variables. These occur in signatures as lowercase identifers `a`, `b`
-    /// etc and are what unbound type variables are eventually made into.
+    /// A variable that needs to be instantiated with a fresh type variable
+    /// when the binding is refered to.
     Generic(Generic<Id>),
     Alias(AliasData<Id, T>),
 }

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -243,7 +243,7 @@ pub enum Type<Id, T = ArcType<Id>> {
         rest: T,
     },
     /// An identifier type. These are created during parsing, but should all be
-    ///resolved into `Type::Alias`es during type checking.
+    /// resolved into `Type::Alias`es during type checking.
     ///
     /// Identifiers are also sometimes used inside aliased types to avoid cycles
     /// in reference counted pointers. This is a bit of a wart at the moment and
@@ -285,9 +285,7 @@ impl<Id, T> Type<Id, T>
         Type::poly_variant(fields, Type::empty_row())
     }
 
-    pub fn poly_variant(fields: Vec<Field<Id, T>>,
-                        rest: T)
-                        -> T {
+    pub fn poly_variant(fields: Vec<Field<Id, T>>, rest: T) -> T {
         T::from(Type::Variant(Type::extend_row(Vec::new(), fields, rest)))
     }
 
@@ -471,8 +469,8 @@ impl<Id> ArcType<Id> {
         }
     }
 
-    pub fn field_iter(&self) -> FieldIterator<Self> {
-        FieldIterator {
+    pub fn row_iter(&self) -> RowIterator<Self> {
+        RowIterator {
             typ: self,
             current: 0,
         }
@@ -524,18 +522,18 @@ impl<'a, Id: 'a, T> Iterator for TypeFieldIterator<'a, T>
 }
 
 #[derive(Clone)]
-pub struct FieldIterator<'a, T: 'a> {
+pub struct RowIterator<'a, T: 'a> {
     typ: &'a T,
     current: usize,
 }
 
-impl<'a, T> FieldIterator<'a, T> {
+impl<'a, T> RowIterator<'a, T> {
     pub fn current_type(&self) -> &'a T {
         self.typ
     }
 }
 
-impl<'a, Id: 'a, T> Iterator for FieldIterator<'a, T>
+impl<'a, Id: 'a, T> Iterator for RowIterator<'a, T>
     where T: Deref<Target = Type<Id, T>>,
 {
     type Item = &'a Field<Id, T>;
@@ -920,7 +918,8 @@ pub fn walk_type_<I, T, F: ?Sized>(typ: &T, f: &mut F)
                 f.walk(a);
             }
         }
-        Type::Record(ref row) | Type::Variant(ref row) => f.walk(row),
+        Type::Record(ref row) |
+        Type::Variant(ref row) => f.walk(row),
         Type::ExtendRow { ref types, ref fields, ref rest } => {
             for field in types {
                 f.walk(&field.typ.typ);

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -276,14 +276,13 @@ impl<Id, T> Type<Id, T>
     }
 
     pub fn variant(fields: Vec<Field<Id, T>>) -> T {
-        Type::poly_variant(Vec::new(), fields, Type::empty_row())
+        Type::poly_variant(fields, Type::empty_row())
     }
 
-    pub fn poly_variant(types: Vec<Field<Id, Alias<Id, T>>>,
-                        fields: Vec<Field<Id, T>>,
+    pub fn poly_variant(fields: Vec<Field<Id, T>>,
                         rest: T)
                         -> T {
-        T::from(Type::Variant(Type::extend_row(types, fields, rest)))
+        T::from(Type::Variant(Type::extend_row(Vec::new(), fields, rest)))
     }
 
     pub fn record(types: Vec<Field<Id, Alias<Id, T>>>, fields: Vec<Field<Id, T>>) -> T {
@@ -777,7 +776,7 @@ impl<'a, I, T, E> DisplayType<'a, I, T, E>
                             }
                         }
                     }
-                    _ => panic!("Polymorphic variant syntax not yet decided"),
+                    ref typ => panic!("Unexpected type `{}` in variant", typ),
                 };
 
                 enclose(p, Prec::Constructor, arena, doc).group()
@@ -915,8 +914,7 @@ pub fn walk_type_<I, T, F: ?Sized>(typ: &T, f: &mut F)
                 f.walk(a);
             }
         }
-        Type::Record(ref row) => f.walk(row),
-        Type::Variant(ref row) => f.walk(row),
+        Type::Record(ref row) | Type::Variant(ref row) => f.walk(row),
         Type::ExtendRow { ref types, ref fields, ref rest } => {
             for field in types {
                 f.walk(&field.typ.typ);

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -222,13 +222,9 @@ pub enum Type<Id, T = ArcType<Id>> {
     Hole,
     /// An opaque type
     Opaque,
-    /// An application with multiple arguments.
-    /// `Map String Int` would be represented as `App(Map, [String, Int])`
+    /// A type application with multiple arguments. For example,
+    /// `Map String Int` would be represented as `App(Map, [String, Int])`.
     App(T, Vec<T>),
-    /// A variant type `| A Int Float | B`.
-    /// The second element of the tuple is the function type which the constructor has which in the
-    /// above example means that A's type is `Int -> Float -> A` and B's is `B`
-    Variants(Vec<(Id, T)>),
     /// Representation for type variables
     Variable(TypeVariable),
     /// Variant for "generic" variables. These occur in signatures as lowercase identifers `a`, `b`
@@ -236,11 +232,13 @@ pub enum Type<Id, T = ArcType<Id>> {
     Generic(Generic<Id>),
     /// A builtin type
     Builtin(BuiltinType),
-    /// A record type
+    /// Record constructor, of kind `Row -> Type`
     Record(T),
-    /// The empty row
+    /// Variant constructor, of kind `Row -> Type`
+    Variant(T),
+    /// The empty row, of kind `Row`
     EmptyRow,
-    /// Row extension
+    /// Row extension, of kind `... -> Row -> Row`
     ExtendRow {
         /// The associated types of this record type
         types: Vec<Field<Id, Alias<Id, T>>>,
@@ -277,8 +275,15 @@ impl<Id, T> Type<Id, T>
         }
     }
 
-    pub fn variants(vs: Vec<(Id, T)>) -> T {
-        T::from(Type::Variants(vs))
+    pub fn variant(fields: Vec<Field<Id, T>>) -> T {
+        Type::poly_variant(Vec::new(), fields, Type::empty_row())
+    }
+
+    pub fn poly_variant(types: Vec<Field<Id, Alias<Id, T>>>,
+                        fields: Vec<Field<Id, T>>,
+                        rest: T)
+                        -> T {
+        T::from(Type::Variant(Type::extend_row(types, fields, rest)))
     }
 
     pub fn record(types: Vec<Field<Id, Alias<Id, T>>>, fields: Vec<Field<Id, T>>) -> T {
@@ -750,23 +755,31 @@ impl<'a, I, T, E> DisplayType<'a, I, T, E>
                     }
                 }
             }
-            Type::Variants(ref variants) => {
+            Type::Variant(ref row) => {
                 let mut first = true;
                 let mut doc = arena.nil();
-                for variant in variants {
-                    if !first {
-                        doc = doc.append(arena.newline());
+
+                match **row {
+                    Type::EmptyRow => (),
+                    Type::ExtendRow { ref fields, .. } => {
+                        for field in fields.iter() {
+                            if !first {
+                                doc = doc.append(arena.newline());
+                            }
+                            first = false;
+                            doc = doc.append("| ")
+                                .append(field.name.as_ref());
+                            for arg in arg_iter(&field.typ) {
+                                doc = chain![arena;
+                                            doc,
+                                            " ",
+                                            dt(self.env, Prec::Constructor, &arg).pretty(arena)];
+                            }
+                        }
                     }
-                    first = false;
-                    doc = doc.append("| ")
-                        .append(variant.0.as_ref());
-                    for arg in arg_iter(&variant.1) {
-                        doc = chain![arena;
-                                     doc,
-                                     " ",
-                                     dt(self.env, Prec::Constructor, &arg).pretty(arena)];
-                    }
-                }
+                    _ => panic!("Polymorphic variant syntax not yet decided"),
+                };
+
                 enclose(p, Prec::Constructor, arena, doc).group()
             }
             Type::Builtin(ref t) => arena.text(t.to_str()),
@@ -903,6 +916,7 @@ pub fn walk_type_<I, T, F: ?Sized>(typ: &T, f: &mut F)
             }
         }
         Type::Record(ref row) => f.walk(row),
+        Type::Variant(ref row) => f.walk(row),
         Type::ExtendRow { ref types, ref fields, ref rest } => {
             for field in types {
                 f.walk(&field.typ.typ);
@@ -911,11 +925,6 @@ pub fn walk_type_<I, T, F: ?Sized>(typ: &T, f: &mut F)
                 f.walk(&field.typ);
             }
             f.walk(rest);
-        }
-        Type::Variants(ref variants) => {
-            for variant in variants {
-                f.walk(&variant.1);
-            }
         }
         Type::Hole |
         Type::Opaque |
@@ -1029,6 +1038,7 @@ pub fn walk_move_type_opt<F: ?Sized, I, T>(typ: &Type<I, T>, f: &mut F) -> Optio
             merge(id, f.visit(id), args, new_args, Type::app)
         }
         Type::Record(ref row) => f.visit(row).map(|row| T::from(Type::Record(row))),
+        Type::Variant(ref row) => f.visit(row).map(|row| T::from(Type::Variant(row))),
         Type::ExtendRow { ref types, ref fields, ref rest } => {
             let new_fields = walk_move_types(fields, |field| {
                 f.visit(&field.typ).map(|typ| {
@@ -1044,10 +1054,6 @@ pub fn walk_move_type_opt<F: ?Sized, I, T>(typ: &Type<I, T>, f: &mut F) -> Optio
                   rest,
                   new_rest,
                   |fields, rest| Type::extend_row(types.clone(), fields, rest))
-        }
-        Type::Variants(ref variants) => {
-            walk_move_types(variants, |v| f.visit(&v.1).map(|t| (v.0.clone(), t)))
-                .map(Type::variants)
         }
         Type::Hole |
         Type::Opaque |

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -222,16 +222,11 @@ pub enum Type<Id, T = ArcType<Id>> {
     Hole,
     /// An opaque type
     Opaque,
+    /// A builtin type
+    Builtin(BuiltinType),
     /// A type application with multiple arguments. For example,
     /// `Map String Int` would be represented as `App(Map, [String, Int])`.
     App(T, Vec<T>),
-    /// Representation for type variables
-    Variable(TypeVariable),
-    /// Variant for "generic" variables. These occur in signatures as lowercase identifers `a`, `b`
-    /// etc and are what unbound type variables are eventually made into.
-    Generic(Generic<Id>),
-    /// A builtin type
-    Builtin(BuiltinType),
     /// Record constructor, of kind `Row -> Type`
     Record(T),
     /// Variant constructor, of kind `Row -> Type`
@@ -249,6 +244,11 @@ pub enum Type<Id, T = ArcType<Id>> {
     },
     /// An identifier type. Anything that is not a builtin type.
     Ident(Id),
+    /// Representation for type variables
+    Variable(TypeVariable),
+    /// Variant for "generic" variables. These occur in signatures as lowercase identifers `a`, `b`
+    /// etc and are what unbound type variables are eventually made into.
+    Generic(Generic<Id>),
     Alias(AliasData<Id, T>),
 }
 

--- a/base/tests/types.rs
+++ b/base/tests/types.rs
@@ -174,10 +174,16 @@ fn show_record_multi_line() {
 }
 
 #[test]
-fn variants() {
-    let typ: ArcType<&str> =
-        Type::variants(vec![("A", Type::function(vec![Type::int()], Type::ident("A"))),
-                            ("B", Type::ident("A"))]);
+fn show_variant() {
+    let typ: ArcType<&str> = Type::variant(vec![Field {
+                                                    name: "A",
+                                                    typ: Type::function(vec![Type::int()],
+                                                                        Type::ident("A")),
+                                                },
+                                                Field {
+                                                    name: "B",
+                                                    typ: Type::ident("A"),
+                                                }]);
     assert_eq_display!(format!("{}", typ), "| A Int | B");
 }
 

--- a/check/src/completion.rs
+++ b/check/src/completion.rs
@@ -101,7 +101,7 @@ impl<E: TypeEnv> OnFound for Suggest<E> {
         if let Expr::Projection(ref expr, _, _) = context.value {
             let typ = instantiate::remove_aliases(&self.env, expr.env_type_of(&self.env));
             let id = ident.as_ref();
-            for field in typ.field_iter() {
+            for field in typ.row_iter() {
                 if field.name.as_ref().starts_with(id) {
                     self.result.push(Suggestion {
                         name: field.name.declared_name().into(),

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -192,7 +192,7 @@ impl<'a> KindCheck<'a> {
                 Ok((kind, Type::app(ctor, new_args)))
             }
             Type::Variant(ref row) => {
-                let row = try!(row.field_iter()
+                let row = try!(row.row_iter()
                     .map(|field| {
                         let (kind, typ) = try!(self.kindcheck(&field.typ));
                         let type_kind = self.type_kind();

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -87,7 +87,7 @@ pub fn rename(symbols: &mut SymbolModule,
         fn find_fields(&self, typ: &ArcType) -> Vec<types::Field<Symbol, ArcType>> {
             // Walk through all type aliases
             let record = instantiate::remove_aliases(&self.env, typ.clone());
-            record.field_iter().cloned().collect()
+            record.row_iter().cloned().collect()
         }
 
         fn new_pattern(&mut self, typ: &ArcType, pattern: &mut ast::SpannedPattern<Symbol>) {
@@ -144,7 +144,7 @@ pub fn rename(symbols: &mut SymbolModule,
         fn stack_type(&mut self, id: Symbol, span: Span<BytePos>, alias: &Alias<Symbol, ArcType>) {
             // Insert variant constructors into the local scope
             if let Type::Variant(ref row) = *alias.typ {
-                for field in row.field_iter().cloned() {
+                for field in row.row_iter().cloned() {
                     self.env.stack.insert(field.name.clone(), (field.name, span, field.typ));
                 }
             }

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -143,9 +143,9 @@ pub fn rename(symbols: &mut SymbolModule,
 
         fn stack_type(&mut self, id: Symbol, span: Span<BytePos>, alias: &Alias<Symbol, ArcType>) {
             // Insert variant constructors into the local scope
-            if let Type::Variants(ref variants) = *alias.typ {
-                for &(ref name, ref typ) in variants {
-                    self.env.stack.insert(name.clone(), (name.clone(), span, typ.clone()));
+            if let Type::Variant(ref row) = *alias.typ {
+                for field in row.field_iter().cloned() {
+                    self.env.stack.insert(field.name.clone(), (field.name, span, field.typ));
                 }
             }
 

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -322,8 +322,7 @@ fn unify_rows<'a, U>(unifier: &mut UnifierState<'a, U>,
         return Err(UnifyError::TypeMismatch(l.clone(), r.clone()));
     }
 
-    let (missing_from_left, both, missing_from_right) = gather_fields(l.field_iter(),
-                                                                      r.field_iter());
+    let (missing_from_left, both, missing_from_right) = gather_fields(l.row_iter(), r.row_iter());
 
     let mut types: Vec<_> = types_both.iter().map(|pair| pair.0.clone()).collect();
 
@@ -352,7 +351,7 @@ fn unify_rows<'a, U>(unifier: &mut UnifierState<'a, U>,
     // `Row (y : String | Fresh var 2) <=> $0`
 
     // This default `rest` value will only be used on errors, or if both fields has the same fields
-    let mut r_iter = r.field_iter();
+    let mut r_iter = r.row_iter();
     for _ in r_iter.by_ref() {
     }
     let mut rest = r_iter.current_type().clone();
@@ -376,14 +375,14 @@ fn unify_rows<'a, U>(unifier: &mut UnifierState<'a, U>,
                     Type::extend_row(types_missing_from_right, missing_from_right, rest.clone());
                 unifier.try_match(&l_rest, r_iter.current_type());
                 types.extend(l_rest.type_field_iter().cloned());
-                fields.extend(l_rest.field_iter().cloned());
+                fields.extend(l_rest.row_iter().cloned());
             }
         }
     }
 
     // No need to do anything of no fields are missing
     if !missing_from_left.is_empty() {
-        let mut l_iter = l.field_iter();
+        let mut l_iter = l.row_iter();
         for _ in l_iter.by_ref() {
         }
 
@@ -402,7 +401,7 @@ fn unify_rows<'a, U>(unifier: &mut UnifierState<'a, U>,
                     Type::extend_row(types_missing_from_left, missing_from_left, rest.clone());
                 unifier.try_match(&l_iter.current_type(), &r_rest);
                 types.extend(r_rest.type_field_iter().cloned());
-                fields.extend(r_rest.field_iter().cloned());
+                fields.extend(r_rest.row_iter().cloned());
             }
         }
     }
@@ -744,7 +743,7 @@ mod tests {
         match result {
             Ok(result) => {
                 // Get the row variable at the end of the resulting type so we can compare the types
-                let mut iter = result.field_iter();
+                let mut iter = result.row_iter();
                 for _ in iter.by_ref() {
                 }
                 let row_variable = iter.current_type().clone();

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -309,10 +309,16 @@ let option_Functor: Functor Option = {
 in option_Functor.map (\x -> x #Int- 1) (Some 2)
 ";
     let result = support::typecheck(text);
-    let variants = Type::variants(vec![(support::intern_unscoped("None"), support::typ_a("Option", vec![typ("a")])),
-                                       (support::intern_unscoped("Some"),
-                                        Type::function(vec![typ("a")],
-                                                       support::typ_a("Option", vec![typ("a")])))]);
+    let variants = Type::variant(vec![Field {
+                                          name: support::intern_unscoped("None"),
+                                          typ: support::typ_a("Option", vec![typ("a")]),
+                                      },
+                                      Field {
+                                          name: support::intern_unscoped("Some"),
+                                          typ: Type::function(vec![typ("a")],
+                                                                   support::typ_a("Option",
+                                                                                  vec![typ("a")])),
+                                      }]);
     let option = alias("Option", &["a"], variants);
     let expected = Ok(Type::app(option, vec![typ("Int")]));
 
@@ -347,9 +353,12 @@ test
     let result = support::typecheck(text);
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
-    let variants = Type::variants(vec![(support::intern_unscoped("T"),
-                                        Type::function(vec![typ("a")],
-                                                       support::typ_a("Test", vec![typ("a")])))]);
+    let variants = Type::variant(vec![Field {
+                                          name: support::intern_unscoped("T"),
+                                          typ: Type::function(vec![typ("a")],
+                                                                   support::typ_a("Test",
+                                                                                  vec![typ("a")])),
+                                      }]);
     let expected = Ok(Type::app(alias("Test", &["a"], variants), vec![Type::unit()]));
 
     assert_eq!(result, expected);
@@ -486,7 +495,7 @@ type Test = | Test String Int in { Test, x = 1 }
 "#;
     let result = support::typecheck(text);
     let variant = Type::function(vec![typ("String"), typ("Int")], typ("Test"));
-    let test = Type::variants(vec![(intern("Test"), variant)]);
+    let test = Type::variant(vec![Field { name: intern("Test"), typ: variant }]);
     let types = vec![Field {
         name: support::intern_unscoped("Test"),
         typ: types::Alias::new(intern("Test"), vec![], test),
@@ -527,11 +536,11 @@ return 1
 "#;
     let result = support::typecheck(text);
     let variant = |name| {
-        Type::variants(vec![(
-            intern(name),
-            Type::function(vec![typ("a")],
-            Type::app(typ(name), vec![typ("a")]),
-        ))])
+        Type::variant(vec![Field {
+                               name: intern(name),
+                               typ: Type::function(vec![typ("a")],
+                                                        Type::app(typ(name), vec![typ("a")])),
+                           }])
     };
     let test = alias("Test", &["a"], variant("Test"));
     let m = Generic {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -262,12 +262,17 @@ impl<'input, I, Id, F> ParserEnv<I, F>
     }
 
     fn parse_adt(&self, return_type: &ArcType<Id>, input: I) -> ParseResult<ArcType<Id>, I> {
-        let variant = (token(Token::Pipe),
-                       self.ident(),
-                       many(self.parser(ParserEnv::<I, F>::type_arg)))
-            .map(|(_, id, args): (_, _, Vec<_>)| (id, Type::function(args, return_type.clone())));
+        let variant =
+            (token(Token::Pipe), self.ident(), many(self.parser(ParserEnv::<I, F>::type_arg)))
+                .map(|(_, id, args): (_, _, Vec<_>)| {
+                    Field {
+                        name: id,
+                        typ: Type::function(args, return_type.clone()),
+                    }
+                });
+
         many1(variant)
-            .map(Type::variants)
+            .map(Type::variant)
             .parse_stream(input)
     }
 

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -245,8 +245,7 @@ fn type_decl_record() {
 fn type_mutually_recursive() {
     let _ = ::env_logger::init();
     let e = parse_new!("type Test = | Test Int and Test2 = { x: Int, y: {} } in 1");
-    let test = Type::variants(vec![(intern("Test"),
-                                    Type::function(vec![typ("Int")], typ("Test")))]);
+    let test = Type::variant(vec![field("Test", Type::function(vec![typ("Int")], typ("Test")))]);
     let test2 = Type::record(Vec::new(),
                              vec![Field {
                                       name: intern("x"),
@@ -307,7 +306,7 @@ fn variant_type() {
     assert_eq!(e,
                type_decl(intern("Option"),
                          vec![generic("a")],
-                         Type::variants(vec![(intern("None"), none), (intern("Some"), some)]),
+                         Type::variant(vec![field("None", none), field("Some", some)]),
                          app(id("Some"), vec![int(1)])));
 }
 #[test]

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -257,7 +257,7 @@ impl CompilerEnv for TypeInfos {
             .filter_map(|(_, ref alias)| {
                 match *alias.typ {
                     Type::Variant(ref row) => {
-                        row.field_iter()
+                        row.row_iter()
                             .enumerate()
                             .find(|&(_, field)| field.name == *id)
                     }
@@ -330,7 +330,7 @@ impl<'a> Compiler<'a> {
             .filter_map(|(_, typ)| {
                 match **typ {
                     Type::Variant(ref row) => {
-                        row.field_iter()
+                        row.row_iter()
                             .enumerate()
                             .find(|&(_, field)| field.name == *id)
                     }
@@ -388,7 +388,7 @@ impl<'a> Compiler<'a> {
     fn find_field(&self, typ: &ArcType, field: &Symbol) -> Option<FieldAccess> {
         // Remove all type aliases to get the actual record type
         let typ = instantiate::remove_aliases_cow(self, typ);
-        let mut iter = typ.field_iter();
+        let mut iter = typ.row_iter();
         match iter.by_ref().position(|f| f.name.name_eq(field)) {
             Some(index) => {
                 for _ in iter.by_ref() {}
@@ -406,7 +406,7 @@ impl<'a> Compiler<'a> {
     fn find_tag(&self, typ: &ArcType, constructor: &Symbol) -> Option<VmTag> {
         match **instantiate::remove_aliases_cow(self, typ) {
             Type::Variant(ref row) => {
-                row.field_iter()
+                row.row_iter()
                     .enumerate()
                     .find(|&(_, field)| field.name == *constructor)
                     .map(|(tag, _)| tag as VmTag)
@@ -794,7 +794,7 @@ impl<'a> Compiler<'a> {
                 });
                 match *typ {
                     Type::Record(_) => {
-                        let mut field_iter = typ.field_iter();
+                        let mut field_iter = typ.row_iter();
                         let number_of_fields = field_iter.by_ref().count();
                         let is_polymorphic = **field_iter.current_type() != Type::EmptyRow;
                         if fields.len() == 0 ||
@@ -816,7 +816,7 @@ impl<'a> Compiler<'a> {
                             }
                         } else {
                             function.emit(Split);
-                            for field in typ.field_iter() {
+                            for field in typ.row_iter() {
                                 let name = match fields.iter()
                                     .find(|tup| tup.0.name_eq(&field.name)) {
                                     Some(&(ref name, ref bind)) => {

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -173,12 +173,14 @@ impl TypeEnv for TypeInfos {
             .iter()
             .filter_map(|(_, ref alias)| {
                 match *alias.typ {
-                    Type::Variants(ref variants) => variants.iter().find(|v| v.0.as_ref() == id),
+                    Type::Variant(ref row) => {
+                        row.field_iter().find(|field| field.name.as_ref() == id)
+                    }
                     _ => None,
                 }
             })
             .next()
-            .map(|x| &x.1)
+            .map(|field| &field.typ)
     }
 
     fn find_type_info(&self, id: &SymbolRef) -> Option<&Alias<Symbol, ArcType>> {

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -174,7 +174,7 @@ impl TypeEnv for TypeInfos {
             .filter_map(|(_, ref alias)| {
                 match *alias.typ {
                     Type::Variant(ref row) => {
-                        row.field_iter().find(|field| field.name.as_ref() == id)
+                        row.row_iter().find(|field| field.name.as_ref() == id)
                     }
                     _ => None,
                 }
@@ -196,7 +196,7 @@ impl TypeEnv for TypeInfos {
                 match *alias.typ {
                     Type::Record(_) => {
                         fields.iter().all(|name| {
-                            alias.typ.field_iter().any(|f| f.name.as_ref() == name.as_ref())
+                            alias.typ.row_iter().any(|f| f.name.as_ref() == name.as_ref())
                         })
                     }
                     _ => false,

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -141,7 +141,7 @@ impl TypeEnv for VmEnv {
                     .filter_map(|alias| {
                         match *alias.typ {
                             Type::Variant(ref row) => {
-                                row.field_iter()
+                                row.row_iter()
                                     .find(|field| *field.name == *id)
                                     .map(|field| &field.typ)
                             }
@@ -260,7 +260,7 @@ impl VmEnv {
             };
             // HACK Can't return the data directly due to the use of cow on the type
             let next_type = map_cow_option(typ.clone(), |typ| {
-                typ.field_iter()
+                typ.row_iter()
                     .enumerate()
                     .find(|&(_, field)| field.name.as_ref() == field_name)
                     .map(|(index, field)| {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -140,8 +140,10 @@ impl TypeEnv for VmEnv {
                     .values()
                     .filter_map(|alias| {
                         match *alias.typ {
-                            Type::Variants(ref ctors) => {
-                                ctors.iter().find(|ctor| *ctor.0 == *id).map(|t| &t.1)
+                            Type::Variant(ref row) => {
+                                row.field_iter()
+                                    .find(|field| *field.name == *id)
+                                    .map(|field| &field.typ)
                             }
                             _ => None,
                         }


### PR DESCRIPTION
Like extensible records, you can't actually do much with these at the moment, but it _does_ simplify the internal representation somewhat.