### PR TITLE
refactor: Add a simpler intermediate represenentation

### DIFF
--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -374,6 +374,20 @@ impl<Id: Clone> Typed for TypedIdent<Id> {
     }
 }
 
+impl Typed for Literal {
+    type Ident = Symbol;
+
+    fn env_type_of(&self, env: &TypeEnv) -> ArcType {
+        match *self {
+            Literal::Int(_) => Type::int(),
+            Literal::Float(_) => Type::float(),
+            Literal::Byte(_) => Type::byte(),
+            Literal::String(_) => Type::string(),
+            Literal::Char(_) => Type::char(),
+        }
+    }
+}
+
 impl Typed for Expr<Symbol> {
     type Ident = Symbol;
 
@@ -382,15 +396,7 @@ impl Typed for Expr<Symbol> {
             Expr::Ident(ref id) => id.typ.clone(),
             Expr::Projection(_, _, ref typ) |
             Expr::Record { ref typ, .. } => typ.clone(),
-            Expr::Literal(ref lit) => {
-                match *lit {
-                    Literal::Int(_) => Type::int(),
-                    Literal::Float(_) => Type::float(),
-                    Literal::Byte(_) => Type::byte(),
-                    Literal::String(_) => Type::string(),
-                    Literal::Char(_) => Type::char(),
-                }
-            }
+            Expr::Literal(ref lit) => lit.env_type_of(env),
             Expr::IfElse(_, ref arm, _) => arm.env_type_of(env),
             Expr::Tuple(ref exprs) => {
                 assert!(exprs.is_empty());

--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -377,7 +377,7 @@ impl<Id: Clone> Typed for TypedIdent<Id> {
 impl Typed for Literal {
     type Ident = Symbol;
 
-    fn env_type_of(&self, env: &TypeEnv) -> ArcType {
+    fn env_type_of(&self, _: &TypeEnv) -> ArcType {
         match *self {
             Literal::Int(_) => Type::int(),
             Literal::Float(_) => Type::float(),
@@ -486,4 +486,11 @@ fn get_return_type(env: &TypeEnv, alias_type: &ArcType, arg_count: usize) -> Arc
 
 pub fn is_operator_char(c: char) -> bool {
     "#+-*/&|=<>:.".chars().any(|x| x == c)
+}
+
+pub fn is_constructor(s: &str) -> bool {
+    s.rsplit('.')
+        .next()
+        .unwrap()
+        .starts_with(char::is_uppercase)
 }

--- a/base/src/pos.rs
+++ b/base/src/pos.rs
@@ -144,12 +144,10 @@ impl<Pos> PartialOrd for Span<Pos>
     fn partial_cmp(&self, other: &Span<Pos>) -> Option<Ordering> {
         self.start
             .partial_cmp(&other.start)
-            .and_then(|ord| {
-                if ord == Ordering::Equal {
-                    self.end.partial_cmp(&self.end)
-                } else {
-                    Some(ord)
-                }
+            .and_then(|ord| if ord == Ordering::Equal {
+                self.end.partial_cmp(&self.end)
+            } else {
+                Some(ord)
             })
     }
 }
@@ -170,10 +168,14 @@ impl<Pos> Ord for Span<Pos>
 
 impl<Pos: Ord> Span<Pos> {
     pub fn new(start: Pos, end: Pos) -> Span<Pos> {
+        Span::with_id(start, end, NO_EXPANSION)
+    }
+
+    pub fn with_id(start: Pos, end: Pos, no_expansion: ExpansionId) -> Span<Pos> {
         Span {
             start: start,
             end: end,
-            expansion_id: NO_EXPANSION,
+            expansion_id: no_expansion,
         }
     }
 

--- a/base/src/symbol.rs
+++ b/base/src/symbol.rs
@@ -73,9 +73,16 @@ impl Hash for Symbol {
 
 impl<'a> From<&'a str> for Symbol {
     fn from(name: &'a str) -> Symbol {
-        Symbol(Arc::new(NameBuf(String::from(name))))
+        Symbol::from(String::from(name))
     }
 }
+
+impl From<String> for Symbol {
+    fn from(name: String) -> Symbol {
+        Symbol(Arc::new(NameBuf(name)))
+    }
+}
+
 
 #[derive(Eq)]
 pub struct SymbolRef(str);

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -660,7 +660,8 @@ impl<'a, Id: 'a, T> Iterator for RowIterator<'a, T>
 
     fn next(&mut self) -> Option<&'a Field<Id, T>> {
         match **self.typ {
-            Type::Record(ref row) => {
+            Type::Record(ref row) |
+            Type::Variant(ref row) => {
                 self.typ = row;
                 self.next()
             }

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -182,7 +182,8 @@ impl<'a> TypeEnv for Environment<'a> {
                     _ => false,
                 }
             })
-            .map(|t| ((t.1).0.clone(), (t.1).1.typ().into_owned()))
+            // FIXME Don't use unresolved_type
+            .map(|t| ((t.1).0.clone(), (t.1).1.unresolved_type().clone()))
             .or_else(|| self.environment.find_record(fields))
     }
 }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -20,6 +20,8 @@ pretty = "0.2.0"
 bitflags = "0.7.0"
 itertools = "0.5.6"
 futures = "0.1.0"
+typed-arena = "1.2.0"
+smallvec = "0.2.1"
 
 gluon_base = { path = "../base", version = "0.3.0" }
 gluon_check = { path = "../check", version = "0.3.0" }

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -810,7 +810,7 @@ impl<'vm, T: Getable<'vm>> Getable<'vm> for Option<T> {
                 if data.tag == 0 {
                     Some(None)
                 } else {
-                    T::from_value(vm, Variants(&data.fields[1])).map(Some)
+                    T::from_value(vm, Variants(&data.fields[0])).map(Some)
                 }
             }
             Value::Tag(0) => Some(None),

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -592,8 +592,7 @@ impl<'vm> Getable<'vm> for bool {
 impl VmType for Ordering {
     type Type = Self;
     fn make_type(vm: &Thread) -> ArcType {
-        let symbol = vm.find_type_info("std.types.Ordering").unwrap().name.clone();
-        Type::app(Type::ident(symbol), collect![])
+        vm.find_type_info("std.types.Ordering").unwrap().clone().into_type()
     }
 }
 impl<'vm> Pushable<'vm> for Ordering {
@@ -783,8 +782,8 @@ impl<T: VmType> VmType for Option<T>
 {
     type Type = Option<T::Type>;
     fn make_type(vm: &Thread) -> ArcType {
-        let symbol = vm.find_type_info("std.types.Option").unwrap().name.clone();
-        Type::app(Type::ident(symbol), collect![T::make_type(vm)])
+        let option_alias = vm.find_type_info("std.types.Option").unwrap().clone().into_type();
+        Type::app(option_alias, collect![T::make_type(vm)])
     }
 }
 impl<'vm, T: Pushable<'vm>> Pushable<'vm> for Option<T> {
@@ -825,9 +824,8 @@ impl<T: VmType, E: VmType> VmType for StdResult<T, E>
 {
     type Type = StdResult<T::Type, E::Type>;
     fn make_type(vm: &Thread) -> ArcType {
-        let symbol = vm.find_type_info("std.types.Result").unwrap().name.clone();
-        Type::app(Type::ident(symbol),
-                  collect![E::make_type(vm), T::make_type(vm)])
+        let result_alias = vm.find_type_info("std.types.Result").unwrap().clone().into_type();
+        Type::app(result_alias, collect![E::make_type(vm), T::make_type(vm)])
     }
 }
 

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -710,7 +710,7 @@ impl<'a> Compiler<'a> {
                         Jump(function.function.instructions.len() as VmIndex);
                 }
             }
-            Expr::Data(ref id, exprs, _) => {
+            Expr::Data(ref id, exprs, _, _) => {
                 for expr in exprs {
                     self.compile(expr, function, false)?;
                 }

--- a/vm/src/core.rs
+++ b/vm/src/core.rs
@@ -1,26 +1,26 @@
 extern crate typed_arena;
 extern crate smallvec;
 
-use std::iter::{once, repeat};
+use std::iter::once;
 
 use self::typed_arena::Arena;
 
 use self::smallvec::SmallVec;
 
 use base::ast::{self, Literal, SpannedExpr, TypedIdent, Typed};
+use base::pos::{BytePos, Span};
 use base::symbol::Symbol;
-use base::types::{ArcType, Type, TypeEnv};
+use base::types::{ArcType, Type, TypeEnv, PrimitiveEnv, arg_iter};
 
 #[derive(Clone, Debug)]
 pub struct Closure<'a> {
+    pub name: TypedIdent<Symbol>,
     pub args: Vec<TypedIdent<Symbol>>,
     pub expr: &'a Expr<'a>,
 }
 
 #[derive(Clone, Debug)]
 pub enum Named<'a> {
-    // TODO Merge Closure and Recursive
-    Closure(Vec<TypedIdent<Symbol>>, &'a Expr<'a>),
     Recursive(Vec<Closure<'a>>),
     Expr(&'a Expr<'a>),
 }
@@ -29,6 +29,7 @@ pub enum Named<'a> {
 pub struct LetBinding<'a> {
     pub name: TypedIdent<Symbol>,
     pub expr: Named<'a>,
+    pub span_start: BytePos,
 }
 
 #[derive(Clone, Debug)]
@@ -46,50 +47,102 @@ pub struct Alternative<'a> {
 
 #[derive(Clone, Debug)]
 pub enum Expr<'a> {
-    Const(Literal),
-    Ident(TypedIdent<Symbol>),
+    Const(Literal, Span<BytePos>),
+    Ident(TypedIdent<Symbol>, Span<BytePos>),
     Call(&'a Expr<'a>, &'a [Expr<'a>]),
-    Data(ArcType<Symbol>, &'a [Expr<'a>]),
+    Data(TypedIdent<Symbol>, &'a [Expr<'a>], BytePos),
     Let(LetBinding<'a>, &'a Expr<'a>),
     Match(&'a Expr<'a>, &'a [Alternative<'a>]),
 }
 
-pub struct Allocator<'a> {
+impl<'a> Expr<'a> {
+    pub fn span(&self) -> Span<BytePos> {
+        match *self {
+            Expr::Call(expr, args) => Span::new(expr.span().start, args.last().unwrap().span().end),
+            Expr::Const(_, span) => span,
+            Expr::Data(_, args, span_start) => {
+                Span::new(span_start,
+                          args.last().map_or(span_start, |arg| arg.span().end))
+            }
+            Expr::Ident(_, span) => span,
+            Expr::Let(ref let_binding, ref body) => {
+                Span::new(let_binding.span_start, body.span().end)
+            }
+            Expr::Match(expr, alts) => {
+                Span::new(expr.span().start, alts.last().unwrap().expr.span().end)
+            }
+        }
+    }
+}
+
+fn is_constructor(s: &Symbol) -> bool {
+    s.as_ref()
+        .rsplit('.')
+        .next()
+        .unwrap()
+        .starts_with(char::is_uppercase)
+}
+
+pub struct Allocator<'a, 'e> {
     arena: Arena<Expr<'a>>,
     alternative_arena: Arena<Alternative<'a>>,
-    true_constructor: TypedIdent<Symbol>,
-    false_constructor: TypedIdent<Symbol>,
+    env: &'e PrimitiveEnv,
     dummy_symbol: TypedIdent<Symbol>,
 }
 
-impl<'a> Allocator<'a> {
-    pub fn new() -> Allocator<'a> {
+impl<'a, 'e> Allocator<'a, 'e> {
+    pub fn new(env: &'e PrimitiveEnv) -> Allocator<'a, 'e> {
         Allocator {
             arena: Arena::new(),
             alternative_arena: Arena::new(),
-            // TODO
-            true_constructor: TypedIdent::new(Symbol::from("true")),
-            false_constructor: TypedIdent::new(Symbol::from("false")),
+            env: env,
             dummy_symbol: TypedIdent::new(Symbol::from("")),
         }
     }
+
     pub fn translate_alloc(&'a self, expr: &SpannedExpr<Symbol>) -> &'a Expr<'a> {
         self.arena.alloc(self.translate(expr))
     }
 
     pub fn translate(&'a self, expr: &SpannedExpr<Symbol>) -> Expr<'a> {
+        let mut current = expr;
+        let mut lets = Vec::new();
+        while let ast::Expr::LetBindings(ref binds, ref tail) = current.value {
+            lets.push((current.span.start, binds));
+            current = tail;
+        }
+        let tail = self.translate_(current);
+        lets.iter().rev().fold(tail, |result, &(span_start, ref binds)| {
+            self.translate_let(binds, result, span_start)
+        })
+    }
+
+    fn translate_(&'a self, expr: &SpannedExpr<Symbol>) -> Expr<'a> {
         let arena = &self.arena;
         match expr.value {
             ast::Expr::App(ref function, ref args) => {
                 let new_args: SmallVec<[_; 16]> =
                     args.iter().map(|arg| self.translate(arg)).collect();
-                Expr::Call(self.translate_alloc(function),
-                           arena.alloc_extend(new_args.into_iter()))
+                match function.value {
+                    ast::Expr::Ident(ref id) if is_constructor(&id.name) => {
+                        let typ = expr.env_type_of(&self.env);
+                        self.new_data_constructor(typ, id, new_args, expr.span)
+                    }
+                    _ => {
+                        Expr::Call(self.translate_alloc(function),
+                                   arena.alloc_extend(new_args.into_iter()))
+                    }
+                }
             }
             ast::Expr::Array(ref array) => {
                 let exprs: SmallVec<[_; 16]> =
                     array.exprs.iter().map(|expr| self.translate(expr)).collect();
-                Expr::Data(array.typ.clone(), arena.alloc_extend(exprs.into_iter()))
+                Expr::Data(TypedIdent {
+                               name: self.dummy_symbol.name.clone(),
+                               typ: array.typ.clone(),
+                           },
+                           arena.alloc_extend(exprs.into_iter()),
+                           expr.span.start)
             }
             ast::Expr::Block(ref exprs) => {
                 let (last, prefix) = exprs.split_last().unwrap();
@@ -98,19 +151,26 @@ impl<'a> Allocator<'a> {
                     Expr::Let(LetBinding {
                                   name: self.dummy_symbol.clone(),
                                   expr: Named::Expr(self.translate_alloc(expr)),
+                                  span_start: expr.span.start,
                               },
                               arena.alloc(result))
                 })
             }
-            ast::Expr::Ident(ref id) => Expr::Ident(id.clone()),
+            ast::Expr::Ident(ref id) => {
+                if is_constructor(&id.name) {
+                    self.new_data_constructor(id.typ.clone(), id, SmallVec::new(), expr.span)
+                } else {
+                    Expr::Ident(id.clone(), expr.span)
+                }
+            }
             ast::Expr::IfElse(ref pred, ref if_true, ref if_false) => {
                 let alts: SmallVec<[_; 2]> = collect![Alternative {
-                                 pattern: Pattern::Constructor(self.true_constructor.clone(),
+                                 pattern: Pattern::Constructor(self.bool_constructor(true),
                                                                vec![]),
                                  expr: self.translate(if_true),
                              },
                              Alternative {
-                                 pattern: Pattern::Constructor(self.false_constructor.clone(),
+                                 pattern: Pattern::Constructor(self.bool_constructor(false),
                                                                vec![]),
                                  expr: self.translate(if_false),
                              }];
@@ -119,62 +179,19 @@ impl<'a> Allocator<'a> {
             }
             ast::Expr::Infix(ref l, ref op, ref r) => {
                 let args: SmallVec<[_; 2]> = collect![self.translate(l), self.translate(r)];
-                Expr::Call(arena.alloc(Expr::Ident(op.value.clone())),
+                Expr::Call(arena.alloc(Expr::Ident(op.value.clone(), op.span)),
                            arena.alloc_extend(args.into_iter()))
             }
             ast::Expr::Lambda(ref lambda) => {
-                Expr::Let(LetBinding {
-                              name: lambda.id.clone(),
-                              expr: Named::Closure(lambda.args.clone(),
-                                                   self.translate_alloc(&lambda.body)),
-                          },
-                          arena.alloc(Expr::Ident(lambda.id.clone())))
+                self.new_lambda(lambda.id.clone(),
+                                lambda.args.clone(),
+                                self.translate_alloc(&lambda.body),
+                                expr.span)
             }
-            ast::Expr::LetBindings(ref binds, ref expr) => {
-                let tail = self.translate(expr);
-                let is_recursive = binds.iter().all(|bind| bind.args.len() > 0);
-                if is_recursive {
-                    let closures = binds.iter()
-                        .map(|bind| {
-                            Closure {
-                                args: bind.args.clone(),
-                                expr: self.translate_alloc(&bind.expr),
-                            }
-                        })
-                        .collect();
-                    Expr::Let(LetBinding {
-                                  // TODO
-                                  name: self.dummy_symbol.clone(),
-                                  expr: Named::Recursive(closures),
-                              },
-                              arena.alloc(tail))
-                } else {
-                    binds.iter().rev().fold(tail, |tail, bind| {
-                        let name = match bind.name.value {
-                            ast::Pattern::Ident(ref id) => id.clone(),
-                            _ => {
-                                let alt = Alternative {
-                                    pattern: self.translate_pattern(&bind.name.value),
-                                    expr: tail,
-                                };
-                                return Expr::Match(self.translate_alloc(&bind.expr),
-                                                   self.alternative_arena.alloc_extend(once(alt)));
-                            }
-                        };
-                        let expr = if bind.args.is_empty() {
-                            Named::Expr(self.translate_alloc(&bind.expr))
-                        } else {
-                            Named::Closure(bind.args.clone(), self.translate_alloc(&bind.expr))
-                        };
-                        Expr::Let(LetBinding {
-                                      name: name,
-                                      expr: expr,
-                                  },
-                                  arena.alloc(tail))
-                    })
-                }
+            ast::Expr::LetBindings(ref binds, ref tail) => {
+                self.translate_let(binds, self.translate(tail), expr.span.start)
             }
-            ast::Expr::Literal(ref literal) => Expr::Const(literal.clone()),
+            ast::Expr::Literal(ref literal) => Expr::Const(literal.clone(), expr.span),
             ast::Expr::Match(ref expr, ref alts) => {
                 let new_alts: SmallVec<[_; 16]> = alts.iter()
                     .map(|alt| {
@@ -191,32 +208,109 @@ impl<'a> Allocator<'a> {
             // =>
             // match expr with
             // | { projection } -> projection
-            ast::Expr::Projection(ref expr, ref projection, _) => {
+            ast::Expr::Projection(ref projected_expr, ref projection, ref projected_type) => {
                 let alt = Alternative {
                     pattern: Pattern::Record(vec![(projection.clone(), None)]),
-                    expr: Expr::Ident(TypedIdent::new(projection.clone())),
+                    expr: Expr::Ident(TypedIdent {
+                                          name: projection.clone(),
+                                          typ: projected_type.clone(),
+                                      },
+                                      expr.span),
                 };
-                Expr::Match(self.translate_alloc(expr),
+                Expr::Match(self.translate_alloc(projected_expr),
                             self.alternative_arena.alloc_extend(once(alt)))
             }
             ast::Expr::Record { ref typ, ref exprs, .. } => {
+                let mut last_span = expr.span;
                 let args: SmallVec<[_; 16]> = exprs.iter()
                     .map(|&(ref field, ref expr)| match *expr {
-                        Some(ref expr) => self.translate(expr),
-                        None => Expr::Ident(TypedIdent::new(field.clone())),
+                        Some(ref expr) => {
+                            last_span = expr.span;
+                            self.translate(expr)
+                        }
+                        None => Expr::Ident(TypedIdent::new(field.clone()), last_span),
                     })
                     .collect();
-                Expr::Data(typ.clone(), arena.alloc_extend(args.into_iter()))
+                Expr::Data(TypedIdent {
+                               name: self.dummy_symbol.name.clone(),
+                               typ: typ.clone(),
+                           },
+                           arena.alloc_extend(args.into_iter()),
+                           expr.span.start)
             }
             ast::Expr::Tuple(ref exprs) => {
                 assert!(exprs.len() == 0, "Only unit is handled at the moment");
                 let args: SmallVec<[_; 16]> = exprs.iter()
                     .map(|expr| self.translate(expr))
                     .collect();
-                Expr::Data(Type::unit(), arena.alloc_extend(args.into_iter()))
+                Expr::Data(TypedIdent {
+                               name: self.dummy_symbol.name.clone(),
+                               typ: Type::unit(),
+                           },
+                           arena.alloc_extend(args.into_iter()),
+                           expr.span.start)
             }
             ast::Expr::TypeBindings(_, ref expr) => self.translate(expr),
             ast::Expr::Error => panic!("ICE: Error expression found in the compiler"),
+        }
+    }
+
+    fn translate_let(&'a self,
+                     binds: &[ast::ValueBinding<Symbol>],
+                     tail: Expr<'a>,
+                     span_start: BytePos)
+                     -> Expr<'a> {
+        let arena = &self.arena;
+        let is_recursive = binds.iter().all(|bind| bind.args.len() > 0);
+        if is_recursive {
+            let closures = binds.iter()
+                .map(|bind| {
+                    Closure {
+                        name: match bind.name.value {
+                            ast::Pattern::Ident(ref id) => id.clone(),
+                            _ => unreachable!(),
+                        },
+                        args: bind.args.clone(),
+                        expr: self.translate_alloc(&bind.expr),
+                    }
+                })
+                .collect();
+            Expr::Let(LetBinding {
+                          // TODO
+                          name: self.dummy_symbol.clone(),
+                          expr: Named::Recursive(closures),
+                          span_start: span_start,
+                      },
+                      arena.alloc(tail))
+        } else {
+            binds.iter().rev().fold(tail, |tail, bind| {
+                let name = match bind.name.value {
+                    ast::Pattern::Ident(ref id) => id.clone(),
+                    _ => {
+                        let alt = Alternative {
+                            pattern: self.translate_pattern(&bind.name.value),
+                            expr: tail,
+                        };
+                        return Expr::Match(self.translate_alloc(&bind.expr),
+                                           self.alternative_arena.alloc_extend(once(alt)));
+                    }
+                };
+                let named = if bind.args.is_empty() {
+                    Named::Expr(self.translate_alloc(&bind.expr))
+                } else {
+                    Named::Recursive(vec![Closure {
+                                              name: name.clone(),
+                                              args: bind.args.clone(),
+                                              expr: self.translate_alloc(&bind.expr),
+                                          }])
+                };
+                Expr::Let(LetBinding {
+                              name: name,
+                              expr: named,
+                              span_start: bind.expr.span.start,
+                          },
+                          arena.alloc(tail))
+            })
         }
     }
 
@@ -229,6 +323,90 @@ impl<'a> Allocator<'a> {
             ast::Pattern::Record { ref fields, .. } => Pattern::Record(fields.clone()),
         }
     }
+
+    fn bool_constructor(&self, variant: bool) -> TypedIdent<Symbol> {
+        let b = self.env.get_bool();
+        match **b {
+            Type::Alias(ref alias) => {
+                match **alias.typ() {
+                    Type::Variant(ref variants) => {
+                        TypedIdent {
+                            name: variants.row_iter().nth(variant as usize).unwrap().name.clone(),
+                            typ: b.clone(),
+                        }
+                    }
+                    _ => panic!(),
+                }
+            }
+            _ => panic!(),
+        }
+    }
+
+    fn new_data_constructor(&'a self,
+                            expr_type: ArcType,
+                            id: &TypedIdent<Symbol>,
+                            mut new_args: SmallVec<[Expr<'a>; 16]>,
+                            span: Span<BytePos>)
+                            -> Expr<'a> {
+        let arena = &self.arena;
+        let typ = expr_type;
+        let unapplied_args: Vec<_>;
+        // If the constructor is not fully applied we retrieve the type of the data
+        // by iterating through the arguments. If it is fully applied the arg_iter
+        // has no effect and `typ` itself will be used
+        let data_type;
+        {
+            let mut args = arg_iter(&typ);
+            unapplied_args = args.by_ref()
+                .enumerate()
+                .map(|(i, arg)| {
+                    TypedIdent {
+                        name: Symbol::from(format!("#{}", i)),
+                        typ: arg.clone(),
+                    }
+                })
+                .collect();
+            data_type = args.typ.clone();
+        }
+        new_args.extend(unapplied_args.iter()
+            .map(|arg| Expr::Ident(arg.clone(), span)));
+        let data = Expr::Data(TypedIdent {
+                                  name: id.name.clone(),
+                                  typ: data_type,
+                              },
+                              arena.alloc_extend(new_args.into_iter()),
+                              span.start);
+        if unapplied_args.is_empty() {
+            data
+        } else {
+            self.new_lambda(TypedIdent {
+                                name: Symbol::from(format!("${}", id.name)),
+                                typ: typ,
+                            },
+                            unapplied_args,
+                            arena.alloc(data),
+                            span)
+        }
+    }
+
+    fn new_lambda(&'a self,
+                  name: TypedIdent<Symbol>,
+                  args: Vec<TypedIdent<Symbol>>,
+                  body: &'a Expr<'a>,
+                  span: Span<BytePos>)
+                  -> Expr<'a> {
+        let arena = &self.arena;
+        Expr::Let(LetBinding {
+                      name: name.clone(),
+                      expr: Named::Recursive(vec![Closure {
+                                                      name: name.clone(),
+                                                      args: args,
+                                                      expr: body,
+                                                  }]),
+                      span_start: span.start,
+                  },
+                  arena.alloc(Expr::Ident(name, span)))
+    }
 }
 
 impl<'a> Typed for Expr<'a> {
@@ -237,9 +415,9 @@ impl<'a> Typed for Expr<'a> {
     fn env_type_of(&self, env: &TypeEnv) -> ArcType<Self::Ident> {
         match *self {
             Expr::Call(expr, args) => get_return_type(env, &expr.env_type_of(env), args.len()),
-            Expr::Const(ref literal) => literal.env_type_of(env),
-            Expr::Data(ref typ, args) => get_return_type(env, typ, args.len()),
-            Expr::Ident(ref id) => id.typ.clone(),
+            Expr::Const(ref literal, _) => literal.env_type_of(env),
+            Expr::Data(ref id, _, _) => id.typ.clone(),
+            Expr::Ident(ref id, _) => id.typ.clone(),
             Expr::Let(_, ref body) => body.env_type_of(env),
             Expr::Match(_, alts) => alts[0].expr.env_type_of(env),
         }
@@ -253,6 +431,9 @@ fn get_return_type(env: &TypeEnv, alias_type: &ArcType, arg_count: usize) -> Arc
     }
     let function_type = remove_aliases_cow(env, alias_type);
 
-    let (_, ret) = function_type.as_function().expect("Call expression with a non function type");
+    let (_, ret) = function_type.as_function().unwrap_or_else(|| {
+        panic!("Call expression with a non function type `{}`",
+               function_type)
+    });
     get_return_type(env, ret, arg_count - 1)
 }

--- a/vm/src/core.rs
+++ b/vm/src/core.rs
@@ -1,0 +1,221 @@
+extern crate typed_arena;
+extern crate smallvec;
+
+use std::iter::{once, repeat};
+
+use self::typed_arena::Arena;
+
+use self::smallvec::SmallVec;
+
+use base::ast::{self, Literal, SpannedExpr, TypedIdent};
+use base::symbol::Symbol;
+use base::types::Type;
+
+#[derive(Clone, Debug)]
+pub struct Closure<'a> {
+    pub args: Vec<TypedIdent<Symbol>>,
+    pub expr: &'a Expr<'a>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Named<'a> {
+    // TODO Merge Closure and Recursive
+    Closure(Vec<TypedIdent<Symbol>>, &'a Expr<'a>),
+    Recursive(Vec<Closure<'a>>),
+    Expr(&'a Expr<'a>),
+}
+
+#[derive(Clone, Debug)]
+pub struct LetBinding<'a> {
+    pub name: TypedIdent<Symbol>,
+    pub expr: Named<'a>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Pattern {
+    Constructor(TypedIdent<Symbol>, Vec<TypedIdent<Symbol>>),
+    Record(Vec<(Symbol, Option<Symbol>)>),
+    Ident(TypedIdent<Symbol>),
+}
+
+#[derive(Clone, Debug)]
+pub struct Alternative<'a> {
+    pub pattern: Pattern,
+    pub expr: Expr<'a>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Expr<'a> {
+    Const(Literal),
+    Ident(TypedIdent<Symbol>),
+    Call(&'a Expr<'a>, &'a [Expr<'a>]),
+    Data(Option<Symbol>, &'a [Expr<'a>]),
+    Let(LetBinding<'a>, &'a Expr<'a>),
+    Match(&'a Expr<'a>, &'a [Alternative<'a>]),
+}
+
+pub struct Allocator<'a> {
+    arena: &'a Arena<Expr<'a>>,
+    alternative_arena: &'a Arena<Alternative<'a>>,
+    true_constructor: TypedIdent<Symbol>,
+    false_constructor: TypedIdent<Symbol>,
+    dummy_symbol: TypedIdent<Symbol>,
+}
+
+impl<'a> Allocator<'a> {
+    pub fn translate_alloc(&self, expr: &SpannedExpr<Symbol>) -> &'a Expr<'a> {
+        self.arena.alloc(self.translate(expr))
+    }
+
+    pub fn translate(&self, expr: &SpannedExpr<Symbol>) -> Expr<'a> {
+        let arena = self.arena;
+        match expr.value {
+            ast::Expr::App(ref function, ref args) => {
+                let new_args: SmallVec<[_; 16]> =
+                    args.iter().map(|arg| self.translate(arg)).collect();
+                Expr::Call(self.translate_alloc(function),
+                           arena.alloc_extend(new_args.into_iter()))
+            }
+            ast::Expr::Array(ref array) => {
+                let exprs: SmallVec<[_; 16]> =
+                    array.exprs.iter().map(|expr| self.translate(expr)).collect();
+                Expr::Data(None, arena.alloc_extend(exprs.into_iter()))
+            }
+            ast::Expr::Block(ref exprs) => {
+                let (last, prefix) = exprs.split_last().unwrap();
+                let result = self.translate(last);
+                prefix.iter().rev().fold(result, |result, expr| {
+                    Expr::Let(LetBinding {
+                                  name: self.dummy_symbol.clone(),
+                                  expr: Named::Expr(self.translate_alloc(expr)),
+                              },
+                              arena.alloc(result))
+                })
+            }
+            ast::Expr::Ident(ref id) => Expr::Ident(id.clone()),
+            ast::Expr::IfElse(ref pred, ref if_true, ref if_false) => {
+                let alts: SmallVec<[_; 2]> = collect![Alternative {
+                                 pattern: Pattern::Constructor(self.true_constructor.clone(),
+                                                               vec![]),
+                                 expr: self.translate(if_true),
+                             },
+                             Alternative {
+                                 pattern: Pattern::Constructor(self.false_constructor.clone(),
+                                                               vec![]),
+                                 expr: self.translate(if_false),
+                             }];
+                Expr::Match(self.translate_alloc(pred),
+                            self.alternative_arena.alloc_extend(alts.into_iter()))
+            }
+            ast::Expr::Infix(ref l, ref op, ref r) => {
+                let args: SmallVec<[_; 2]> = collect![self.translate(l), self.translate(r)];
+                Expr::Call(arena.alloc(Expr::Ident(op.value.clone())),
+                           arena.alloc_extend(args.into_iter()))
+            }
+            ast::Expr::Lambda(ref lambda) => {
+                Expr::Let(LetBinding {
+                              name: lambda.id.clone(),
+                              expr: Named::Closure(lambda.args.clone(),
+                                                   self.translate_alloc(&lambda.body)),
+                          },
+                          arena.alloc(Expr::Ident(lambda.id.clone())))
+            }
+            ast::Expr::LetBindings(ref binds, ref expr) => {
+                let tail = self.translate(expr);
+                let is_recursive = binds.iter().all(|bind| bind.args.len() > 0);
+                if is_recursive {
+                    let closures = binds.iter()
+                        .map(|bind| {
+                            Closure {
+                                args: bind.args.clone(),
+                                expr: self.translate_alloc(&bind.expr),
+                            }
+                        })
+                        .collect();
+                    Expr::Let(LetBinding {
+                                  // TODO
+                                  name: self.dummy_symbol.clone(),
+                                  expr: Named::Recursive(closures),
+                              },
+                              arena.alloc(tail))
+                } else {
+                    binds.iter().rev().fold(tail, |tail, bind| {
+                        let name = match bind.name.value {
+                            ast::Pattern::Ident(ref id) => id.clone(),
+                            _ => {
+                                let alt = Alternative {
+                                    pattern: self.translate_pattern(&bind.name.value),
+                                    expr: tail,
+                                };
+                                return Expr::Match(self.translate_alloc(&bind.expr),
+                                                   self.alternative_arena.alloc_extend(once(alt)));
+                            }
+                        };
+                        let expr = if bind.args.is_empty() {
+                            Named::Expr(self.translate_alloc(&bind.expr))
+                        } else {
+                            Named::Closure(bind.args.clone(), self.translate_alloc(&bind.expr))
+                        };
+                        Expr::Let(LetBinding {
+                                      name: name,
+                                      expr: expr,
+                                  },
+                                  arena.alloc(tail))
+                    })
+                }
+            }
+            ast::Expr::Literal(ref literal) => Expr::Const(literal.clone()),
+            ast::Expr::Match(ref expr, ref alts) => {
+                let new_alts: SmallVec<[_; 16]> = alts.iter()
+                    .map(|alt| {
+                        Alternative {
+                            pattern: self.translate_pattern(&alt.pattern.value),
+                            expr: self.translate(&alt.expr),
+                        }
+                    })
+                    .collect();
+                Expr::Match(self.translate_alloc(expr),
+                            self.alternative_arena.alloc_extend(new_alts.into_iter()))
+            }
+            // expr.projection
+            // =>
+            // match expr with
+            // | { projection } -> projection
+            ast::Expr::Projection(ref expr, ref projection, _) => {
+                let alt = Alternative {
+                    pattern: Pattern::Record(vec![(projection.clone(), None)]),
+                    expr: Expr::Ident(TypedIdent::new(projection.clone())),
+                };
+                Expr::Match(self.translate_alloc(expr),
+                            self.alternative_arena.alloc_extend(once(alt)))
+            }
+            ast::Expr::Record { ref exprs, .. } => {
+                let args: SmallVec<[_; 16]> = exprs.iter()
+                    .map(|&(ref field, ref expr)| match *expr {
+                        Some(ref expr) => self.translate(expr),
+                        None => Expr::Ident(TypedIdent::new(field.clone())),
+                    })
+                    .collect();
+                Expr::Data(None, arena.alloc_extend(args.into_iter()))
+            }
+            ast::Expr::Tuple(ref exprs) => {
+                let args: SmallVec<[_; 16]> = exprs.iter()
+                    .map(|expr| self.translate(expr))
+                    .collect();
+                Expr::Data(None, arena.alloc_extend(args.into_iter()))
+            }
+            ast::Expr::TypeBindings(_, ref expr) => self.translate(expr),
+            ast::Expr::Error => panic!("ICE: Error expression found in the compiler"),
+        }
+    }
+
+    fn translate_pattern(&self, pattern: &ast::Pattern<Symbol>) -> Pattern {
+        match *pattern {
+            ast::Pattern::Constructor(ref ctor, ref args) => {
+                Pattern::Constructor(ctor.clone(), args.clone())
+            }
+            ast::Pattern::Ident(ref id) => Pattern::Ident(id.clone()),
+            ast::Pattern::Record { ref fields, .. } => Pattern::Record(fields.clone()),
+        }
+    }
+}

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -37,6 +37,7 @@ pub mod stack;
 pub mod types;
 
 mod array;
+mod core;
 mod field_map;
 mod interner;
 mod lazy;


### PR DESCRIPTION
Not yet working, just wanted to post for feedback. The current core::Expr type is really only removing/merging constructors and I have not taken how easy it is to optimize into account.

#107 