### PR TITLE
fix(vm): Only store generation-0 values in the globals table

### DIFF
--- a/benches/function_call.rs
+++ b/benches/function_call.rs
@@ -53,7 +53,7 @@ fn factorial_tail_call(b: &mut ::test::Bencher) {
 fn gluon_rust_boundary_overhead(b: &mut ::test::Bencher) {
     let vm = new_vm();
 
-    fn test_fn(_: &Thread) -> Status {
+    extern "C" fn test_fn(_: &Thread) -> Status {
         Status::Ok
     }
 

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -300,7 +300,7 @@ impl<E> Executable<()> for CompileValue<E>
         let metadata = metadata::metadata(&*vm.get_env(), expr.borrow_mut());
         let closure = try!(vm.global_env().new_global_thunk(function));
         let value = try!(vm.call_thunk(closure));
-        try!(vm.global_env().set_global(closure.function.name.clone(), typ, metadata, value));
+        try!(vm.set_global(closure.function.name.clone(), typ, metadata, value));
         info!("Loaded module `{}` filename", filename);
         Ok(())
     }

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -16,7 +16,6 @@ use base::types::ArcType;
 use base::symbol::{Name, NameBuf, Symbol, SymbolModule};
 
 use vm::compiler::CompiledFunction;
-use vm::internal::ClosureDataDef;
 use vm::macros::MacroExpander;
 use vm::thread::{RootedValue, Thread, ThreadInternal};
 
@@ -281,8 +280,7 @@ impl<E> Executable<()> for CompileValue<E>
 
         let CompileValue { expr, typ, mut function } = self;
         function.id = Symbol::from(name);
-        let function = try!(vm.global_env().new_function(function));
-        let closure = try!(vm.context().alloc(ClosureDataDef(function, &[])));
+        let closure = try!(vm.global_env().new_global_thunk(function));
         let value = try!(vm.call_thunk(closure));
         Ok(ExecuteValue {
             expr: expr,
@@ -300,10 +298,9 @@ impl<E> Executable<()> for CompileValue<E>
 
         let CompileValue { mut expr, typ, function } = self;
         let metadata = metadata::metadata(&*vm.get_env(), expr.borrow_mut());
-        let function = try!(vm.global_env().new_function(function));
-        let closure = try!(vm.context().alloc(ClosureDataDef(function, &[])));
+        let closure = try!(vm.global_env().new_global_thunk(function));
         let value = try!(vm.call_thunk(closure));
-        try!(vm.global_env().set_global(function.name.clone(), typ, metadata, value));
+        try!(vm.global_env().set_global(closure.function.name.clone(), typ, metadata, value));
         info!("Loaded module `{}` filename", filename);
         Ok(())
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -118,7 +118,7 @@ fn read_line() -> IO<String> {
 }
 
 /// IO a -> (String -> IO a) -> IO a
-fn catch_io(vm: &Thread) -> Status {
+extern "C" fn catch_io(vm: &Thread) -> Status {
     let mut context = vm.context();
     let frame_level = context.stack.get_frames().len();
     let action = StackFrame::current(&mut context.stack)[0];

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,4 +1,6 @@
 extern crate env_logger;
+#[macro_use]
+extern crate gluon_vm;
 extern crate gluon;
 
 use gluon::base::types::Type;
@@ -66,11 +68,7 @@ fn root_data() {
     }
     vm.register_type::<Test>("Test", &[])
         .unwrap_or_else(|_| panic!("Could not add type"));
-    vm.define_global("test", {
-            let test: fn(_, _) -> _ = test;
-            test
-        })
-        .unwrap();
+    vm.define_global("test", primitive!(2 test)).unwrap();
     load_script(&vm, "script_fn", expr).unwrap_or_else(|err| panic!("{}", err));
     let mut script_fn: FunctionRef<fn(Test) -> VmInt> = vm.get_global("script_fn").unwrap();
     let result = script_fn.call(Test(123))
@@ -92,11 +90,7 @@ test "hello"
     }
 
     let vm = make_vm();
-    vm.define_global("test", {
-            let test: fn(_) -> _ = test;
-            test
-        })
-        .unwrap();
+    vm.define_global("test", primitive!(1 test)).unwrap();
 
     let result = Compiler::new().run_expr::<String>(&vm, "<top>", expr).unwrap();
     let expected = ("hello world".to_string(), Type::string());
@@ -116,11 +110,7 @@ sum_bytes [100b, 42b, 3b, 15b]
     }
 
     let vm = make_vm();
-    vm.define_global("sum_bytes", {
-            let sum_bytes: fn(_) -> _ = sum_bytes;
-            sum_bytes
-        })
-        .unwrap();
+    vm.define_global("sum_bytes", primitive!(1 sum_bytes)).unwrap();
 
     let result =
         Compiler::new().run_expr::<u8>(&vm, "<top>", expr).unwrap_or_else(|err| panic!("{}", err));

--- a/tests/compile-fail/get-reference.rs
+++ b/tests/compile-fail/get-reference.rs
@@ -4,8 +4,6 @@ use gluon::vm::Variants;
 use gluon::vm::internal::Value;
 use gluon::vm::api::Getable;
 
-fn f(_: &'static str) {}
-
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     unsafe {

--- a/tests/compile-fail/getable-reference-str.rs
+++ b/tests/compile-fail/getable-reference-str.rs
@@ -1,13 +1,18 @@
+#[macro_use]
+extern crate gluon_vm;
 extern crate gluon;
 use gluon::new_vm;
-use gluon::vm::api::Pushable;
+use gluon::vm::thread::{Thread, Status};
+use gluon::vm::api::{primitive_f, Pushable};
 
+extern "C" fn dummy(_: &Thread) -> Status {
+    unimplemented!()
+}
 fn f(_: &'static str) {}
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     let vm = new_vm();
-    let f: fn(_) = f;
-    vm.define_global("test", f);
+    vm.define_global("test", unsafe { primitive_f("f", dummy, f as fn (_)) });
     //~^ Error `vm` does not live long enough
 }

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -1,7 +1,10 @@
+#[macro_use]
+extern crate gluon_vm;
 extern crate gluon;
 use gluon::new_vm;
+use gluon::vm::thread::{Thread, Status};
 use gluon::vm::gc::{Gc, Traverseable};
-use gluon::vm::api::{Pushable, VmType, Userdata};
+use gluon::vm::api::{Pushable, VmType, Userdata, primitive_f};
 
 #[derive(Debug)]
 struct Test;
@@ -16,12 +19,14 @@ impl Traverseable for Test {
     fn traverse(&self, _: &mut Gc) {}
 }
 
+extern "C" fn dummy(_: &Thread) -> Status {
+    unimplemented!()
+}
 fn f(_: &'static Test) {}
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     let vm = new_vm();
-    let f: fn(_) = f;
-    vm.define_global("test", f);
+    vm.define_global("test", unsafe { primitive_f("f", dummy, f as fn (_)) });
     //~^ Error `vm` does not live long enough
 }

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -1,0 +1,39 @@
+let { run, writer, assert, assert_ieq, assert_feq } = import "std/test.glu"
+let prelude = import "std/prelude.glu"
+let { (*>) } = prelude.make_Applicative writer.applicative
+
+
+let _ =
+    let { sender, receiver } = channel (lazy \_ -> 0)
+
+    let thread = spawn \_ ->
+        send sender (lazy \_ -> 1)
+        let l = lazy \_ -> 2
+        force l
+        send sender l
+        ()
+    
+    resume thread
+
+    match recv receiver with
+    | Ok x -> assert (force x == 1)
+    | Err e -> error "Receive 1 error"
+
+    match recv receiver with
+    | Ok x -> assert (force x == 2)
+    | Err e -> error "Receive 2 error"
+
+let _ =
+    let { sender, receiver } = channel (ref 0)
+
+    let thread = spawn \_ ->
+        send sender (ref 3)
+        ()
+        
+    resume thread
+
+    match recv receiver with
+    | Ok x -> assert (load x == 3)
+    | Err e -> error "Receive 3 error"
+
+()

--- a/tests/tutorial.rs
+++ b/tests/tutorial.rs
@@ -1,4 +1,6 @@
 extern crate env_logger;
+#[macro_use]
+extern crate gluon_vm;
 extern crate gluon;
 
 use gluon::base::types::Type;
@@ -38,7 +40,7 @@ fn call_rust_from_gluon() {
         if x <= 1 { 1 } else { x * factorial(x - 1) }
     }
     let vm = new_vm();
-    vm.define_global("factorial", factorial as fn(_) -> _).unwrap();
+    vm.define_global("factorial", primitive!(1 factorial)).unwrap();
 
     let result = Compiler::new().run_expr::<i32>(&vm, "example", "factorial 5").unwrap();
     let expected = (120, Type::int());

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -118,7 +118,7 @@ fn recv(receiver: &Receiver<Generic<A>>) -> Result<Generic<A>, ()> {
 }
 
 fn send(sender: &Sender<Generic<A>>, value: Generic<A>) -> Result<(), ()> {
-    let value = try!(sender.thread.deep_clone(value.0).map_err(|_| ()));
+    let value = try!(sender.thread.deep_clone_value(value.0).map_err(|_| ()));
     Ok(sender.send(Generic::from(value)))
 }
 

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -122,7 +122,7 @@ fn send(sender: &Sender<Generic<A>>, value: Generic<A>) -> Result<(), ()> {
     Ok(sender.send(Generic::from(value)))
 }
 
-fn resume(vm: &Thread) -> Status {
+extern "C" fn resume(vm: &Thread) -> Status {
     let mut context = vm.context();
     let value = StackFrame::current(&mut context.stack)[0];
     match value {
@@ -154,7 +154,7 @@ fn resume(vm: &Thread) -> Status {
     }
 }
 
-fn yield_(_vm: &Thread) -> Status {
+extern "C" fn yield_(_vm: &Thread) -> Status {
     Status::Yield
 }
 
@@ -181,22 +181,15 @@ fn spawn_<'vm>(value: WithVM<'vm, Function<&'vm Thread, fn(())>>) -> VmResult<Ro
     Ok(thread)
 }
 
-fn f1<A, R>(f: fn(A) -> R) -> fn(A) -> R {
-    f
-}
-fn f2<A, B, R>(f: fn(A, B) -> R) -> fn(A, B) -> R {
-    f
-}
-
-pub fn load(vm: &Thread) -> VmResult<()> {
+pub fn load<'vm>(vm: &'vm Thread) -> VmResult<()> {
     let _ = vm.register_type::<Sender<A>>("Sender", &["a"]);
     let _ = vm.register_type::<Receiver<A>>("Receiver", &["a"]);
-    try!(vm.define_global("channel", f1(channel)));
-    try!(vm.define_global("recv", f1(recv)));
-    try!(vm.define_global("send", f2(send)));
+    try!(vm.define_global("channel", primitive!(1 channel)));
+    try!(vm.define_global("recv", primitive!(1 recv)));
+    try!(vm.define_global("send", primitive!(2 send)));
     try!(vm.define_global("resume",
-                          primitive::<fn(RootedThread) -> Result<(), String>>("resume", resume)));
+                          primitive::<fn(&'vm Thread) -> Result<(), String>>("resume", resume)));
     try!(vm.define_global("yield", primitive::<fn(())>("yield", yield_)));
-    try!(vm.define_global("spawn", f1(spawn)));
+    try!(vm.define_global("spawn", primitive!(1 spawn)));
     Ok(())
 }

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -152,7 +152,7 @@ fn show_char(c: char) -> String {
     format!("{}", c)
 }
 
-fn error(_: &Thread) -> Status {
+extern "C" fn error(_: &Thread) -> Status {
     // We expect a string as an argument to this function but we only return Status::Error
     // and let the caller take care of printing the message
     Status::Error
@@ -287,9 +287,9 @@ pub fn load(vm: &Thread) -> Result<()> {
     )));
 
     try!(vm.define_global("#error",
-                          primitive::<fn(StdString) -> A>("#error", prim::error)));
+                          primitive::<fn(StdString) -> Generic<A>>("#error", prim::error)));
     try!(vm.define_global("error",
-                          primitive::<fn(StdString) -> A>("error", prim::error)));
+                          primitive::<fn(StdString) -> Generic<A>>("error", prim::error)));
 
     try!(::lazy::load(vm));
     try!(::reference::load(vm));

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -68,17 +68,10 @@ fn make_ref(a: WithVM<Generic<A>>) -> Reference<A> {
     }
 }
 
-fn f1<A, R>(f: fn(A) -> R) -> fn(A) -> R {
-    f
-}
-fn f2<A, B, R>(f: fn(A, B) -> R) -> fn(A, B) -> R {
-    f
-}
-
 pub fn load(vm: &Thread) -> Result<()> {
     let _ = vm.register_type::<Reference<A>>("Ref", &["a"]);
-    try!(vm.define_global("<-", f2(set)));
-    try!(vm.define_global("load", f1(get)));
-    try!(vm.define_global("ref", f1(make_ref)));
+    try!(vm.define_global("<-", primitive!(2 set)));
+    try!(vm.define_global("load", primitive!(1 get)));
+    try!(vm.define_global("ref", primitive!(1 make_ref)));
     Ok(())
 }

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -159,6 +159,18 @@ pub struct Thread {
     context: Mutex<Context>,
 }
 
+impl fmt::Debug for Thread {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Thread({:p})", self)
+    }
+}
+
+impl Userdata for Thread {}
+
+impl VmType for Thread {
+    type Type = Self;
+}
+
 impl Traverseable for Thread {
     fn traverse(&self, gc: &mut Gc) {
         self.traverse_fields_except_stack(gc);
@@ -174,7 +186,7 @@ impl PartialEq for Thread {
 }
 
 impl VmType for RootedThread {
-    type Type = Self;
+    type Type = Thread;
 }
 
 impl<'vm> Pushable<'vm> for RootedThread {
@@ -186,6 +198,7 @@ impl<'vm> Pushable<'vm> for RootedThread {
 
 /// An instance of `Thread` which is rooted. See the `Thread` type for documentation on interacting
 /// with the type.
+#[derive(Debug)]
 pub struct RootedThread(GcPtr<Thread>);
 
 impl Drop for RootedThread {

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -552,8 +552,7 @@ impl ThreadInternal for Thread {
         let id = Symbol::from(name);
         let mut compiled_fn = CompiledFunction::new(args, id.clone(), typ.clone());
         compiled_fn.instructions = instructions;
-        let f = try!(self.global_env().new_function(compiled_fn));
-        let closure = try!(self.current_context().alloc(ClosureDataDef(f, &[])));
+        let closure = try!(self.global_env().new_global_thunk(compiled_fn));
         self.global_env().set_global(id, typ, Metadata::default(), Closure(closure)).unwrap();
         Ok(())
     }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -15,7 +15,16 @@ use {Error, Result};
 use self::Value::{Int, Float, String, Function, PartialApplication, Closure};
 
 mopafy!(Userdata);
-pub trait Userdata: ::mopa::Any + Traverseable + fmt::Debug + Send + Sync {}
+pub trait Userdata: ::mopa::Any + Traverseable + fmt::Debug + Send + Sync {
+    fn deep_clone(&self,
+                  visited: &mut FnvMap<*const (), Value>,
+                  gc: &mut Gc,
+                  thread: &Thread)
+                  -> Result<GcPtr<Box<Userdata>>> {
+        let _ = (visited, gc, thread);
+        Err(Error::Message("Userdata cannot be cloned".into()))
+    }
+}
 
 impl PartialEq for Userdata {
     fn eq(&self, other: &Userdata) -> bool {
@@ -743,7 +752,8 @@ fn deep_clone_str(data: GcPtr<Str>,
 }
 fn deep_clone_data(data: GcPtr<DataStruct>,
                    visited: &mut FnvMap<*const (), Value>,
-                   gc: &mut Gc)
+                   gc: &mut Gc,
+                   thread: &Thread)
                    -> Result<GcPtr<DataStruct>> {
     let result = try!(deep_clone_ptr(data, visited, |data| {
         let ptr = try!(gc.alloc(Def {
@@ -759,7 +769,7 @@ fn deep_clone_data(data: GcPtr<DataStruct>,
             {
                 let new_fields = unsafe { &mut new_data.as_mut().fields };
                 for (new, old) in new_fields.iter_mut().zip(&data.fields) {
-                    *new = try!(deep_clone(*old, visited, gc));
+                    *new = try!(deep_clone(*old, visited, gc, thread));
                 }
             }
             Ok(new_data)
@@ -767,19 +777,29 @@ fn deep_clone_data(data: GcPtr<DataStruct>,
     }
 }
 
+fn deep_clone_userdata(ptr: GcPtr<Box<Userdata>>,
+                       visited: &mut FnvMap<*const (), Value>,
+                       gc: &mut Gc,
+                       thread: &Thread)
+                       -> Result<GcPtr<Box<Userdata>>> {
+    ptr.deep_clone(visited, gc, thread)
+}
+
 fn deep_clone_array(array: GcPtr<ValueArray>,
                     visited: &mut FnvMap<*const (), Value>,
-                    gc: &mut Gc)
+                    gc: &mut Gc,
+                    thread: &Thread)
                     -> Result<GcPtr<ValueArray>> {
-    type CloneFn<T> = fn(T, &mut FnvMap<*const (), Value>, &mut Gc) -> Result<T>;
+    type CloneFn<T> = fn(T, &mut FnvMap<*const (), Value>, &mut Gc, &Thread) -> Result<T>;
     unsafe fn deep_clone_elems<T: Copy>(deep_clone: CloneFn<T>,
                                         mut new_array: GcPtr<ValueArray>,
                                         visited: &mut FnvMap<*const (), Value>,
-                                        gc: &mut Gc)
+                                        gc: &mut Gc,
+                                        thread: &Thread)
                                         -> Result<()> {
         let new_array = new_array.as_mut().unsafe_array_mut::<T>();
         for field in new_array.iter_mut() {
-            *field = try!(deep_clone(*field, visited, gc));
+            *field = try!(deep_clone(*field, visited, gc, thread));
         }
         Ok(())
     }
@@ -795,12 +815,15 @@ fn deep_clone_array(array: GcPtr<ValueArray>,
             unsafe {
                 try!(match new_array.repr() {
                     Repr::Byte | Repr::Int | Repr::Float | Repr::String => Ok(()),
-                    Repr::Array => deep_clone_elems(deep_clone_array, new_array, visited, gc),
-                    Repr::Unknown => deep_clone_elems(deep_clone, new_array, visited, gc),
-                    Repr::Userdata | Repr::Thread => {
-                        return Err(Error::Message("Threads, Userdata and Extern functions cannot \
-                                                   be deep cloned yet"
-                            .into()))
+                    Repr::Array => {
+                        deep_clone_elems(deep_clone_array, new_array, visited, gc, thread)
+                    }
+                    Repr::Unknown => deep_clone_elems(deep_clone, new_array, visited, gc, thread),
+                    Repr::Userdata => {
+                        deep_clone_elems(deep_clone_userdata, new_array, visited, gc, thread)
+                    }
+                    Repr::Thread => {
+                        return Err(Error::Message("Threads cannot be deep cloned yet".into()))
                     }
                 });
             }
@@ -811,7 +834,8 @@ fn deep_clone_array(array: GcPtr<ValueArray>,
 
 fn deep_clone_closure(data: GcPtr<ClosureData>,
                       visited: &mut FnvMap<*const (), Value>,
-                      gc: &mut Gc)
+                      gc: &mut Gc,
+                      thread: &Thread)
                       -> Result<GcPtr<ClosureData>> {
     let result = try!(deep_clone_ptr(data, visited, |data| {
         let ptr = try!(gc.alloc(ClosureDataDef(data.function, &data.upvars)));
@@ -824,7 +848,7 @@ fn deep_clone_closure(data: GcPtr<ClosureData>,
             {
                 let new_upvars = unsafe { &mut new_data.as_mut().upvars };
                 for (new, old) in new_upvars.iter_mut().zip(&data.upvars) {
-                    *new = try!(deep_clone(*old, visited, gc));
+                    *new = try!(deep_clone(*old, visited, gc, thread));
                 }
             }
             Ok(new_data)
@@ -833,7 +857,8 @@ fn deep_clone_closure(data: GcPtr<ClosureData>,
 }
 fn deep_clone_app(data: GcPtr<PartialApplicationData>,
                   visited: &mut FnvMap<*const (), Value>,
-                  gc: &mut Gc)
+                  gc: &mut Gc,
+                  thread: &Thread)
                   -> Result<GcPtr<PartialApplicationData>> {
     let result = try!(deep_clone_ptr(data, visited, |data| {
         let ptr = try!(gc.alloc(PartialApplicationDataDef(data.function, &data.args)));
@@ -847,7 +872,7 @@ fn deep_clone_app(data: GcPtr<PartialApplicationData>,
                 let new_args = unsafe { &mut new_data.as_mut().args };
                 for (new, old) in new_args.iter_mut()
                     .zip(&data.args) {
-                    *new = try!(deep_clone(*old, visited, gc));
+                    *new = try!(deep_clone(*old, visited, gc, thread));
                 }
             }
             Ok(new_data)
@@ -856,7 +881,8 @@ fn deep_clone_app(data: GcPtr<PartialApplicationData>,
 }
 pub fn deep_clone(value: Value,
                   visited: &mut FnvMap<*const (), Value>,
-                  gc: &mut Gc)
+                  gc: &mut Gc,
+                  thread: &Thread)
                   -> Result<Value> {
     // Only need to clone values which belong to a younger generation than the gc that the new
     // value will live in
@@ -865,20 +891,18 @@ pub fn deep_clone(value: Value,
     }
     match value {
         String(data) => deep_clone_str(data, visited, gc),
-        Value::Data(data) => deep_clone_data(data, visited, gc).map(Value::Data),
-        Value::Array(data) => deep_clone_array(data, visited, gc).map(Value::Array),
-        Closure(data) => deep_clone_closure(data, visited, gc).map(Value::Closure),
+        Value::Data(data) => deep_clone_data(data, visited, gc, thread).map(Value::Data),
+        Value::Array(data) => deep_clone_array(data, visited, gc, thread).map(Value::Array),
+        Closure(data) => deep_clone_closure(data, visited, gc, thread).map(Value::Closure),
         PartialApplication(data) => {
-            deep_clone_app(data, visited, gc).map(Value::PartialApplication)
+            deep_clone_app(data, visited, gc, thread).map(Value::PartialApplication)
         }
-        Function(ref f) => gc.alloc(Move(ExternFunction::clone(f))).map(Value::Function),
-        Value::Userdata(_) |
-        Value::Thread(_) => {
-            return Err(Error::Message("Threads and Userdata cannot be deep cloned yet".into()))
-        }
+        Function(f) => gc.alloc(Move(ExternFunction::clone(&f))).map(Value::Function),
         Value::Tag(i) => Ok(Value::Tag(i)),
         Value::Byte(i) => Ok(Value::Byte(i)),
         Int(i) => Ok(Int(i)),
         Float(f) => Ok(Float(f)),
+        Value::Userdata(userdata) => userdata.deep_clone(visited, gc, thread).map(Value::Userdata),
+        Value::Thread(_) => Err(Error::Message("Threads cannot be deep cloned yet".into())),
     }
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -355,7 +355,7 @@ impl GlobalVmState {
         }
         self.register_type::<IO<Generic<A>>>("IO", &["a"]).unwrap();
         self.register_type::<Lazy<Generic<A>>>("Lazy", &["a"]).unwrap();
-        self.register_type::<RootedThread>("Thread", &[]).unwrap();
+        self.register_type::<Thread>("Thread", &[]).unwrap();
         Ok(())
     }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -20,7 +20,7 @@ use compiler::{CompiledFunction, Variable, CompilerEnv};
 use api::IO;
 use lazy::Lazy;
 
-use value::BytecodeFunction;
+use value::{BytecodeFunction, ClosureData};
 
 pub use value::{ClosureDataDef, Userdata};
 pub use value::Value;//FIXME Value should not be exposed
@@ -359,8 +359,10 @@ impl GlobalVmState {
         Ok(())
     }
 
-    pub fn new_function(&self, f: CompiledFunction) -> Result<GcPtr<BytecodeFunction>> {
-        new_bytecode(&mut self.gc.lock().unwrap(), self, f)
+    pub fn new_global_thunk(&self, f: CompiledFunction) -> Result<GcPtr<ClosureData>> {
+        let mut gc = self.gc.lock().unwrap();
+        let function = try!(new_bytecode(&mut gc, self, f));
+        gc.alloc(ClosureDataDef(function, &[]))
     }
 
     pub fn get_type<T: ?Sized + Any>(&self) -> ArcType {


### PR DESCRIPTION
So the issue in #193 was that a module would be loaded from a child thread which means the objects were allocated from that thread as well. After the child thread was destroyed the values allocated from that thread still existed in the global table being potentially referenced again. To fix this we deep clone any values stored in the global table into the `GlobalVmState` gc which ensures they live long enough.

Fixes #193 