### PR TITLE
fix(vm): Deep clone OpaqueValue when it is sent between disjoint threads

### DIFF
--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -22,6 +22,21 @@ mod rename;
 pub mod completion;
 pub mod metadata;
 
+use base::types::{ArcType, TypeEnv};
+
+/// Checks if `actual` can be assigned to a binding with the type signature `signature`
+pub fn check_signature(env: &TypeEnv, signature: &ArcType, actual: &ArcType) -> bool {
+    use base::scoped_map::ScopedMap;
+    use base::fnv::FnvMap;
+
+    use substitution::Substitution;
+
+    let subs = Substitution::new();
+    let state = unify_type::State::new(env, &subs);
+    let actual = unify_type::instantiate_generic_variables(&mut FnvMap::default(), &subs, actual);
+    unify_type::merge_signature(&subs, &mut ScopedMap::new(), 0, state, &signature, &actual).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -1,0 +1,54 @@
+extern crate env_logger;
+
+extern crate gluon;
+
+mod support;
+
+use gluon::vm::api::{FunctionRef, OpaqueValue};
+use gluon::vm::reference::Reference;
+use gluon::{Compiler, RootedThread, Thread};
+
+use support::*;
+
+fn verify_value_cloned(from: &Thread, to: &Thread) {
+    let expr = r#" ref 0 "#;
+
+    let (value, _) = Compiler::new()
+        .run_expr::<OpaqueValue<RootedThread, Reference<i32>>>(&from, "example", expr)
+        .unwrap_or_else(|err| panic!("{}", err));
+
+    // Load the prelude
+    type Fn<'t> = FunctionRef<'t, fn(OpaqueValue<RootedThread, Reference<i32>>)>;
+    let (mut store_1, _) = Compiler::new()
+        .run_expr::<Fn>(&to, "store_1", r#"\r -> r <- 1"#)
+        .unwrap();
+    assert_eq!(store_1.call(value.clone()), Ok(()));
+
+    let mut load: FunctionRef<fn(OpaqueValue<RootedThread, Reference<i32>>) -> i32> =
+        from.get_global("load").unwrap();
+    assert_eq!(load.call(value), Ok(0));
+}
+
+#[test]
+fn cant_transfer_opaque_value_between_sibling_threads() {
+    let _ = ::env_logger::init();
+    //     vm
+    //  /     \
+    // vm1    vm2
+    // Passing a value directly from vm1 to vm2 requires the value to be cloned in its entirety
+    let vm = make_vm();
+    let vm1 = vm.new_thread().unwrap();
+    let vm2 = vm.new_thread().unwrap();
+    verify_value_cloned(&vm1, &vm2);
+}
+
+#[test]
+fn cant_transfer_opaque_value_between_disjoint_threads() {
+    let _ = ::env_logger::init();
+    // vm1    vm2
+    // Passing a value directly from vm1 to vm2 requires the value to be cloned in its entirety
+    // since the vms do not share the same global vm
+    let vm1 = make_vm();
+    let vm2 = make_vm();
+    verify_value_cloned(&vm1, &vm2);
+}

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -642,6 +642,31 @@ fn access_operator_without_parentheses() {
 }
 
 #[test]
+fn get_binding_with_alias_type() {
+    let _ = ::env_logger::init();
+    let text = r#"
+        type Test = Int
+        let x: Test = 0
+        { Test, x }
+        "#;
+    let mut vm = make_vm();
+    load_script(&mut vm, "test", text).unwrap_or_else(|err| panic!("{}", err));
+    let test_x = vm.get_global("test.x");
+    assert_eq!(test_x, Ok(0));
+}
+
+#[test]
+fn get_binding_with_generic_params() {
+    let _ = ::env_logger::init();
+
+    let mut vm = make_vm();
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import "std/prelude.glu" "#);
+    let mut id: FunctionRef<fn(String) -> String> = vm.get_global("std.prelude.id")
+        .unwrap_or_else(|err| panic!("{}", err));
+    assert_eq!(id.call("test".to_string()), Ok("test".to_string()));
+}
+
+#[test]
 fn test_prelude() {
     let _ = ::env_logger::init();
     let vm = make_vm();

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -17,6 +17,7 @@ quick-error = "1.1.0"
 mopa = "0.2.2"
 collect-mac = "0.1.0"
 gluon_base = { path = "../base", version = "0.2.2" }
+gluon_check = { path = "../check", version = "0.2.2" }
 
 [features]
 test = ["env_logger"]

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -905,6 +905,13 @@ impl<T, V> fmt::Debug for OpaqueValue<T, V>
     }
 }
 
+impl<T, V> Clone for OpaqueValue<T, V>
+    where T: Deref<Target = Thread> + Clone,
+{
+    fn clone(&self) -> Self {
+        OpaqueValue(self.0.clone(), self.1.clone())
+    }
+}
 
 impl<T, V> OpaqueValue<T, V>
     where T: Deref<Target = Thread>,
@@ -1525,6 +1532,17 @@ pub struct Function<T, F>
 {
     value: RootedValue<T>,
     _marker: PhantomData<F>,
+}
+
+impl<T, F> Clone for Function<T, F>
+    where T: Deref<Target = Thread> + Clone,
+{
+    fn clone(&self) -> Self {
+        Function {
+            value: self.value.clone(),
+            _marker: self._marker.clone(),
+        }
+    }
 }
 
 impl<T, F> Function<T, F>

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -1572,10 +1572,20 @@ impl<'vm, T, F: Any> Pushable<'vm> for Function<T, F>
         Ok(())
     }
 }
+
 impl<'vm, F> Getable<'vm> for Function<&'vm Thread, F> {
     fn from_value(vm: &'vm Thread, value: Variants) -> Option<Function<&'vm Thread, F>> {
         Some(Function {
             value: vm.root_value_ref(*value.0),
+            _marker: PhantomData,
+        })//TODO not type safe
+    }
+}
+
+impl<'vm, F> Getable<'vm> for Function<RootedThread, F> {
+    fn from_value(vm: &'vm Thread, value: Variants) -> Option<Self> {
+        Some(Function {
+            value: vm.root_value(*value.0),
             _marker: PhantomData,
         })//TODO not type safe
     }

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -117,7 +117,7 @@ fn recv(receiver: &Receiver<Generic<A>>) -> Result<Generic<A>, ()> {
 }
 
 fn send(sender: &Sender<Generic<A>>, value: Generic<A>) -> Result<(), ()> {
-    let value = sender.thread.deep_clone_value(value.0).map_err(|_| ())?;
+    let value = sender.thread.deep_clone_value(&sender.thread, value.0).map_err(|_| ())?;
     Ok(sender.send(Generic::from(value)))
 }
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -12,6 +12,7 @@ extern crate mopa;
 extern crate collect_mac;
 
 extern crate gluon_base as base;
+extern crate gluon_check as check;
 
 #[macro_use]
 pub mod api;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -23,6 +23,7 @@ pub mod gc;
 pub mod macros;
 pub mod thread;
 pub mod primitives;
+pub mod reference;
 pub mod stack;
 pub mod types;
 
@@ -30,7 +31,6 @@ mod array;
 mod field_map;
 mod interner;
 mod lazy;
-mod reference;
 mod source_map;
 mod value;
 mod vm;

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -12,7 +12,7 @@ use value::{Value, Cloner};
 use api::{RuntimeResult, Generic, Userdata, VmType, WithVM};
 use api::generic::A;
 
-struct Reference<T> {
+pub struct Reference<T> {
     value: Mutex<Value>,
     thread: GcPtr<Thread>,
     _marker: PhantomData<T>,
@@ -60,7 +60,7 @@ impl<T> VmType for Reference<T>
 }
 
 fn set(r: &Reference<A>, a: Generic<A>) -> RuntimeResult<(), String> {
-    match r.thread.deep_clone_value(a.0) {
+    match r.thread.deep_clone_value(&r.thread, a.0) {
         Ok(a) => {
             *r.value.lock().unwrap() = a;
             RuntimeResult::Return(())

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -4,12 +4,11 @@ use std::sync::Mutex;
 use std::marker::PhantomData;
 
 use base::types::{Type, ArcType};
-use base::fnv::FnvMap;
 use Result;
 use gc::{Gc, GcPtr, Move, Traverseable};
 use vm::Thread;
 use thread::ThreadInternal;
-use value::{Value, deep_clone};
+use value::{Value, Cloner};
 use api::{RuntimeResult, Generic, Userdata, VmType, WithVM};
 use api::generic::A;
 
@@ -22,19 +21,15 @@ struct Reference<T> {
 impl<T> Userdata for Reference<T>
     where T: Any + Send + Sync,
 {
-    fn deep_clone(&self,
-                  visited: &mut FnvMap<*const (), Value>,
-                  gc: &mut Gc,
-                  thread: &Thread)
-                  -> Result<GcPtr<Box<Userdata>>> {
+    fn deep_clone(&self, deep_cloner: &mut Cloner) -> Result<GcPtr<Box<Userdata>>> {
         let value = self.value.lock().unwrap();
-        let cloned_value = deep_clone(*value, visited, gc, thread)?;
+        let cloned_value = deep_cloner.deep_clone(*value)?;
         let data: Box<Userdata> = Box::new(Reference {
             value: Mutex::new(cloned_value),
-            thread: unsafe { GcPtr::from_raw(thread) },
+            thread: unsafe { GcPtr::from_raw(deep_cloner.thread()) },
             _marker: PhantomData::<A>,
         });
-        gc.alloc(Move(data))
+        deep_cloner.gc().alloc(Move(data))
     }
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -347,11 +347,12 @@ impl Thread {
     pub fn get_global<'vm, T>(&'vm self, name: &str) -> Result<T>
         where T: Getable<'vm> + VmType,
     {
+        use check::check_signature;
         let env = self.get_env();
         let (value, actual) = env.get_binding(name)?;
         // Finally check that type of the returned value is correct
         let expected = T::make_type(self);
-        if expected == *actual {
+        if check_signature(&*env, &expected, &actual) {
             T::from_value(self, Variants(&value))
                 .ok_or_else(|| Error::UndefinedBinding(name.into()))
         } else {

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -14,7 +14,6 @@ use base::metadata::Metadata;
 use base::symbol::Symbol;
 use base::types::ArcType;
 use base::types;
-use base::fnv::FnvMap;
 
 use {Variants, Error, Result};
 use field_map::FieldMap;
@@ -644,18 +643,13 @@ impl ThreadInternal for Thread {
                   metadata: Metadata,
                   value: Value)
                   -> Result<()> {
-        let mut visited = FnvMap::default();
-        let value = ::value::deep_clone(value,
-                                        &mut visited,
-                                        &mut self.global_env().gc.lock().unwrap(),
-                                        self)?;
+        let value = ::value::Cloner::new(self, &mut self.global_env().gc.lock().unwrap()).deep_clone(value)?;
         self.global_env().set_global(name, typ, metadata, value)
     }
 
     fn deep_clone_value(&self, value: Value) -> Result<Value> {
-        let mut visited = FnvMap::default();
         let mut context = self.current_context();
-        ::value::deep_clone(value, &mut visited, &mut context.gc, self)
+        ::value::Cloner::new(self, &mut context.gc).deep_clone(value)
     }
 }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -16,7 +16,7 @@ use macros::MacroEnv;
 use {Error, Result};
 use types::*;
 use interner::{Interner, InternedStr};
-use gc::{Gc, GcPtr, Traverseable, Move};
+use gc::{Gc, GcPtr, Generation, Traverseable, Move};
 use compiler::{CompiledFunction, Variable, CompilerEnv};
 use api::IO;
 use lazy::Lazy;
@@ -325,7 +325,7 @@ impl GlobalVmState {
             generics: RwLock::new(FnvMap::default()),
             typeids: RwLock::new(FnvMap::default()),
             interner: RwLock::new(Interner::new()),
-            gc: Mutex::new(Gc::new(0, usize::MAX)),
+            gc: Mutex::new(Gc::new(Generation::default(), usize::MAX)),
             macros: MacroEnv::new(),
             generation_0_threads: RwLock::new(Vec::new()),
         };


### PR DESCRIPTION
Plugs a memory safety hole which would be very simple for a user to introduce. See the added tests from a sketch of what would have been unsafe prior to this PR. This PR ensures that the owner of a `OpaqueValue` is taken into consideration when pushing it to a thread so that it will get copied if it is not possible to share it.

Builds on #234 