### PR TITLE
fix(vm): Make get_global's type check act as a type signature check

### DIFF
--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -22,6 +22,21 @@ mod rename;
 pub mod completion;
 pub mod metadata;
 
+use base::types::{ArcType, TypeEnv};
+
+/// Checks if `actual` can be assigned to a binding with the type signature `signature`
+pub fn check_signature(env: &TypeEnv, signature: &ArcType, actual: &ArcType) -> bool {
+    use base::scoped_map::ScopedMap;
+    use base::fnv::FnvMap;
+
+    use substitution::Substitution;
+
+    let subs = Substitution::new();
+    let state = unify_type::State::new(env, &subs);
+    let actual = unify_type::instantiate_generic_variables(&mut FnvMap::default(), &subs, actual);
+    unify_type::merge_signature(&subs, &mut ScopedMap::new(), 0, state, &signature, &actual).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -642,6 +642,31 @@ fn access_operator_without_parentheses() {
 }
 
 #[test]
+fn get_binding_with_alias_type() {
+    let _ = ::env_logger::init();
+    let text = r#"
+        type Test = Int
+        let x: Test = 0
+        { Test, x }
+        "#;
+    let mut vm = make_vm();
+    load_script(&mut vm, "test", text).unwrap_or_else(|err| panic!("{}", err));
+    let test_x = vm.get_global("test.x");
+    assert_eq!(test_x, Ok(0));
+}
+
+#[test]
+fn get_binding_with_generic_params() {
+    let _ = ::env_logger::init();
+
+    let mut vm = make_vm();
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import "std/prelude.glu" "#);
+    let mut id: FunctionRef<fn(String) -> String> = vm.get_global("std.prelude.id")
+        .unwrap_or_else(|err| panic!("{}", err));
+    assert_eq!(id.call("test".to_string()), Ok("test".to_string()));
+}
+
+#[test]
 fn test_prelude() {
     let _ = ::env_logger::init();
     let vm = make_vm();

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -17,6 +17,7 @@ quick-error = "1.1.0"
 mopa = "0.2.2"
 collect-mac = "0.1.0"
 gluon_base = { path = "../base", version = "0.2.2" }
+gluon_check = { path = "../check", version = "0.2.2" }
 
 [features]
 test = ["env_logger"]

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -905,6 +905,13 @@ impl<T, V> fmt::Debug for OpaqueValue<T, V>
     }
 }
 
+impl<T, V> Clone for OpaqueValue<T, V>
+    where T: Deref<Target = Thread> + Clone,
+{
+    fn clone(&self) -> Self {
+        OpaqueValue(self.0.clone(), self.1.clone())
+    }
+}
 
 impl<T, V> OpaqueValue<T, V>
     where T: Deref<Target = Thread>,
@@ -1525,6 +1532,17 @@ pub struct Function<T, F>
 {
     value: RootedValue<T>,
     _marker: PhantomData<F>,
+}
+
+impl<T, F> Clone for Function<T, F>
+    where T: Deref<Target = Thread> + Clone,
+{
+    fn clone(&self) -> Self {
+        Function {
+            value: self.value.clone(),
+            _marker: self._marker.clone(),
+        }
+    }
 }
 
 impl<T, F> Function<T, F>

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -1572,10 +1572,20 @@ impl<'vm, T, F: Any> Pushable<'vm> for Function<T, F>
         Ok(())
     }
 }
+
 impl<'vm, F> Getable<'vm> for Function<&'vm Thread, F> {
     fn from_value(vm: &'vm Thread, value: Variants) -> Option<Function<&'vm Thread, F>> {
         Some(Function {
             value: vm.root_value_ref(*value.0),
+            _marker: PhantomData,
+        })//TODO not type safe
+    }
+}
+
+impl<'vm, F> Getable<'vm> for Function<RootedThread, F> {
+    fn from_value(vm: &'vm Thread, value: Variants) -> Option<Self> {
+        Some(Function {
+            value: vm.root_value(*value.0),
             _marker: PhantomData,
         })//TODO not type safe
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -12,6 +12,7 @@ extern crate mopa;
 extern crate collect_mac;
 
 extern crate gluon_base as base;
+extern crate gluon_check as check;
 
 #[macro_use]
 pub mod api;

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -347,11 +347,12 @@ impl Thread {
     pub fn get_global<'vm, T>(&'vm self, name: &str) -> Result<T>
         where T: Getable<'vm> + VmType,
     {
+        use check::check_signature;
         let env = self.get_env();
         let (value, actual) = env.get_binding(name)?;
         // Finally check that type of the returned value is correct
         let expected = T::make_type(self);
-        if expected == *actual {
+        if check_signature(&*env, &expected, &actual) {
             T::from_value(self, Variants(&value))
                 .ok_or_else(|| Error::UndefinedBinding(name.into()))
         } else {


### PR DESCRIPTION
This means that aliases are resolved when retrieving bindings and
generic type parameters can be specialized.

Extracted from #226 and extended to work with specialized type parameters (i.e `id : a -> a` can be retrieved as `Int -> Int`)