### PR TITLE
fix: Track from where a part of the AST originated

### DIFF
--- a/base/src/error.rs
+++ b/base/src/error.rs
@@ -5,7 +5,7 @@ use std::any::Any;
 use std::error::Error as StdError;
 use std::fmt;
 
-use pos::{BytePos, Location, Span, Spanned};
+use pos::{BytePos, Location, Span, Spanned, spanned2};
 use source::Source;
 
 /// An error type which can represent multiple errors.
@@ -60,13 +60,7 @@ impl<E> SourceContext<E> {
 
         SourceContext {
             line: line.to_string(),
-            error: Spanned {
-                span: Span {
-                    start: start,
-                    end: end,
-                },
-                value: error.value,
-            },
+            error: spanned2(start, end, error.value),
         }
     }
 }
@@ -103,7 +97,7 @@ impl<E: fmt::Display> InFile<E> {
 impl<E: fmt::Display> fmt::Display for InFile<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for error in &self.error.errors {
-            let Span { start, end } = error.error.span;
+            let Span { start, end, .. } = error.error.span;
 
             try!(write!(f, "{}:{}\n{}\n", self.source_name, error.error, error.line));
 

--- a/check/src/completion.rs
+++ b/check/src/completion.rs
@@ -3,9 +3,10 @@
 use std::iter::once;
 use std::cmp::Ordering;
 
-use base::ast::{Expr, SpannedExpr, SpannedPattern, Pattern, TypedIdent, Typed};
+use base::ast::{Expr, SpannedExpr, SpannedPattern, Pattern, TypedIdent, Typed, Visitor, walk_expr,
+                walk_pattern};
 use base::instantiate;
-use base::pos::{BytePos, Span};
+use base::pos::{BytePos, Span, NO_EXPANSION};
 use base::scoped_map::ScopedMap;
 use base::symbol::Symbol;
 use base::types::{ArcType, Type, TypeEnv};
@@ -25,6 +26,8 @@ trait OnFound {
 
     /// Location points to whitespace
     fn nothing(&mut self);
+
+    fn found(&self) -> bool;
 }
 
 struct GetType<E> {
@@ -42,6 +45,10 @@ impl<E: TypeEnv> OnFound for GetType<E> {
     }
 
     fn nothing(&mut self) {}
+
+    fn found(&self) -> bool {
+        self.typ.is_some()
+    }
 }
 
 pub struct Suggestion {
@@ -120,6 +127,10 @@ impl<E: TypeEnv> OnFound for Suggest<E> {
             }
         }));
     }
+
+    fn found(&self) -> bool {
+        !self.result.is_empty()
+    }
 }
 
 struct FindVisitor<F> {
@@ -156,6 +167,32 @@ impl<F> FindVisitor<F> {
     }
 }
 
+struct VisitUnExpanded<'e, F: 'e>(&'e mut FindVisitor<F>);
+
+impl<'e, F> Visitor for VisitUnExpanded<'e, F>
+    where F: OnFound,
+{
+    type Ident = Symbol;
+
+    fn visit_expr(&mut self, e: &SpannedExpr<Self::Ident>) {
+        if !self.0.on_found.found() {
+            if e.span.expansion_id == NO_EXPANSION {
+                self.0.visit_expr(e);
+            } else {
+                walk_expr(self, e);
+            }
+        }
+    }
+
+    fn visit_pattern(&mut self, e: &SpannedPattern<Self::Ident>) {
+        if e.span.expansion_id == NO_EXPANSION {
+            self.0.visit_pattern(e);
+        } else {
+            walk_pattern(self, &e.value);
+        }
+    }
+}
+
 impl<F> FindVisitor<F>
     where F: OnFound,
 {
@@ -171,6 +208,11 @@ impl<F> FindVisitor<F>
     }
 
     fn visit_expr(&mut self, current: &SpannedExpr<Symbol>) {
+        // When inside a macro expanded expression we do a exhaustive search for an unexpanded expression
+        if current.span.expansion_id != NO_EXPANSION {
+            VisitUnExpanded(self).visit_expr(current);
+            return;
+        }
         match current.value {
             Expr::Ident(_) | Expr::Literal(_) => {
                 if current.span.containment(&self.pos) == Ordering::Equal {

--- a/check/tests/completion.rs
+++ b/check/tests/completion.rs
@@ -81,6 +81,21 @@ and g x = "asd"
 }
 
 #[test]
+fn let_in_let() {
+    let result = find_type(r#"
+let f =
+    let g y =
+        123
+    g
+f
+"#,
+                           BytePos::from(33));
+    let expected = Ok(typ("Int"));
+
+    assert_eq!(result, expected);
+}
+
+#[test]
 fn function_app() {
     let _ = env_logger::init();
 

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -730,10 +730,7 @@ in f "123"
     let err = result.unwrap_err();
     assert_eq!(err.errors.len(), 1);
     assert_eq!(err.errors[0].span,
-               Span {
-                   start: BytePos::from(26),
-                   end: BytePos::from(31),
-               });
+               Span::new(BytePos::from(26), BytePos::from(31)));
 }
 
 /// Test that overload resolution selects the closest implementation that matches even if another

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use base::ast::is_operator_char;
-use base::pos::{BytePos, Column, Line, Location, Span, Spanned};
+use base::pos::{BytePos, Column, Line, Location, Span, Spanned, NO_EXPANSION};
 
 use combine::primitives::{Consumed, Error as CombineError, RangeStream};
 use combine::combinator::EnvParser;
@@ -464,6 +464,7 @@ impl<'input, I> Lexer<'input, I>
                     span: Span {
                         start: loc,
                         end: loc,
+                        expansion_id: NO_EXPANSION,
                     },
                     value: Token::EOF,
                 };
@@ -484,6 +485,7 @@ impl<'input, I> Lexer<'input, I>
                     span: Span {
                         start: start,
                         end: end,
+                        expansion_id: NO_EXPANSION,
                     },
                     value: token,
                 }
@@ -494,6 +496,7 @@ impl<'input, I> Lexer<'input, I>
                 let span = Span {
                     start: start,
                     end: start,
+                    expansion_id: NO_EXPANSION,
                 };
                 self.end_span = Some(span);
                 SpannedToken {
@@ -680,6 +683,7 @@ impl<'input, I> Lexer<'input, I>
                     self.end_span = Some(Span {
                         start: loc,
                         end: loc,
+                        expansion_id: NO_EXPANSION,
                     });
                 }
                 Err(err)

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -102,6 +102,7 @@ impl<'input, 'lexer> StreamOnce for Wrapper<'input, 'lexer> {
         Span {
             start: span.start.absolute,
             end: span.end.absolute,
+            expansion_id: pos::NO_EXPANSION,
         }
     }
 }
@@ -451,6 +452,7 @@ impl<'input, I, Id, F> ParserEnv<I, F>
                 let span = Span {
                     start: start,
                     end: input.position().end,
+                    expansion_id: pos::NO_EXPANSION,
                 };
                 Ok((span, Consumed::Empty(input)))
             }))
@@ -731,11 +733,9 @@ impl<'input, I, Id, F> ParserEnv<I, F>
          token(Token::Else),
          self.expr())
             .map(|(_, b, _, t, _, f)| {
-                pos::spanned(Span {
-                                 start: start,
-                                 end: f.span.end,
-                             },
-                             Expr::IfElse(Box::new(b), Box::new(t), Box::new(f)))
+                pos::spanned2(start,
+                              f.span.end,
+                              Expr::IfElse(Box::new(b), Box::new(t), Box::new(f)))
             })
             .parse_stream(input)
     }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -438,8 +438,7 @@ impl<'input, I, Id, F> ParserEnv<I, F>
     /// Parses an expression which could be an argument to a function
     fn parse_arg(&self, input: I) -> ParseResult<SpannedExpr<Id>, I> {
         debug!("Expr start: {:?}", input.clone().uncons());
-        let span = input.position();
-        let loc = |expr| pos::spanned(span, expr);
+        let start = input.position().start;
 
         // To prevent stack overflows we push all binding groups (which are commonly deeply nested)
         // to a stack and construct the expressions afterwards
@@ -448,7 +447,14 @@ impl<'input, I, Id, F> ParserEnv<I, F>
         let mut input = input;
         let mut declaration_parser = self.parser(ParserEnv::<I, F>::type_decl)
             .or(self.parser(ParserEnv::<I, F>::let_in))
-            .map(loc);
+            .and(parser(move |input: I| {
+                let span = Span {
+                    start: start,
+                    end: input.position().end,
+                };
+                Ok((span, Consumed::Empty(input)))
+            }))
+            .map(|(decl, span)| pos::spanned(span, decl));
         loop {
             match declaration_parser.parse_lazy(input.clone()) {
                 ConsumedOk((bindings, new_input)) |

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -20,11 +20,7 @@ pub fn intern(s: &str) -> String {
 type SpExpr = SpannedExpr<String>;
 
 fn no_loc<T>(value: T) -> Spanned<T, BytePos> {
-    pos::spanned(Span {
-                     start: BytePos::from(0),
-                     end: BytePos::from(0),
-                 },
-                 value)
+    pos::spanned(Span::default(), value)
 }
 
 fn binop(l: SpExpr, s: &str, r: SpExpr) -> SpExpr {
@@ -412,24 +408,15 @@ fn span_identifier() {
     let _ = ::env_logger::init();
 
     let e = parse_new!("test");
-    assert_eq!(e.span,
-               Span {
-                   start: BytePos::from(0),
-                   end: BytePos::from(4),
-               });
+    assert_eq!(e.span, Span::new(BytePos::from(0), BytePos::from(4)));
 }
-
 
 #[test]
 fn span_integer() {
     let _ = ::env_logger::init();
 
     let e = parse_new!("1234");
-    assert_eq!(e.span,
-               Span {
-                   start: BytePos::from(0),
-                   end: BytePos::from(4),
-               });
+    assert_eq!(e.span, Span::new(BytePos::from(0), BytePos::from(4)));
 }
 
 // FIXME The span of string literals includes the spaces after them
@@ -439,11 +426,7 @@ fn span_string_literal() {
     let _ = ::env_logger::init();
 
     let e = parse_new!(r#" "test" "#);
-    assert_eq!(e.span,
-               Span {
-                   start: BytePos::from(1),
-                   end: BytePos::from(7),
-               });
+    assert_eq!(e.span, Span::new(BytePos::from(1), BytePos::from(7)));
 }
 
 #[test]
@@ -451,11 +434,7 @@ fn span_app() {
     let _ = ::env_logger::init();
 
     let e = parse_new!(r#" f 123 "asd""#);
-    assert_eq!(e.span,
-               Span {
-                   start: BytePos::from(1),
-                   end: BytePos::from(12),
-               });
+    assert_eq!(e.span, Span::new(BytePos::from(1), BytePos::from(12)));
 }
 
 #[test]
@@ -467,11 +446,7 @@ match False with
     | True -> "asd"
     | False -> ""
 "#);
-    assert_eq!(e.span,
-               Span {
-                   start: BytePos::from(1),
-                   end: BytePos::from(55),
-               });
+    assert_eq!(e.span, Span::new(BytePos::from(1), BytePos::from(55)));
 }
 
 #[test]
@@ -484,11 +459,7 @@ if True then
 else
     123.45
 "#);
-    assert_eq!(e.span,
-               Span {
-                   start: BytePos::from(1),
-                   end: BytePos::from(35),
-               });
+    assert_eq!(e.span, Span::new(BytePos::from(1), BytePos::from(35)));
 }
 
 #[test]
@@ -496,29 +467,17 @@ fn span_byte() {
     let _ = ::env_logger::init();
 
     let e = parse_new!(r#"124b"#);
-    assert_eq!(e.span,
-               Span {
-                   start: BytePos::from(0),
-                   end: BytePos::from(4),
-               });
+    assert_eq!(e.span, Span::new(BytePos::from(0), BytePos::from(4)));
 }
 
 #[test]
 fn span_field_access() {
     let _ = ::env_logger::init();
     let expr = parse_new!("record.x");
-    assert_eq!(expr.span,
-               Span {
-                   start: BytePos::from(0),
-                   end: BytePos::from(8),
-               });
+    assert_eq!(expr.span, Span::new(BytePos::from(0), BytePos::from(8)));
     match expr.value {
         Expr::Projection(ref e, _, _) => {
-            assert_eq!(e.span,
-                       Span {
-                           start: BytePos::from(0),
-                           end: BytePos::from(6),
-                       });
+            assert_eq!(e.span, Span::new(BytePos::from(0), BytePos::from(6)));
         }
         _ => panic!(),
     }
@@ -613,10 +572,7 @@ fn partial_field_access() {
     assert!(e.is_err());
     assert_eq!(e.unwrap_err().0,
                Some(Spanned {
-                   span: Span {
-                       start: BytePos::from(0),
-                       end: BytePos::from(0),
-                   },
+                   span: Span::default(),
                    value: Expr::Projection(Box::new(id("test")), intern(""), Type::hole()),
                }));
 }
@@ -632,15 +588,9 @@ test
     assert!(e.is_err());
     assert_eq!(e.unwrap_err().0,
                Some(Spanned {
-                   span: Span {
-                       start: BytePos::from(0),
-                       end: BytePos::from(0),
-                   },
+                   span: Span::default(),
                    value: Expr::Block(vec![Spanned {
-                                               span: Span {
-                                                   start: BytePos::from(0),
-                                                   end: BytePos::from(0),
-                                               },
+                                               span: Span::new(BytePos::from(0), BytePos::from(0)),
                                                value: Expr::Projection(Box::new(id("test")),
                                                                        intern(""),
                                                                        Type::hole()),

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -6,6 +6,9 @@ mod support;
 
 use support::*;
 
+use gluon::base::pos::BytePos;
+use gluon::base::types::Type;
+use gluon::check::completion;
 use gluon::vm::api::{FunctionRef, Hole, IO, OpaqueValue, ValueRef};
 use gluon::vm::thread::{Thread, ThreadInternal};
 use gluon::vm::internal::Value;
@@ -752,6 +755,55 @@ g 10
         Err(err) => panic!("Unexpected error `{}`", err),
         Ok(_) => panic!("Expected an error"),
     }
+}
+#[test]
+fn completion_with_prelude() {
+    let _ = ::env_logger::init();
+    let vm = make_vm();
+
+    let expr = r#"
+let prelude = import "std/prelude.glu"
+and { Option, Num } = prelude
+and { (+) } = prelude.num_Int
+
+type Stream_ a =
+    | Value a (Stream a)
+    | Empty
+and Stream a = Lazy (Stream_ a)
+
+let from f : (Int -> Option a) -> Stream a =
+        let from_ i =
+                lazy (\_ ->
+                    match f i with
+                        | Some x -> Value x (from_ (i + 1))
+                        | None -> Empty
+                )
+        in from_ 0
+
+{ from }
+"#;
+
+    let (expr, _) = Compiler::new()
+        .typecheck_str(&vm, "example", expr, None)
+        .unwrap_or_else(|err| panic!("{}", err));
+
+    let result = completion::find(&*vm.get_env(), &expr, BytePos::from(311));
+    assert_eq!(result, Ok(Type::int()));
+}
+
+#[test]
+fn completion_with_prelude_at_0() {
+    let _ = ::env_logger::init();
+    let vm = make_vm();
+
+    let expr = "1";
+
+    let (expr, _) = Compiler::new()
+        .typecheck_str(&vm, "example", expr, None)
+        .unwrap_or_else(|err| panic!("{}", err));
+
+    let result = completion::find(&*vm.get_env(), &expr, BytePos::from(0));
+    assert_eq!(result, Ok(Type::int()));
 }
 
 #[test]

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1346,7 +1346,7 @@ fn binop<'b, F, T>(vm: &'b Thread, stack: &mut StackFrame<'b>, f: F)
             // pushing numbers should never return an error so unwrap
             stack.stack.push(result);
         }
-        (l, r) => panic!("{:?} `op` {:?}", l, r),
+        _ => panic!("{:?} `op` {:?}", l, r),
     }
 }
 


### PR DESCRIPTION
This is an attempt of a less hacky alternative to #190. By tracking the source of an expression the completion requests can skip over expanded expressions (like the implicit prelude) and only search in the non expanded expressions.

This increases the size of `Span<BytePos>` by 50% which, being a frequently used type, is rather unfortunate. We could maybe do some trickery to reduce this but this could be done later if it is necessary.

(Supersedes)
Closes #190
