### PR TITLE
feat: Add the repl binary to github releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,14 @@ env:
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/78796507a78a48a4b18e
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: always
+    - https://webhooks.gitter.im/e/78796507a78a48a4b18e
+    on_success: change
+    on_failure: always
+    on_start: never
+deploy:
+  provider: releases
+  api_key:
+    secure: F86FGNVU2PbDun/ek45DX7EB0g6pyoZkaolVKa+K8ZE/x5FJZ/fBv7YtnhMSk5JcZs2vUtI0NDuHlSZwkkXj5ozu0vpp2ohDedALWKsxA68nf3iOkeT4SFUD5EMko9+G9z7fThWJPmE1LShtDEmlhLVXZ9dWZC0II9ojCAfxJmpaU0OruwF6FBvF26VYMgmCzJagyNdWt0GmG9HjyUgxC0exPajWzrg67/sUf7hVxuB/QC9csHwXMR+E31yMeiZNOUUh01z6D+ZQX4XmmuaB8yXeK3MirSoRR2AT3hSwfgEVsprSjVkRqCdouK13wjVmPYV9zS8gX+pwAvfjUR2hw/6MR1E3a16h4v5bpLil/qo65m2bhVXzGirx20uSIUuBRekuOpvEr1/0HjhdGLFq1RwDdLtOJVAryN4OLbJMtKmoJDAtvPg3eQqklsHHtxVIxkqRx/r7KhhcECjwSQhPvtIclc2Lk+yJaCk7Gw+DH27H0EYcHAnCf2py9JreTqy5DQy6UYeSEt+xo9cI1BDPQo6uhbQ5GkKV2nu98OFuI21F9u2IM3WnwrOgLIqFDpOhQeIXYbEx6AjahwBMGOseG/6X7FFytl2HeXTeFV8ey3paSM/dCadbYT9DaO5NiPtdUBEYnkH6f8IQug+71TAyknap7G3p+fleH+87WUHxSYI=
+  file: target/release/repl
+  on:
+    repo: gluon-lang/gluon

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,19 @@ rust:
 - nightly
 - beta
 - stable
+os:
+- linux
+- osx
+matrix:
+  exclude:
+  - os: osx
+    rust: nightly
+  - os: osx
+    rust: beta
 before_script:
 - |
   pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  export PATH=$HOME/Library/Python/2.7/bin:$HOME/.local/bin:$PATH
 script:
 - |
   sh ./test-no-skeptic.sh &&


### PR DESCRIPTION
I think this should solve #194. The repl executable should be the only relevant file to upload
