### PR TITLE
fix(check): Don't leak `Type::Ident` outside of aliased types

### DIFF
--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -2,7 +2,7 @@
 
 use pos::{BytePos, Spanned};
 use symbol::Symbol;
-use types::{self, Alias, ArcType, Type, TypeEnv};
+use types::{self, Alias, AliasData, ArcType, Type, TypeEnv};
 
 pub trait DisplayEnv {
     type Ident;
@@ -140,7 +140,8 @@ pub enum Expr<Id> {
 pub struct TypeBinding<Id> {
     pub comment: Option<String>,
     pub name: Id,
-    pub alias: Alias<Id, ArcType<Id>>,
+    pub alias: AliasData<Id, ArcType<Id>>,
+    pub finalized_alias: Option<Alias<Id, ArcType<Id>>>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -466,7 +467,7 @@ fn get_return_type(env: &TypeEnv, alias_type: &ArcType, arg_count: usize) -> Arc
             .unwrap_or_else(|| panic!("Unexpected type {:?} is not a function", alias_type))
     };
 
-    let typ = types::walk_move_type(alias.typ.clone(),
+    let typ = types::walk_move_type(alias.typ().into_owned(),
                                     &mut |typ| {
         match *typ {
             Type::Generic(ref generic) => {

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -1,4 +1,4 @@
-use std::borrow::ToOwned;
+use std::borrow::{Cow, ToOwned};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -132,7 +132,7 @@ impl<Id> Generic<Id> {
 }
 
 /// An alias is wrapper around `Type::Alias`, allowing it to be cheaply converted to a type and dereferenced
-/// to `AliasData`
+/// to `AliasRef`
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Alias<Id, T> {
     _typ: T,
@@ -144,9 +144,9 @@ impl<Id, T> Deref for Alias<Id, T>
 {
     type Target = AliasData<Id, T>;
 
-    fn deref(&self) -> &AliasData<Id, T> {
+    fn deref(&self) -> &Self::Target {
         match *self._typ {
-            Type::Alias(ref alias) => alias,
+            Type::Alias(ref alias) => &alias.group[alias.index],
             _ => unreachable!(),
         }
     }
@@ -157,7 +157,7 @@ impl<Id, T> From<AliasData<Id, T>> for Alias<Id, T>
 {
     fn from(data: AliasData<Id, T>) -> Alias<Id, T> {
         Alias {
-            _typ: T::from(Type::Alias(data)),
+            _typ: Type::alias(data.name, data.args, data.typ),
             _marker: PhantomData,
         }
     }
@@ -179,15 +179,68 @@ impl<Id, T> Alias<Id, T>
         }
     }
 
+    pub fn group(group: Vec<AliasData<Id, T>>) -> Vec<Alias<Id, T>> {
+        let group = Arc::new(group);
+        (0..group.len())
+            .map(|index| {
+                Alias {
+                    _typ: T::from(Type::Alias(AliasRef {
+                        index: index,
+                        group: group.clone(),
+                    })),
+                    _marker: PhantomData,
+                }
+            })
+            .collect()
+    }
+
+    pub fn as_type(&self) -> &T {
+        &self._typ
+    }
+
     pub fn into_type(self) -> T {
         self._typ
+    }
+}
+
+impl<Id, T> Alias<Id, T>
+    where T: From<Type<Id, T>> + Deref<Target = Type<Id, T>> + Clone,
+          Id: Clone + PartialEq,
+{
+    /// Returns the actual type of the alias
+    pub fn typ(&self) -> Cow<T> {
+        let group = match *self._typ {
+            Type::Alias(ref alias) => &alias.group,
+            _ => unreachable!(),
+        };
+        let opt = walk_move_type_opt(&self.typ,
+                                     &mut |typ: &Type<_, _>| {
+            match *typ {
+                Type::Ident(ref id) => {
+                    // Replace `Ident` with the alias it resolves to so that a `TypeEnv` is not needed
+                    // to resolve the type later on
+                    let index = group.iter()
+                        .position(|alias| alias.name == *id)
+                        .expect("ICE: Alias group were not able to resolve an identifier");
+                    Some(T::from(Type::Alias(AliasRef {
+                        index: index,
+                        group: group.clone(),
+                    })))
+                }
+                _ => None,
+            }
+        });
+        match opt {
+            Some(typ) => Cow::Owned(typ),
+            None => Cow::Borrowed(&self.typ),
+        }
     }
 }
 
 impl<Id> Alias<Id, ArcType<Id>>
     where Id: Clone,
 {
-    pub fn make_mut(alias: &mut Alias<Id, ArcType<Id>>) -> &mut AliasData<Id, ArcType<Id>> {
+    pub fn make_mut(alias: &mut Alias<Id, ArcType<Id>>) -> &mut AliasRef<Id, ArcType<Id>> {
         match *Arc::make_mut(&mut alias._typ.typ) {
             Type::Alias(ref mut alias) => alias,
             _ => unreachable!(),
@@ -198,14 +251,50 @@ impl<Id> Alias<Id, ArcType<Id>>
 /// Data for a type alias. Probably you want to use `Alias` instead of this directly as Alias allows for
 /// cheap conversion back into a type as well.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct AliasData<Id, T> {
+pub struct AliasRef<Id, T> {
     /// Name of the Alias
+    index: usize,
+    /// The other aliases defined in this group
+    pub group: Arc<Vec<AliasData<Id, T>>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct AliasData<Id, T> {
     pub name: Id,
     /// Arguments to the alias
     pub args: Vec<Generic<Id>>,
     /// The type that is being aliased
-    pub typ: T,
+    typ: T,
 }
+
+impl<Id, T> AliasData<Id, T> {
+    pub fn new(name: Id, args: Vec<Generic<Id>>, typ: T) -> AliasData<Id, T> {
+        AliasData {
+            name: name,
+            args: args,
+            typ: typ,
+        }
+    }
+
+    /// Returns the type aliased by `self` with out `Type::Ident` resolved to their actual
+    /// `Type::Alias` representation
+    pub fn unresolved_type(&self) -> &T {
+        &self.typ
+    }
+
+    pub fn unresolved_type_mut(&mut self) -> &mut T {
+        &mut self.typ
+    }
+}
+
+impl<Id, T> Deref for AliasRef<Id, T> {
+    type Target = AliasData<Id, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.group[self.index]
+    }
+}
+
 
 #[derive(Clone, Hash, Eq, PartialEq, Debug)]
 pub struct Field<Id, T = ArcType<Id>> {
@@ -273,7 +362,7 @@ pub enum Type<Id, T = ArcType<Id>> {
     /// A variable that needs to be instantiated with a fresh type variable
     /// when the binding is refered to.
     Generic(Generic<Id>),
-    Alias(AliasData<Id, T>),
+    Alias(AliasRef<Id, T>),
 }
 
 impl<Id, T> Type<Id, T>
@@ -360,10 +449,13 @@ impl<Id, T> Type<Id, T>
     }
 
     pub fn alias(name: Id, args: Vec<Generic<Id>>, typ: T) -> T {
-        T::from(Type::Alias(AliasData {
-            name: name,
-            args: args,
-            typ: typ,
+        T::from(Type::Alias(AliasRef {
+            index: 0,
+            group: Arc::new(vec![AliasData {
+                                     name: name,
+                                     args: args,
+                                     typ: typ,
+                                 }]),
         }))
     }
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -22,7 +22,7 @@ pub trait TypeEnv: KindEnv {
 
     /// Returns a record which contains all `fields`. The first element is the record type and the
     /// second is the alias type.
-    fn find_record(&self, fields: &[Symbol]) -> Option<(&ArcType, &ArcType)>;
+    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)>;
 }
 
 impl<'a, T: ?Sized + TypeEnv> TypeEnv for &'a T {
@@ -34,7 +34,7 @@ impl<'a, T: ?Sized + TypeEnv> TypeEnv for &'a T {
         (**self).find_type_info(id)
     }
 
-    fn find_record(&self, fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
         (**self).find_record(fields)
     }
 }

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -61,7 +61,7 @@ mod tests {
         fn find_type_info(&self, _id: &SymbolRef) -> Option<&Alias<Symbol, ArcType>> {
             None
         }
-        fn find_record(&self, _fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+        fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
             None
         }
     }

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -66,7 +66,7 @@ impl<'a> TypeEnv for Environment<'a> {
             .or_else(|| self.env.find_type_info(id))
     }
 
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+    fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
         None
     }
 }

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -143,7 +143,8 @@ pub fn rename(symbols: &mut SymbolModule,
 
         fn stack_type(&mut self, id: Symbol, span: Span<BytePos>, alias: &Alias<Symbol, ArcType>) {
             // Insert variant constructors into the local scope
-            if let Type::Variant(ref row) = *alias.typ {
+            let aliased_type = alias.typ();
+            if let Type::Variant(ref row) = **aliased_type {
                 for field in row.row_iter().cloned() {
                     self.env.stack.insert(field.name.clone(), (field.name, span, field.typ));
                 }
@@ -200,8 +201,9 @@ pub fn rename(symbols: &mut SymbolModule,
                 }
                 Expr::Record { ref mut typ, ref mut exprs, .. } => {
                     let field_types = self.find_fields(typ);
-                    for (field, &mut (ref id, ref mut maybe_expr)) in field_types.iter()
-                        .zip(exprs) {
+                    for (field, &mut (ref id, ref mut maybe_expr)) in
+                        field_types.iter()
+                            .zip(exprs) {
                         match *maybe_expr {
                             Some(ref mut expr) => self.visit_expr(expr),
                             None => {
@@ -274,7 +276,12 @@ pub fn rename(symbols: &mut SymbolModule,
                 Expr::TypeBindings(ref bindings, ref mut body) => {
                     self.env.stack_types.enter_scope();
                     for bind in bindings {
-                        self.stack_type(bind.name.clone(), expr.span, &bind.alias);
+                        self.stack_type(bind.name.clone(),
+                                        expr.span,
+                                        bind.finalized_alias
+                                            .as_ref()
+                                            .expect("ICE: Alias should have been finalized \
+                                                     before renaming"));
                     }
                     self.visit_expr(body);
                     self.env.stack_types.exit_scope();

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -170,7 +170,7 @@ impl<'a> TypeEnv for Environment<'a> {
             .or_else(|| self.environment.find_type_info(id))
     }
 
-    fn find_record(&self, fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
         self.stack_types
             .iter()
             .find(|&(_, &(_, ref alias))| {
@@ -182,8 +182,7 @@ impl<'a> TypeEnv for Environment<'a> {
                     _ => false,
                 }
             })
-            // FIXME Don't use unresolved_type
-            .map(|t| (&(t.1).0, (t.1).1.unresolved_type()))
+            .map(|t| ((t.1).0.clone(), (t.1).1.typ().into_owned()))
             .or_else(|| self.environment.find_record(fields))
     }
 }
@@ -275,7 +274,7 @@ impl<'a> Typecheck<'a> {
         }
     }
 
-    fn find_record(&self, fields: &[Symbol]) -> TcResult<(&ArcType, &ArcType)> {
+    fn find_record(&self, fields: &[Symbol]) -> TcResult<(ArcType, ArcType)> {
         self.environment
             .find_record(fields)
             .ok_or(TypeError::UndefinedRecord { fields: fields.to_owned() })

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -280,8 +280,9 @@ fn do_zip_match<'a, U>(unifier: &mut UnifierState<'a, U>,
                 (_, _) => {
                     let lhs = lhs.as_ref().unwrap_or(expected);
                     let rhs = rhs.as_ref().unwrap_or(actual);
-                    unifier.try_match(lhs, rhs);
-                    Ok(None)
+                    // FIXME Maybe always return `None` here since the types before we removed the
+                    // aliases are probably more specific.
+                    Ok(unifier.try_match(lhs, rhs))
                 }
             }
         }

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -78,7 +78,7 @@ impl KindEnv for MockEnv {
 impl TypeEnv for MockEnv {
     fn find_type(&self, id: &SymbolRef) -> Option<&ArcType> {
         match id.as_ref() {
-            "False" | "True" => Some(&self.bool.typ),
+            "False" | "True" => Some(&self.bool.as_type()),
             _ => None,
         }
     }
@@ -97,7 +97,7 @@ impl TypeEnv for MockEnv {
 
 impl PrimitiveEnv for MockEnv {
     fn get_bool(&self) -> &ArcType {
-        &self.bool.typ
+        &self.bool.as_type()
     }
 }
 

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -90,7 +90,7 @@ impl TypeEnv for MockEnv {
         }
     }
 
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+    fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
         None
     }
 }

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -1,7 +1,7 @@
 use base::ast::{Alternative, Array, Expr, Lambda, Literal, Pattern, SpannedExpr, TypeBinding, TypedIdent, ValueBinding};
 use base::kind::{ArcKind, Kind};
 use base::pos::{self, BytePos, Spanned};
-use base::types::{Alias, ArcType, BuiltinType, Field, Generic, Type};
+use base::types::{AliasData, ArcType, BuiltinType, Field, Generic, Type};
 use std::str::FromStr;
 
 use token::Token;
@@ -143,7 +143,8 @@ TypeBinding: TypeBinding<Id> = {
         TypeBinding {
             comment: None,
             name: id.clone(),
-            alias: Alias::new(id, params, Type::variant(row)),
+            alias: AliasData::new(id, params, Type::variant(row)),
+            finalized_alias: None,
         }
     },
 
@@ -151,7 +152,8 @@ TypeBinding: TypeBinding<Id> = {
         TypeBinding {
             comment: None,
             name: id.clone(),
-            alias: Alias::new(id, params, body),
+            alias: AliasData::new(id, params, body),
+            finalized_alias: None,
         }
     },
 };

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -11,7 +11,7 @@ mod support;
 
 use base::ast::*;
 use base::pos::{BytePos, Span, Spanned};
-use base::types::{Alias, Field, Type};
+use base::types::{AliasData, Field, Type};
 use support::*;
 
 #[test]
@@ -99,18 +99,18 @@ fn type_mutually_recursive() {
     let test2 = Type::record(Vec::new(),
                              vec![Field::new(intern("x"), typ("Int")),
                                   Field::new(intern("y"), Type::record(vec![], vec![]))]);
-    let binds = vec![
-        TypeBinding {
-            comment: None,
-            name: intern("Test"),
-            alias: Alias::new(intern("Test"), Vec::new(), test),
-        },
-        TypeBinding {
-            comment: None,
-            name: intern("Test2"),
-            alias: Alias::new(intern("Test2"), Vec::new(), test2),
-        },
-        ];
+    let binds = vec![TypeBinding {
+                         comment: None,
+                         name: intern("Test"),
+                         alias: AliasData::new(intern("Test"), Vec::new(), test),
+                         finalized_alias: None,
+                     },
+                     TypeBinding {
+                         comment: None,
+                         name: intern("Test2"),
+                         alias: AliasData::new(intern("Test2"), Vec::new(), test2),
+                         finalized_alias: None,
+                     }];
     assert_eq!(e, type_decls(binds, int(1)));
 }
 
@@ -343,7 +343,8 @@ id
                type_decls(vec![TypeBinding {
                                    comment: Some("Test type ".into()),
                                    name: intern("Test"),
-                                   alias: Alias::new(intern("Test"), Vec::new(), typ("Int")),
+                                   alias: AliasData::new(intern("Test"), Vec::new(), typ("Int")),
+                                   finalized_alias: None,
                                }],
                           id("id")));
 }
@@ -366,7 +367,10 @@ id
                      type_decls(vec![TypeBinding {
                                          comment: Some("Test type ".into()),
                                          name: intern("Test"),
-                                         alias: Alias::new(intern("Test"), Vec::new(), typ("Int")),
+                                         alias: AliasData::new(intern("Test"),
+                                                               Vec::new(),
+                                                               typ("Int")),
+                                         finalized_alias: None,
                                      }],
                                 id("id"))));
 }
@@ -386,7 +390,8 @@ id
                type_decls(vec![TypeBinding {
                                    comment: Some("Merge\nconsecutive\nline comments.".into()),
                                    name: intern("Test"),
-                                   alias: Alias::new(intern("Test"), Vec::new(), typ("Int")),
+                                   alias: AliasData::new(intern("Test"), Vec::new(), typ("Int")),
+                                   finalized_alias: None,
                                }],
                           id("id")));
 }

--- a/parser/tests/support/mod.rs
+++ b/parser/tests/support/mod.rs
@@ -5,7 +5,7 @@ use base::ast::{Alternative, Array, DisplayEnv, Expr, IdentEnv, Lambda, Literal,
 use base::error::Errors;
 use base::pos::{self, BytePos, Span, Spanned};
 use base::kind::Kind;
-use base::types::{Alias, ArcType, Field, Generic, Type};
+use base::types::{AliasData, ArcType, Field, Generic, Type};
 use parser::{Error, ParseErrors, parse_string};
 use std::marker::PhantomData;
 
@@ -138,7 +138,8 @@ pub fn type_decl(name: String,
     type_decls(vec![TypeBinding {
                         comment: None,
                         name: name.clone(),
-                        alias: Alias::new(name, args, typ),
+                        alias: AliasData::new(name, args, typ),
+                        finalized_alias: None,
                     }],
                body)
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -54,7 +54,7 @@ fn find_info(args: WithVM<RootStr>) -> IO<Result<String, String>> {
                 for g in &alias.args {
                     write!(&mut buffer, " {}", g.id)?;
                 }
-                write!(&mut buffer, " = {}", alias.typ)
+                write!(&mut buffer, " = {}", alias.unresolved_type())
             };
             fmt().unwrap();
         }

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -305,7 +305,7 @@ impl<'a> TypeEnv for Compiler<'a> {
             .get(id)
     }
 
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+    fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
         None
     }
 }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -188,7 +188,7 @@ impl TypeEnv for TypeInfos {
             .get(id)
     }
 
-    fn find_record(&self, fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
         None
     }
 }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -151,7 +151,6 @@ impl Instruction {
 #[derive(Debug)]
 pub struct TypeInfos {
     pub id_to_type: FnvMap<String, Alias<Symbol, ArcType>>,
-    pub type_to_id: FnvMap<ArcType, ArcType>,
 }
 
 impl KindEnv for TypeInfos {
@@ -190,36 +189,17 @@ impl TypeEnv for TypeInfos {
     }
 
     fn find_record(&self, fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
-        self.id_to_type
-            .iter()
-            .find(|&(_, alias)| {
-                match **alias.unresolved_type() {
-                    Type::Record(ref row) => {
-                        fields.iter()
-                            .all(|name| row.row_iter().any(|f| f.name.as_ref() == name.as_ref()))
-                    }
-                    _ => false,
-                }
-            })
-            .and_then(|t| {
-                // FIXME Don't use unresolved type
-                let typ = t.1.unresolved_type();
-                self.type_to_id.get(typ).map(|id_type| (id_type, typ))
-            })
+        None
     }
 }
 
 impl TypeInfos {
     pub fn new() -> TypeInfos {
-        TypeInfos {
-            id_to_type: FnvMap::default(),
-            type_to_id: FnvMap::default(),
-        }
+        TypeInfos { id_to_type: FnvMap::default() }
     }
 
     pub fn extend(&mut self, other: TypeInfos) {
-        let TypeInfos { id_to_type, type_to_id } = other;
+        let TypeInfos { id_to_type } = other;
         self.id_to_type.extend(id_to_type);
-        self.type_to_id.extend(type_to_id);
     }
 }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -172,7 +172,7 @@ impl TypeEnv for TypeInfos {
         self.id_to_type
             .iter()
             .filter_map(|(_, ref alias)| {
-                match *alias.typ {
+                match **alias.unresolved_type() {
                     Type::Variant(ref row) => {
                         row.row_iter().find(|field| field.name.as_ref() == id)
                     }
@@ -193,17 +193,17 @@ impl TypeEnv for TypeInfos {
         self.id_to_type
             .iter()
             .find(|&(_, alias)| {
-                match *alias.typ {
-                    Type::Record(_) => {
-                        fields.iter().all(|name| {
-                            alias.typ.row_iter().any(|f| f.name.as_ref() == name.as_ref())
-                        })
+                match **alias.unresolved_type() {
+                    Type::Record(ref row) => {
+                        fields.iter()
+                            .all(|name| row.row_iter().any(|f| f.name.as_ref() == name.as_ref()))
                     }
                     _ => false,
                 }
             })
             .and_then(|t| {
-                let typ = &t.1.typ;
+                // FIXME Don't use unresolved type
+                let typ = t.1.unresolved_type();
                 self.type_to_id.get(typ).map(|id_type| (id_type, typ))
             })
     }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1189,7 +1189,7 @@ mod tests {
             self.0.as_ref()
         }
 
-        fn find_record(&self, _fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+        fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
             None
         }
     }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -933,7 +933,7 @@ unsafe impl<'a> DataDef for &'a ValueArray {
             let result = &mut *result.as_mut_ptr();
             result.repr = self.repr;
             on_array!(self,
-                      |array: &Array<_>| result.unsafe_array_mut().initialize(array.iter().cloned()));
+                      |array: &Array<_>| { result.unsafe_array_mut().initialize(array.iter().cloned()) });
             result
         }
     }
@@ -1165,11 +1165,11 @@ impl<'t> Cloner<'t> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gc::Gc;
+    use gc::{Gc, Generation};
     use types::VmInt;
 
     use base::kind::{ArcKind, KindEnv};
-    use base::types::{Alias, AliasData, ArcType, Field, Type, TypeEnv};
+    use base::types::{Alias, ArcType, Field, Type, TypeEnv};
     use base::symbol::{Symbol, SymbolRef};
 
     struct MockEnv(Option<Alias<Symbol, ArcType>>);
@@ -1196,7 +1196,7 @@ mod tests {
 
     #[test]
     fn pretty_variant() {
-        let mut gc = Gc::new(0, usize::max_value());
+        let mut gc = Gc::new(Generation::default(), usize::max_value());
 
         let list = Symbol::from("List");
         let typ: ArcType = Type::variant(vec![Field {
@@ -1210,11 +1210,7 @@ mod tests {
                                                   typ: Type::ident(list.clone()),
                                               }]);
 
-        let env = MockEnv(Some(Alias::from(AliasData {
-            name: list.clone(),
-            args: vec![],
-            typ: typ.clone(),
-        })));
+        let env = MockEnv(Some(Alias::new(list.clone(), vec![], typ.clone())));
 
         let nil = Value::Tag(1);
         assert_eq!(format!("{}", ValuePrinter::new(&env, &typ, nil)), "Nil");
@@ -1236,7 +1232,7 @@ mod tests {
 
     #[test]
     fn pretty_array() {
-        let mut gc = Gc::new(0, usize::max_value());
+        let mut gc = Gc::new(Generation::default(), usize::max_value());
 
         let typ = Type::array(Type::int());
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -145,7 +145,7 @@ impl TypeEnv for VmEnv {
                     .id_to_type
                     .values()
                     .filter_map(|alias| {
-                        match *alias.typ {
+                        match **alias.unresolved_type() {
                             Type::Variant(ref row) => {
                                 row.row_iter()
                                     .find(|field| *field.name == *id)
@@ -171,7 +171,7 @@ impl PrimitiveEnv for VmEnv {
     fn get_bool(&self) -> &ArcType {
         self.find_type_info("std.types.Bool")
             .map(|alias| match alias {
-                Cow::Borrowed(alias) => &alias.typ,
+                Cow::Borrowed(alias) => alias.as_type(),
                 Cow::Owned(_) => panic!("Expected to be able to retrieve a borrowed bool type"),
             })
             .expect("std.types.Bool")
@@ -344,11 +344,9 @@ impl GlobalVmState {
             ids.insert(TypeId::of::<T>(), typ);
             // Insert aliases so that `find_info` can retrieve information about the primitives
             env.type_infos.id_to_type.insert(name.into(),
-                                             Alias::from(AliasData {
-                                                 name: Symbol::from(name),
-                                                 args: Vec::new(),
-                                                 typ: Type::opaque(),
-                                             }));
+                                             Alias::from(AliasData::new(Symbol::from(name),
+                                                                        Vec::new(),
+                                                                        Type::opaque())));
         }
 
         {
@@ -440,11 +438,7 @@ impl GlobalVmState {
                 .insert(id, typ.clone());
             let t = self.typeids.read().unwrap().get(&id).unwrap().clone();
             type_infos.id_to_type.insert(name.into(),
-                                         Alias::from(AliasData {
-                                             name: n,
-                                             args: args,
-                                             typ: Type::opaque(),
-                                         }));
+                                         Alias::from(AliasData::new(n, args, Type::opaque())));
             Ok(t)
         }
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -162,7 +162,7 @@ impl TypeEnv for VmEnv {
         self.type_infos
             .find_type_info(id)
     }
-    fn find_record(&self, fields: &[Symbol]) -> Option<(&ArcType, &ArcType)> {
+    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
         self.type_infos.find_record(fields)
     }
 }


### PR DESCRIPTION
This is a bit of a weird one. The fundamental idea behind this commit is to make any 'alias' type always know the type it aliases. So for instance, if `Option a` is encountered we always know what the representation (`| None | Some a`) is. Before this commit this was not always the case as `Option a` could be `App(Ident("Option"), Generic("a"))` and not `App(Alias("Option"), Generic("a"))`.

However, due to Rust's ownership semantics preventing cyclic reference we need to be a bit clever. Each group of `type ... and ... in` is combined into the same type (`AliasData`) since these groups are the only places which types can be mutually recursive. Then when the aliased type (`| None | Option a`) is requested by calling `fn typ` we walk through the type and replace any occurances of `Type::Ident` with the proper `Alias` variant. Some helper methods which do not do this replacement are also provided but the `typ` field itself has been hidden to discourage its use.