### PR TITLE
fix(parser): Don't loop forever from inserting default blocks

### DIFF
--- a/parser/tests/error_handling.rs
+++ b/parser/tests/error_handling.rs
@@ -103,3 +103,17 @@ fn tokenizer_error_at_eof_is_returned() {
 
     assert_eq!(result.map_err(|(_, err)| err), Err(errors));
 }
+
+#[test]
+fn no_infinite_loop_from_default_block() {
+    let _ = ::env_logger::init();
+
+    let result = parse(r#"
+let x = 1
+
+    x,
+    y = 1
+}
+"#);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
In the added test the lalrpop parser would enter error recovery and then repeatedly ask the lexer for tokens until a token that could succeed is found. Unfortunately due to the `,` token the layout algorithm would drop all contexts resulting in a default block to be added which again would be dropped (followed by the default block being added again etc.).

This is a kind of hack but I do believe that just returning the token is the best idea here since if it cannot be recoevered from then the parser will just drop it and request a new (real) token which has a better chance of succeding.