### PR TITLE
fix(parser): Remove unwrap on tokenizer errors

### DIFF
--- a/parser/tests/error_handling.rs
+++ b/parser/tests/error_handling.rs
@@ -63,3 +63,13 @@ y
 
     assert_eq!(result.map_err(|(_, err)| err), Err(errors));
 }
+
+#[test]
+fn unclosed_string() {
+    let _ = ::env_logger::init();
+
+    let result = parse(r#"
+"abc
+"#);
+    assert!(result.is_err());
+}

--- a/parser/tests/indentation.rs
+++ b/parser/tests/indentation.rs
@@ -8,8 +8,7 @@ extern crate gluon_parser as parser;
 mod support;
 
 use base::ast::*;
-use base::pos::{self, BytePos};
-use parser::{Error, parse_string, ParseErrors};
+use parser::{parse_string, ParseErrors};
 use support::MockEnv;
 
 fn parse(text: &str) -> Result<SpannedExpr<String>, ParseErrors> {


### PR DESCRIPTION
The use of `RefCell` feels a bit icky but this is the least intrusive solution I could come up with. Most of the changes are just boilerplate due to the addition of two custom iterator adapters.

Fixes #210

Closes #214