### PR TITLE
feat: Integrate futures/tokio for asynchronous computations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ gluon_vm = { path = "vm", version = "0.2.2" }
 clap = "2.2.5"
 log = "0.3.6"
 quick-error = "1.0.0"
+futures = "0.1.0"
 
 env_logger = { version = "0.3.4", optional = true }
 lazy_static = { version = "0.2.0", optional = true }

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -395,7 +395,6 @@ Once in possession of a [RootedThread][] you can compile and execute code using 
 let vm = new_vm();
 let (result, _) = Compiler::new()
     .run_expr::<i32>(&vm, "example", "1 + 2")
-    .sync_or_error()
     .ok();
 assert_eq!(result, Some(3));
 ```
@@ -407,7 +406,6 @@ let vm = new_vm();
 // Ensure that the prelude module is loaded before trying to access something from it
 Compiler::new()
     .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", " import \"std/prelude.glu\" ")
-    .sync_or_error()
     .unwrap();
 let mut add: FunctionRef<fn (i32, i32) -> i32> = vm.get_global("std.prelude.num_Int.(+)")
     .unwrap();
@@ -428,7 +426,6 @@ vm.define_global("factorial", factorial as fn (_) -> _)
     .unwrap();
 let (result, _) = Compiler::new()
     .run_expr::<i32>(&vm, "example", "factorial 5")
-    .sync_or_error()
     .unwrap();
 assert_eq!(result, 120);
 ```
@@ -439,7 +436,6 @@ assert_eq!(result, 120);
 let vm = new_vm();
 let (result, _) = Compiler::new()
     .run_expr::<String>(&vm, "example", " let string = import \"std/string.glu\" in string.trim \"  Hello world  \t\" ")
-    .sync_or_error()
     .unwrap();
 assert_eq!(result, "Hello world");
 ```

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -395,6 +395,7 @@ Once in possession of a [RootedThread][] you can compile and execute code using 
 let vm = new_vm();
 let (result, _) = Compiler::new()
     .run_expr::<i32>(&vm, "example", "1 + 2")
+    .sync_or_error()
     .ok();
 assert_eq!(result, Some(3));
 ```
@@ -406,6 +407,7 @@ let vm = new_vm();
 // Ensure that the prelude module is loaded before trying to access something from it
 Compiler::new()
     .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", " import \"std/prelude.glu\" ")
+    .sync_or_error()
     .unwrap();
 let mut add: FunctionRef<fn (i32, i32) -> i32> = vm.get_global("std.prelude.num_Int.(+)")
     .unwrap();
@@ -426,6 +428,7 @@ vm.define_global("factorial", factorial as fn (_) -> _)
     .unwrap();
 let (result, _) = Compiler::new()
     .run_expr::<i32>(&vm, "example", "factorial 5")
+    .sync_or_error()
     .unwrap();
 assert_eq!(result, 120);
 ```
@@ -436,6 +439,7 @@ assert_eq!(result, 120);
 let vm = new_vm();
 let (result, _) = Compiler::new()
     .run_expr::<String>(&vm, "example", " let string = import \"std/string.glu\" in string.trim \"  Hello world  \t\" ")
+    .sync_or_error()
     .unwrap();
 assert_eq!(result, "Hello world");
 ```

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ fn main() {{
     let _ = ::env_logger::init();
     let text = r#\"{}\"#;
     let vm = new_vm();
-    match Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, \"example\", text) {{
+    match Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, \"example\", text) .sync_or_error() {{
         Ok(_value) => (),
         Err(err) => {{
             panic!(\"{{}}\", err);

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -10,7 +10,7 @@ use gluon::vm::api::{Getable, Pushable, CPrimitive, Hole, OpaqueValue};
 use gluon::vm::types::{VmIndex, VmInt};
 use gluon::vm::thread::{RootedThread, Thread, ThreadInternal, Status};
 
-use gluon::Compiler;
+use gluon::{Compiler, Future};
 
 pub type Function = extern "C" fn(&Thread) -> Status;
 
@@ -46,8 +46,7 @@ pub unsafe extern "C" fn glu_run_expr(vm: &Thread,
         Ok(s) => s,
         Err(_) => return Error::Unknown,
     };
-    let result =
-        Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, module, expr).sync_or_error();
+    let result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, module, expr).wait();
     match result {
         Ok(_) => Error::Ok,
         Err(_) => Error::Unknown,
@@ -68,7 +67,7 @@ pub unsafe extern "C" fn glu_load_script(vm: &Thread,
         Ok(s) => s,
         Err(_) => return Error::Unknown,
     };
-    let result = Compiler::new().load_script(vm, module, expr);
+    let result = Compiler::new().load_script(vm, module, expr).wait();
     match result {
         Ok(_) => Error::Ok,
         Err(_) => Error::Unknown,

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -46,7 +46,8 @@ pub unsafe extern "C" fn glu_run_expr(vm: &Thread,
         Ok(s) => s,
         Err(_) => return Error::Unknown,
     };
-    let result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, module, expr);
+    let result =
+        Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, module, expr).sync_or_error();
     match result {
         Ok(_) => Error::Ok,
         Err(_) => Error::Unknown,

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -10,7 +10,7 @@ use gluon::vm::api::{Getable, Pushable, CPrimitive, Hole, OpaqueValue};
 use gluon::vm::types::{VmIndex, VmInt};
 use gluon::vm::thread::{RootedThread, Thread, ThreadInternal, Status};
 
-use gluon::{Compiler, Future};
+use gluon::Compiler;
 
 pub type Function = extern "C" fn(&Thread) -> Status;
 
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn glu_run_expr(vm: &Thread,
         Ok(s) => s,
         Err(_) => return Error::Unknown,
     };
-    let result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, module, expr).wait();
+    let result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, module, expr);
     match result {
         Ok(_) => Error::Ok,
         Err(_) => Error::Unknown,
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn glu_load_script(vm: &Thread,
         Ok(s) => s,
         Err(_) => return Error::Unknown,
     };
-    let result = Compiler::new().load_script(vm, module, expr).wait();
+    let result = Compiler::new().load_script(vm, module, expr);
     match result {
         Ok(_) => Error::Ok,
         Err(_) => Error::Unknown,

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -302,7 +302,7 @@ impl<E> Executable<()> for CompileValue<E>
         let CompileValue { expr, typ, mut function } = self;
         function.id = Symbol::from(name);
         let closure = vm.global_env().new_global_thunk(function)?;
-        let value = vm.call_thunk(closure)?.wait()?;
+        let (_, value) = vm.call_thunk(closure)?.wait()?;
         Ok(ExecuteValue {
             expr: expr,
             typ: typ,
@@ -321,7 +321,7 @@ impl<E> Executable<()> for CompileValue<E>
         let CompileValue { mut expr, typ, function } = self;
         let metadata = metadata::metadata(&*vm.get_env(), expr.borrow_mut());
         let closure = vm.global_env().new_global_thunk(function)?;
-        let value = vm.call_thunk(closure)?.wait()?;
+        let (_, value) = vm.call_thunk(closure)?.wait()?;
         vm.set_global(closure.function.name.clone(), typ, metadata, value)?;
         info!("Loaded module `{}` filename", filename);
         Ok(())

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -10,6 +10,8 @@
 
 use std::borrow::{Borrow, BorrowMut};
 
+use futures::Future;
+
 use base::ast::SpannedExpr;
 use base::error::InFile;
 use base::types::ArcType;
@@ -300,7 +302,7 @@ impl<E> Executable<()> for CompileValue<E>
         let CompileValue { expr, typ, mut function } = self;
         function.id = Symbol::from(name);
         let closure = vm.global_env().new_global_thunk(function)?;
-        let value = vm.call_thunk(closure)?;
+        let value = vm.call_thunk(closure).wait()?;
         Ok(ExecuteValue {
             expr: expr,
             typ: typ,
@@ -319,7 +321,7 @@ impl<E> Executable<()> for CompileValue<E>
         let CompileValue { mut expr, typ, function } = self;
         let metadata = metadata::metadata(&*vm.get_env(), expr.borrow_mut());
         let closure = vm.global_env().new_global_thunk(function)?;
-        let value = vm.call_thunk(closure)?;
+        let value = vm.call_thunk(closure).wait()?;
         vm.set_global(closure.function.name.clone(), typ, metadata, value)?;
         info!("Loaded module `{}` filename", filename);
         Ok(())

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -302,7 +302,7 @@ impl<E> Executable<()> for CompileValue<E>
         let CompileValue { expr, typ, mut function } = self;
         function.id = Symbol::from(name);
         let closure = vm.global_env().new_global_thunk(function)?;
-        let value = vm.call_thunk(closure).wait()?;
+        let value = vm.call_thunk(closure)?.wait()?;
         Ok(ExecuteValue {
             expr: expr,
             typ: typ,
@@ -321,7 +321,7 @@ impl<E> Executable<()> for CompileValue<E>
         let CompileValue { mut expr, typ, function } = self;
         let metadata = metadata::metadata(&*vm.get_env(), expr.borrow_mut());
         let closure = vm.global_env().new_global_thunk(function)?;
-        let value = vm.call_thunk(closure).wait()?;
+        let value = vm.call_thunk(closure)?.wait()?;
         vm.set_global(closure.function.name.clone(), typ, metadata, value)?;
         info!("Loaded module `{}` filename", filename);
         Ok(())

--- a/src/import.rs
+++ b/src/import.rs
@@ -77,7 +77,8 @@ impl Importer for DefaultImporter {
               -> Result<(), MacroError> {
         use compiler_pipeline::*;
 
-        MacroValue { expr: expr }.load_script(compiler, vm, modulename, input, None)?;
+        MacroValue { expr: expr }.load_script(compiler, vm, modulename, input, None)
+            .sync_or_error()?;
         Ok(())
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -186,7 +186,7 @@ fn run_expr(WithVM { vm, value: expr }: WithVM<&str>) -> IO<String> {
 
 fn load_script(WithVM { vm, value: name }: WithVM<&str>, expr: &str) -> IO<String> {
     let frame_level = vm.context().stack.get_frames().len();
-    let run_result = Compiler::new().load_script(vm, name, expr);
+    let run_result = Compiler::new().load_script(vm, name, expr).sync_or_error();
     let mut context = vm.context();
     let stack = StackFrame::current(&mut context.stack);
     match run_result {

--- a/src/io.rs
+++ b/src/io.rs
@@ -171,8 +171,11 @@ fn clear_frames(err: Error, frame_level: usize, mut stack: StackFrame) -> IO<Str
 }
 
 fn run_expr(WithVM { vm, value: expr }: WithVM<&str>) -> IO<String> {
+    use futures::Future;
+
     let frame_level = vm.context().stack.get_frames().len();
-    let run_result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(vm, "<top>", expr);
+    let run_result =
+        Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(vm, "<top>", expr).wait();
     let mut context = vm.context();
     let stack = StackFrame::current(&mut context.stack);
     match run_result {

--- a/src/io.rs
+++ b/src/io.rs
@@ -171,11 +171,8 @@ fn clear_frames(err: Error, frame_level: usize, mut stack: StackFrame) -> IO<Str
 }
 
 fn run_expr(WithVM { vm, value: expr }: WithVM<&str>) -> IO<String> {
-    use futures::Future;
-
     let frame_level = vm.context().stack.get_frames().len();
-    let run_result =
-        Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(vm, "<top>", expr).wait();
+    let run_result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(vm, "<top>", expr);
     let mut context = vm.context();
     let stack = StackFrame::current(&mut context.stack);
     match run_result {
@@ -186,7 +183,7 @@ fn run_expr(WithVM { vm, value: expr }: WithVM<&str>) -> IO<String> {
 
 fn load_script(WithVM { vm, value: name }: WithVM<&str>, expr: &str) -> IO<String> {
     let frame_level = vm.context().stack.get_frames().len();
-    let run_result = Compiler::new().load_script(vm, name, expr).sync_or_error();
+    let run_result = Compiler::new().load_script_async(vm, name, expr).sync_or_error();
     let mut context = vm.context();
     let stack = StackFrame::current(&mut context.stack);
     match run_result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ impl Compiler {
         where T: Getable<'vm> + VmType,
     {
         let expected = T::make_type(vm);
-        expr_str.run_expr(self, vm, name, expr_str, Some(&expected))?
+        expr_str.run_expr(self, vm, name, expr_str, Some(&expected))
             .and_then(|v| {
                 let ExecuteValue { typ: actual, value, .. } = v;
                 unsafe {
@@ -285,7 +285,7 @@ impl Compiler {
               T::Type: Sized,
     {
         let expected = T::make_type(vm);
-        expr_str.run_expr(self, vm, name, expr_str, Some(&expected))?
+        expr_str.run_expr(self, vm, name, expr_str, Some(&expected))
             .and_then(move |v| {
                 let ExecuteValue { typ: actual, value, .. } = v;
                 let is_io = {
@@ -299,13 +299,9 @@ impl Compiler {
                         .unwrap_or(false)
                 };
                 if is_io {
-                    match vm.execute_io(*value) {
-                        Ok(future) => {
-                            future.map(move |(_, value)| (value, expected, actual))
-                                .map_err(Error::from)
-                        }
-                        Err(err) => FutureValue::Value(Err(err.into())),
-                    }
+                    vm.execute_io(*value)
+                        .map(move |(_, value)| (value, expected, actual))
+                        .map_err(Error::from)
                 } else {
                     FutureValue::Value(Ok((*value, expected, actual)))
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use std::result::Result as StdResult;
 use std::string::String as StdString;
 use std::env;
 
-use futures::Async;
+use futures::Future;
 
 use base::ast::{self, SpannedExpr};
 use base::error::{Errors, InFile};
@@ -294,12 +294,7 @@ impl Compiler {
                 .unwrap_or(false)
         };
         let value = if is_io {
-            match vm.execute_io(*value)? {
-                Async::Ready(value) => value,
-                Async::NotReady => {
-                    return Err(VmError::Message("Unhandled asynchronous execution".into()).into())
-                }
-            }
+            vm.execute_io(*value)?.wait()?.1
         } else {
             *value
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate clap;
 extern crate quick_error;
 #[macro_use]
 extern crate lazy_static;
+extern crate futures;
 
 extern crate gluon_base as base;
 extern crate gluon;
@@ -14,7 +15,6 @@ extern crate gluon_check as check;
 extern crate gluon_parser as parser;
 #[macro_use]
 extern crate gluon_vm as vm;
-
 
 #[cfg(not(test))]
 use gluon::{new_vm, Compiler, Thread, Error, Result};
@@ -32,9 +32,11 @@ mod repl;
 fn run_files<'s, I>(vm: &Thread, files: I) -> Result<()>
     where I: Iterator<Item = &'s str>,
 {
+    use futures::Future;
+
     let mut compiler = Compiler::new();
     for file in files {
-        compiler.load_file(&vm, file)?;
+        compiler.load_file(&vm, file).wait()?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,9 @@ mod repl;
 fn run_files<'s, I>(vm: &Thread, files: I) -> Result<()>
     where I: Iterator<Item = &'s str>,
 {
-    use futures::Future;
-
     let mut compiler = Compiler::new();
     for file in files {
-        compiler.load_file(&vm, file).wait()?;
+        compiler.load_file(&vm, file)?;
     }
     Ok(())
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -176,8 +176,7 @@ fn compile_repl(vm: &Thread) -> Result<(), Box<StdError + Send + Sync>> {
         find_kind => primitive!(1 find_kind)
     ))?;
     let mut compiler = Compiler::new();
-    compiler.load_file(vm, "std/prelude.glu")?;
-    compiler.load_file(vm, "std/repl.glu")?;
+    compiler.load_file(vm, "std/repl.glu").sync_or_error()?;
     Ok(())
 }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -31,9 +31,9 @@ fn find_kind(args: WithVM<RootStr>) -> IO<Result<String, String>> {
     let args = args.value.trim();
     IO::Value(match vm.find_type_info(args) {
         Ok(ref alias) => {
-            let kind =
-                alias.args.iter().rev().fold(Kind::typ(),
-                                             |acc, arg| Kind::function(arg.kind.clone(), acc));
+            let kind = alias.args.iter().rev().fold(Kind::typ(), |acc, arg| {
+                Kind::function(arg.kind.clone(), acc)
+            });
             Ok(format!("{}", kind))
         }
         Err(err) => Err(format!("{}", err)),
@@ -176,7 +176,7 @@ fn compile_repl(vm: &Thread) -> Result<(), Box<StdError + Send + Sync>> {
         find_kind => primitive!(1 find_kind)
     ))?;
     let mut compiler = Compiler::new();
-    compiler.load_file(vm, "std/repl.glu").sync_or_error()?;
+    compiler.load_file_async(vm, "std/repl.glu").sync_or_error()?;
     Ok(())
 }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -98,7 +98,10 @@ test "hello"
     let vm = make_vm();
     vm.define_global("test", primitive!(1 test)).unwrap();
 
-    let result = Compiler::new().run_expr::<String>(&vm, "<top>", expr).unwrap();
+    let result = Compiler::new()
+        .run_expr::<String>(&vm, "<top>", expr)
+        .wait()
+        .unwrap();
     let expected = ("hello world".to_string(), Type::string());
 
     assert_eq!(result, expected);
@@ -118,8 +121,10 @@ sum_bytes [100b, 42b, 3b, 15b]
     let vm = make_vm();
     vm.define_global("sum_bytes", primitive!(1 sum_bytes)).unwrap();
 
-    let result =
-        Compiler::new().run_expr::<u8>(&vm, "<top>", expr).unwrap_or_else(|err| panic!("{}", err));
+    let result = Compiler::new()
+        .run_expr::<u8>(&vm, "<top>", expr)
+        .wait()
+        .unwrap_or_else(|err| panic!("{}", err));
     let expected = (160, Type::byte());
 
     assert_eq!(result, expected);
@@ -140,8 +145,10 @@ fn return_finished_future() {
     let vm = make_vm();
     vm.define_global("add", primitive!(2 add)).unwrap();
 
-    let result =
-        Compiler::new().run_expr::<i32>(&vm, "<top>", expr).unwrap_or_else(|err| panic!("{}", err));
+    let result = Compiler::new()
+        .run_expr::<i32>(&vm, "<top>", expr)
+        .wait()
+        .unwrap_or_else(|err| panic!("{}", err));
     let expected = (3, Type::int());
 
     assert_eq!(result, expected);
@@ -178,6 +185,7 @@ fn return_delayed_future() {
 
     let result = Compiler::new()
         .run_expr::<i32>(&vm, "<top>", expr)
+        .wait()
         .unwrap_or_else(|err| panic!("{}", err));
     let expected = (3, Type::int());
 
@@ -204,6 +212,7 @@ fn io_future() {
 
     let result = Compiler::new()
         .run_io_expr::<IO<i32>>(&vm, "<top>", expr)
+        .wait()
         .unwrap_or_else(|err| panic!("{}", err));
 
     assert_eq!(result.0, IO::Value(124));

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -17,7 +17,7 @@ use gluon::Compiler;
 use gluon::import::Import;
 
 fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<()> {
-    Compiler::new().load_script(vm, filename, input).sync_or_error()
+    Compiler::new().load_script_async(vm, filename, input).sync_or_error()
 }
 
 fn make_vm() -> RootedThread {
@@ -100,7 +100,6 @@ test "hello"
 
     let result = Compiler::new()
         .run_expr::<String>(&vm, "<top>", expr)
-        .wait()
         .unwrap();
     let expected = ("hello world".to_string(), Type::string());
 
@@ -123,7 +122,6 @@ sum_bytes [100b, 42b, 3b, 15b]
 
     let result = Compiler::new()
         .run_expr::<u8>(&vm, "<top>", expr)
-        .wait()
         .unwrap_or_else(|err| panic!("{}", err));
     let expected = (160, Type::byte());
 
@@ -147,7 +145,6 @@ fn return_finished_future() {
 
     let result = Compiler::new()
         .run_expr::<i32>(&vm, "<top>", expr)
-        .wait()
         .unwrap_or_else(|err| panic!("{}", err));
     let expected = (3, Type::int());
 
@@ -185,7 +182,6 @@ fn return_delayed_future() {
 
     let result = Compiler::new()
         .run_expr::<i32>(&vm, "<top>", expr)
-        .wait()
         .unwrap_or_else(|err| panic!("{}", err));
     let expected = (3, Type::int());
 
@@ -212,7 +208,6 @@ fn io_future() {
 
     let result = Compiler::new()
         .run_io_expr::<IO<i32>>(&vm, "<top>", expr)
-        .wait()
         .unwrap_or_else(|err| panic!("{}", err));
 
     assert_eq!(result.0, IO::Value(124));

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -17,7 +17,7 @@ use gluon::Compiler;
 use gluon::import::Import;
 
 fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<()> {
-    Compiler::new().load_script(vm, filename, input)
+    Compiler::new().load_script(vm, filename, input).sync_or_error()
 }
 
 fn make_vm() -> RootedThread {

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -10,6 +10,6 @@ fn dont_panic_when_error_span_is_at_eof() {
     let _ = ::env_logger::init();
     let vm = support::make_vm();
     let text = r#"abc"#;
-    let result = Compiler::new().load_script(&vm, "test", text);
+    let result = Compiler::new().load_script(&vm, "test", text).sync_or_error();
     assert!(result.is_err());
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -10,6 +10,6 @@ fn dont_panic_when_error_span_is_at_eof() {
     let _ = ::env_logger::init();
     let vm = support::make_vm();
     let text = r#"abc"#;
-    let result = Compiler::new().load_script(&vm, "test", text).sync_or_error();
+    let result = Compiler::new().load_script_async(&vm, "test", text).sync_or_error();
     assert!(result.is_err());
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -22,7 +22,8 @@ fn read_file() {
             assert (array.index bytes 1 #Byte== 112b) // p
             pure (array.index bytes 8)
         "#;
-    let result = Compiler::new().run_io_expr::<IO<u8>>(&thread, "<top>", text).sync_or_error();
+    let result =
+        Compiler::new().run_io_expr_async::<IO<u8>>(&thread, "<top>", text).sync_or_error();
 
     match result {
         Ok((IO::Value(value), _)) => assert_eq!(value, b']'),

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -22,7 +22,7 @@ fn read_file() {
             assert (array.index bytes 1 #Byte== 112b) // p
             pure (array.index bytes 8)
         "#;
-    let result = Compiler::new().run_io_expr::<IO<u8>>(&thread, "<top>", text);
+    let result = Compiler::new().run_io_expr::<IO<u8>>(&thread, "<top>", text).sync_or_error();
 
     match result {
         Ok((IO::Value(value), _)) => assert_eq!(value, b']'),

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -19,7 +19,7 @@ fn out_of_memory() {
 
     let expr = " [1, 2, 3, 4] ";
     let result = Compiler::new()
-        .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
         .sync_or_error();
 
     match result {
@@ -39,7 +39,7 @@ fn stack_overflow() {
 
     let expr = " [1, 2, 3, 4] ";
     let result = Compiler::new()
-        .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
         .sync_or_error();
 
     match result {

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -18,7 +18,9 @@ fn out_of_memory() {
     vm.set_memory_limit(10);
 
     let expr = " [1, 2, 3, 4] ";
-    let result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr);
+    let result = Compiler::new()
+        .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
+        .sync_or_error();
 
     match result {
         // FIXME This should just need to match on the explicit out of memory error
@@ -36,7 +38,9 @@ fn stack_overflow() {
     vm.context().set_max_stack_size(3);
 
     let expr = " [1, 2, 3, 4] ";
-    let result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr);
+    let result = Compiler::new()
+        .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
+        .sync_or_error();
 
     match result {
         Err(Error::VM(VMError::StackOverflow(3))) => (),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -64,7 +64,7 @@ fn main_() -> Result<(), Box<Error>> {
         file.read_to_string(&mut text)?;
         let name = filename.to_str().unwrap_or("<unknown>");
         println!("test {}", name);
-        compiler.run_expr::<OpaqueValue<&Thread, Hole>>(&vm, name, &text)?;
+        compiler.run_expr::<OpaqueValue<&Thread, Hole>>(&vm, name, &text).sync_or_error()?;
     }
     for filename in test_files("tests/fail")? {
         let mut file = File::open(&filename)?;
@@ -72,7 +72,7 @@ fn main_() -> Result<(), Box<Error>> {
         file.read_to_string(&mut text)?;
         let name = filename.to_str().unwrap_or("<unknown>");
         println!("test {}", name);
-        match compiler.run_expr::<OpaqueValue<&Thread, Hole>>(&vm, name, &text) {
+        match compiler.run_expr::<OpaqueValue<&Thread, Hole>>(&vm, name, &text).sync_or_error() {
             Ok(x) => {
                 return Err(StringError(format!("Expected test '{}' to fail got {:?}",
                                                filename.to_str().unwrap(),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -55,7 +55,7 @@ fn test_files(path: &str) -> Result<Vec<PathBuf>, Box<Error>> {
 fn main_() -> Result<(), Box<Error>> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
-    compiler.load_file(&vm, "std/prelude.glu").sync_or_error()?;
+    compiler.load_file_async(&vm, "std/prelude.glu").sync_or_error()?;
     let mut text = String::new();
     let _ = ::env_logger::init();
     for filename in test_files("tests/pass")? {
@@ -64,7 +64,7 @@ fn main_() -> Result<(), Box<Error>> {
         file.read_to_string(&mut text)?;
         let name = filename.to_str().unwrap_or("<unknown>");
         println!("test {}", name);
-        compiler.run_expr::<OpaqueValue<&Thread, Hole>>(&vm, name, &text).sync_or_error()?;
+        compiler.run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, name, &text).sync_or_error()?;
     }
     for filename in test_files("tests/fail")? {
         let mut file = File::open(&filename)?;
@@ -72,7 +72,8 @@ fn main_() -> Result<(), Box<Error>> {
         file.read_to_string(&mut text)?;
         let name = filename.to_str().unwrap_or("<unknown>");
         println!("test {}", name);
-        match compiler.run_expr::<OpaqueValue<&Thread, Hole>>(&vm, name, &text).sync_or_error() {
+        match compiler.run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, name, &text)
+            .sync_or_error() {
             Ok(x) => {
                 return Err(StringError(format!("Expected test '{}' to fail got {:?}",
                                                filename.to_str().unwrap(),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -55,7 +55,7 @@ fn test_files(path: &str) -> Result<Vec<PathBuf>, Box<Error>> {
 fn main_() -> Result<(), Box<Error>> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
-    compiler.load_file(&vm, "std/prelude.glu")?;
+    compiler.load_file(&vm, "std/prelude.glu").sync_or_error()?;
     let mut text = String::new();
     let _ = ::env_logger::init();
     for filename in test_files("tests/pass")? {

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -23,7 +23,7 @@ fn metadata_from_other_module() {
 let { List, id } = import "std/prelude.hs"
 { List, id }
 "#;
-    Compiler::new().load_script(&vm, "test", text).sync_or_error().unwrap();
+    Compiler::new().load_script_async(&vm, "test", text).sync_or_error().unwrap();
 
     let env = vm.get_env();
     assert!(env.get_metadata("test.id").is_ok());

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -23,7 +23,7 @@ fn metadata_from_other_module() {
 let { List, id } = import "std/prelude.hs"
 { List, id }
 "#;
-    Compiler::new().load_script(&vm, "test", text).unwrap();
+    Compiler::new().load_script(&vm, "test", text).sync_or_error().unwrap();
 
     let env = vm.get_env();
     assert!(env.get_metadata("test.id").is_ok());

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -18,7 +18,7 @@ fn parallel() {
 fn parallel_() -> Result<(), Error> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
-    let (value, _) = compiler.run_expr(&vm, "<top>", " channel 0 ")
+    let (value, _) = compiler.run_expr_async(&vm, "<top>", " channel 0 ")
         .sync_or_error()?;
     let value: ChannelRecord<OpaqueValue<RootedThread, Sender<i32>>,
                              OpaqueValue<RootedThread, Receiver<i32>>> = value;
@@ -35,7 +35,7 @@ fn parallel_() -> Result<(), Error> {
         "#;
         let mut compiler = Compiler::new();
         let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Sender<i32>>)> =
-            compiler.run_expr(&child, "<top>", expr)
+            compiler.run_expr_async(&child, "<top>", expr)
                 .sync_or_error()?
                 .0;
         Ok(f.call(sender)?)
@@ -56,7 +56,7 @@ fn parallel_() -> Result<(), Error> {
         "#;
         let mut compiler = Compiler::new();
         let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Receiver<i32>>)> =
-            compiler.run_expr(&child2, "<top>", expr)
+            compiler.run_expr_async(&child2, "<top>", expr)
                 .sync_or_error()?
                 .0;
         Ok(f.call(receiver)?)

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -18,7 +18,8 @@ fn parallel() {
 fn parallel_() -> Result<(), Error> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
-    let (value, _) = compiler.run_expr(&vm, "<top>", " channel 0 ")?;
+    let (value, _) = compiler.run_expr(&vm, "<top>", " channel 0 ")
+        .sync_or_error()?;
     let value: ChannelRecord<OpaqueValue<RootedThread, Sender<i32>>,
                              OpaqueValue<RootedThread, Receiver<i32>>> = value;
     let (sender, receiver) = value.split();
@@ -34,7 +35,9 @@ fn parallel_() -> Result<(), Error> {
         "#;
         let mut compiler = Compiler::new();
         let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Sender<i32>>)> =
-            compiler.run_expr(&child, "<top>", expr)?.0;
+            compiler.run_expr(&child, "<top>", expr)
+                .sync_or_error()?
+                .0;
         Ok(f.call(sender)?)
     });
 
@@ -53,7 +56,9 @@ fn parallel_() -> Result<(), Error> {
         "#;
         let mut compiler = Compiler::new();
         let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Receiver<i32>>)> =
-            compiler.run_expr(&child2, "<top>", expr)?.0;
+            compiler.run_expr(&child2, "<top>", expr)
+                .sync_or_error()?
+                .0;
         Ok(f.call(receiver)?)
     });
 

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -17,7 +17,7 @@ let thread = spawn (\_ ->
         send sender 0
         yield ()
         send sender 1
-        yield ()
+        ()
     )
 resume thread
 

--- a/tests/regex_bind.rs
+++ b/tests/regex_bind.rs
@@ -19,7 +19,7 @@ fn regex_match() {
         let match_hello = regex.new "hello, .*" |> unwrap_ok
         regex.is_match match_hello "hello, world"
         "#;
-    let result = Compiler::new().run_expr::<bool>(&thread, "<top>", text);
+    let result = Compiler::new().run_expr::<bool>(&thread, "<top>", text).sync_or_error();
 
     assert!(result.unwrap().0);
 }
@@ -34,7 +34,7 @@ fn regex_error() {
 
         regex.new ")" |> unwrap_err |> regex.error_to_string
         "#;
-    let result = Compiler::new().run_expr::<String>(&thread, "<top>", text);
+    let result = Compiler::new().run_expr::<String>(&thread, "<top>", text).sync_or_error();
 
     assert_eq!(result.unwrap().0,
                "Error parsing regex near \')\' at character offset 0: Unopened parenthesis.");

--- a/tests/regex_bind.rs
+++ b/tests/regex_bind.rs
@@ -19,7 +19,7 @@ fn regex_match() {
         let match_hello = regex.new "hello, .*" |> unwrap_ok
         regex.is_match match_hello "hello, world"
         "#;
-    let result = Compiler::new().run_expr::<bool>(&thread, "<top>", text).sync_or_error();
+    let result = Compiler::new().run_expr_async::<bool>(&thread, "<top>", text).sync_or_error();
 
     assert!(result.unwrap().0);
 }
@@ -34,7 +34,7 @@ fn regex_error() {
 
         regex.new ")" |> unwrap_err |> regex.error_to_string
         "#;
-    let result = Compiler::new().run_expr::<String>(&thread, "<top>", text).sync_or_error();
+    let result = Compiler::new().run_expr_async::<String>(&thread, "<top>", text).sync_or_error();
 
     assert_eq!(result.unwrap().0,
                "Error parsing regex near \')\' at character offset 0: Unopened parenthesis.");

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -15,12 +15,14 @@ fn verify_value_cloned(from: &Thread, to: &Thread) {
 
     let (value, _) = Compiler::new()
         .run_expr::<OpaqueValue<RootedThread, Reference<i32>>>(&from, "example", expr)
+        .sync_or_error()
         .unwrap_or_else(|err| panic!("{}", err));
 
     // Load the prelude
     type Fn<'t> = FunctionRef<'t, fn(OpaqueValue<RootedThread, Reference<i32>>)>;
     let (mut store_1, _) = Compiler::new()
         .run_expr::<Fn>(&to, "store_1", r#"\r -> r <- 1"#)
+        .sync_or_error()
         .unwrap();
     assert_eq!(store_1.call(value.clone()), Ok(()));
 

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -14,14 +14,14 @@ fn verify_value_cloned(from: &Thread, to: &Thread) {
     let expr = r#" ref 0 "#;
 
     let (value, _) = Compiler::new()
-        .run_expr::<OpaqueValue<RootedThread, Reference<i32>>>(&from, "example", expr)
+        .run_expr_async::<OpaqueValue<RootedThread, Reference<i32>>>(&from, "example", expr)
         .sync_or_error()
         .unwrap_or_else(|err| panic!("{}", err));
 
     // Load the prelude
     type Fn<'t> = FunctionRef<'t, fn(OpaqueValue<RootedThread, Reference<i32>>)>;
     let (mut store_1, _) = Compiler::new()
-        .run_expr::<Fn>(&to, "store_1", r#"\r -> r <- 1"#)
+        .run_expr_async::<Fn>(&to, "store_1", r#"\r -> r <- 1"#)
         .sync_or_error()
         .unwrap();
     assert_eq!(store_1.call(value.clone()), Ok(()));

--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -731,5 +731,5 @@ let _ = 1
 in 1
 "#;
     let vm = new_vm();
-    Compiler::new().load_script(&vm, "", text).sync_or_error().unwrap();
+    Compiler::new().load_script_async(&vm, "", text).sync_or_error().unwrap();
 }

--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -731,5 +731,5 @@ let _ = 1
 in 1
 "#;
     let vm = new_vm();
-    Compiler::new().load_script(&vm, "", text).unwrap();
+    Compiler::new().load_script(&vm, "", text).sync_or_error().unwrap();
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -11,7 +11,7 @@ use gluon::Compiler;
 pub fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<()> {
     Compiler::new()
         .implicit_prelude(false)
-        .load_script(vm, filename, input)
+        .load_script_async(vm, filename, input)
         .sync_or_error()
 }
 
@@ -21,7 +21,7 @@ pub fn run_expr_<'vm, T>(vm: &'vm Thread, s: &str, implicit_prelude: bool) -> T
 {
     Compiler::new()
         .implicit_prelude(implicit_prelude)
-        .run_expr(vm, "<top>", s)
+        .run_expr_async(vm, "<top>", s)
         .sync_or_error()
         .unwrap_or_else(|err| panic!("{}", err))
         .0
@@ -62,14 +62,11 @@ macro_rules! test_expr {
     (io $name: ident, $expr: expr, $value: expr) => {
         #[test]
         fn $name() {
-            use $crate::support::futures::Future;
-
             let _ = ::env_logger::init();
             let mut vm = make_vm();
             let (value, _) = Compiler::new()
                 .implicit_prelude(false)
                 .run_io_expr(&mut vm, "<top>", $expr)
-                .wait()
                 .unwrap_or_else(|err| panic!("{}", err));
             match value {
                 IO::Value(value) => {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -12,6 +12,7 @@ pub fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<
     Compiler::new()
         .implicit_prelude(false)
         .load_script(vm, filename, input)
+        .sync_or_error()
 }
 
 #[allow(dead_code)]

--- a/tests/tutorial.rs
+++ b/tests/tutorial.rs
@@ -24,7 +24,9 @@ fn access_field_through_alias() {
     let _ = ::env_logger::init();
     let vm = new_vm();
     Compiler::new()
-        .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", " import \"std/prelude.glu\" ")
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm,
+                                                      "example",
+                                                      " import \"std/prelude.glu\" ")
         .sync_or_error()
         .unwrap();
     let mut add: FunctionRef<fn(i32, i32) -> i32> = vm.get_global("std.prelude.num_Int.(+)")
@@ -44,7 +46,7 @@ fn call_rust_from_gluon() {
     vm.define_global("factorial", primitive!(1 factorial)).unwrap();
 
     let result = Compiler::new()
-        .run_expr::<i32>(&vm, "example", "factorial 5")
+        .run_expr_async::<i32>(&vm, "example", "factorial 5")
         .sync_or_error()
         .unwrap();
     let expected = (120, Type::int());
@@ -58,10 +60,10 @@ fn use_string_module() {
 
     let vm = new_vm();
     let result = Compiler::new()
-        .run_expr::<String>(&vm,
-                            "example",
-                            " let string = import \"std/string.glu\" in string.trim \"  Hello \
-                             world  \t\" ")
+        .run_expr_async::<String>(&vm,
+                                  "example",
+                                  " let string = import \"std/string.glu\" in string.trim \"  \
+                                   Hello world  \t\" ")
         .sync_or_error()
         .unwrap();
     let expected = ("Hello world".to_string(), Type::string());

--- a/tests/tutorial.rs
+++ b/tests/tutorial.rs
@@ -25,6 +25,7 @@ fn access_field_through_alias() {
     let vm = new_vm();
     Compiler::new()
         .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", " import \"std/prelude.glu\" ")
+        .sync_or_error()
         .unwrap();
     let mut add: FunctionRef<fn(i32, i32) -> i32> = vm.get_global("std.prelude.num_Int.(+)")
         .unwrap();
@@ -42,7 +43,10 @@ fn call_rust_from_gluon() {
     let vm = new_vm();
     vm.define_global("factorial", primitive!(1 factorial)).unwrap();
 
-    let result = Compiler::new().run_expr::<i32>(&vm, "example", "factorial 5").unwrap();
+    let result = Compiler::new()
+        .run_expr::<i32>(&vm, "example", "factorial 5")
+        .sync_or_error()
+        .unwrap();
     let expected = (120, Type::int());
 
     assert_eq!(result, expected);
@@ -58,6 +62,7 @@ fn use_string_module() {
                             "example",
                             " let string = import \"std/string.glu\" in string.trim \"  Hello \
                              world  \t\" ")
+        .sync_or_error()
         .unwrap();
     let expected = ("Hello world".to_string(), Type::string());
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -578,7 +578,7 @@ in id 1
 fn run_expr_int() {
     let _ = ::env_logger::init();
 
-    let text = r#"io.run_expr_async "123" "#;
+    let text = r#"io.run_expr "123" "#;
     let mut vm = make_vm();
     let (result, _) = Compiler::new()
         .run_io_expr_async::<IO<String>>(&mut vm, "<top>", text)
@@ -594,7 +594,7 @@ fn run_expr_int() {
 }
 
 test_expr!{ io run_expr_io,
-r#"io_flat_map (\x -> io_pure 100) (io.run_expr_async "io.print \"123\" ") "#,
+r#"io_flat_map (\x -> io_pure 100) (io.run_expr "io.print \"123\" ") "#,
 100i32
 }
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -314,7 +314,7 @@ match A with
 | B -> True
 ";
     let mut vm = make_vm();
-    let result = Compiler::new().run_expr::<bool>(&mut vm, "<top>", text).sync_or_error();
+    let result = Compiler::new().run_expr_async::<bool>(&mut vm, "<top>", text).sync_or_error();
     assert!(result.is_err());
 }
 
@@ -578,10 +578,12 @@ in id 1
 fn run_expr_int() {
     let _ = ::env_logger::init();
 
-    let text = r#"io.run_expr "123" "#;
+    let text = r#"io.run_expr_async "123" "#;
     let mut vm = make_vm();
-    let (result, _) =
-        Compiler::new().run_io_expr::<IO<String>>(&mut vm, "<top>", text).sync_or_error().unwrap();
+    let (result, _) = Compiler::new()
+        .run_io_expr_async::<IO<String>>(&mut vm, "<top>", text)
+        .sync_or_error()
+        .unwrap();
     match result {
         IO::Value(result) => {
             let expected = "123 : Int";
@@ -592,7 +594,7 @@ fn run_expr_int() {
 }
 
 test_expr!{ io run_expr_io,
-r#"io_flat_map (\x -> io_pure 100) (io.run_expr "io.print \"123\" ") "#,
+r#"io_flat_map (\x -> io_pure 100) (io.run_expr_async "io.print \"123\" ") "#,
 100i32
 }
 
@@ -609,7 +611,7 @@ in Cons 1 Nil == Nil
 "#;
     let mut vm = make_vm();
     let (result, _) = Compiler::new()
-        .run_expr::<bool>(&mut vm, "<top>", text)
+        .run_expr_async::<bool>(&mut vm, "<top>", text)
         .sync_or_error()
         .unwrap_or_else(|err| panic!("{}", err));
     let expected = false;
@@ -623,7 +625,7 @@ fn test_implicit_prelude() {
     let text = r#"Ok (Some (1.0 + 3.0 - 2.0)) "#;
     let mut vm = make_vm();
     Compiler::new()
-        .run_expr::<OpaqueValue<&Thread, Hole>>(&mut vm, "<top>", text)
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&mut vm, "<top>", text)
         .sync_or_error()
         .unwrap_or_else(|err| panic!("{}", err));
 }
@@ -645,7 +647,9 @@ fn access_operator_without_parentheses() {
     let _ = ::env_logger::init();
     let vm = make_vm();
     Compiler::new()
-        .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", r#" import "std/prelude.glu" "#)
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm,
+                                                      "example",
+                                                      r#" import "std/prelude.glu" "#)
         .sync_or_error()
         .unwrap();
     let result: Result<FunctionRef<fn(i32, i32) -> i32>, _> =
@@ -712,7 +716,7 @@ sender
 "#;
     let result = Compiler::new()
         .implicit_prelude(false)
-        .run_expr::<OpaqueValue<&Thread, Sender<f64>>>(&vm, "<top>", expr)
+        .run_expr_async::<OpaqueValue<&Thread, Sender<f64>>>(&vm, "<top>", expr)
         .sync_or_error();
     match result {
         Err(Error::Typecheck(..)) => (),
@@ -730,7 +734,7 @@ let s = "åäö"
 string.slice s 1 (string.length s)
 "#;
     let mut vm = make_vm();
-    let result = Compiler::new().run_expr::<String>(&mut vm, "<top>", text).sync_or_error();
+    let result = Compiler::new().run_expr_async::<String>(&mut vm, "<top>", text).sync_or_error();
     match result {
         Err(Error::VM(..)) => (),
         Err(err) => panic!("Unexpected error `{}`", err),
@@ -739,7 +743,7 @@ string.slice s 1 (string.length s)
 }
 
 #[test]
-fn dont_execute_io_in_run_expr() {
+fn dont_execute_io_in_run_expr_async() {
     let _ = ::env_logger::init();
     let vm = make_vm();
     let expr = r#"
@@ -748,7 +752,7 @@ let { pure } = prelude.applicative_IO
 pure 123
 "#;
     let value = Compiler::new()
-        .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example", expr)
         .sync_or_error()
         .unwrap_or_else(|err| panic!("{}", err));
     assert!(value.0.get_ref() != Value::Int(123),
@@ -761,8 +765,9 @@ fn dont_panic_on_partially_applied_constructor() {
     let _ = ::env_logger::init();
     let vm = make_vm();
 
-    let result =
-        Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "test", "Some").sync_or_error();
+    let result = Compiler::new()
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "test", "Some")
+        .sync_or_error();
     assert!(result.is_err());
 }
 
@@ -781,7 +786,7 @@ and g x = 1 + f (x / 2)
 g 10
 "#;
     let mut vm = make_vm();
-    let result = Compiler::new().run_expr::<i32>(&mut vm, "<top>", text).sync_or_error();
+    let result = Compiler::new().run_expr_async::<i32>(&mut vm, "<top>", text).sync_or_error();
     match result {
         Err(Error::VM(..)) => {
             let stacktrace = vm.context().stack.stacktrace(1);

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -19,6 +19,8 @@ collect-mac = "0.1.0"
 pretty = "0.2.0"
 bitflags = "0.7.0"
 itertools = "0.5.6"
+futures = "0.1.0"
+
 gluon_base = { path = "../base", version = "0.2.2" }
 gluon_check = { path = "../check", version = "0.2.2" }
 

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -872,6 +872,9 @@ impl<F> VmType for FutureResult<F>
     fn make_type(vm: &Thread) -> ArcType {
         <F::Item>::make_type(vm)
     }
+    fn extra_args() -> VmIndex {
+        <F::Item>::extra_args()
+    }
 }
 impl<'vm, F> AsyncPushable<'vm> for FutureResult<F>
     where F: Future<Error = Error> + Send + 'static,

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -877,15 +877,11 @@ impl<'vm, F> AsyncPushable<'vm> for FutureResult<F>
     where F: Future<Error = Error> + Send + 'static,
           F::Item: Pushable<'vm>,
 {
-    fn async_push(mut self, vm: &'vm Thread, context: &mut Context) -> Result<Async<()>> {
-        match self.0.poll() {
-            Ok(Async::Ready(value)) => value.push(vm, context).map(Async::Ready),
-            Ok(Async::NotReady) => unsafe {
-                context.return_future(self.0);
-                Ok(Async::NotReady)
-            },
-            Err(err) => Err(err),
+    fn async_push(self, _: &'vm Thread, context: &mut Context) -> Result<Async<()>> {
+        unsafe {
+            context.return_future(self.0);
         }
+        Ok(Async::NotReady)
     }
 }
 

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -2,7 +2,7 @@
 use {Variants, Error, Result};
 use gc::{DataDef, Gc, Traverseable, Move};
 use base::symbol::Symbol;
-use stack::{State, StackFrame};
+use stack::StackFrame;
 use vm::{self, Thread, Status, RootStr, RootedValue, Root};
 use value::{ArrayRepr, Cloner, DataStruct, ExternFunction, GcStr, Value, ValueArray, Def};
 use thread::{self, Context, OwnedContext, RootedThread};
@@ -1841,7 +1841,6 @@ impl<'vm, T, $($args,)* R> Function<T, fn($($args),*) -> R>
     fn call_first(&'vm self $(, $args: $args)*) -> Result<Async<Option<OwnedContext<'vm>>>> {
         let vm = self.value.vm();
         let mut context = vm.context();
-        StackFrame::current(&mut context.stack).enter_scope(0, State::Unknown);
         context.stack.push(*self.value);
         $(
             $args.push(&vm, &mut context)?;

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 use base::types::{ArcType, Type};
 
 use {Error, Result as VmResult};
-use api::{Generic, VmType, primitive, WithVM, Function, Pushable, RuntimeResult};
+use api::{Generic, VmType, primitive, WithVM, Function, AsyncPushable, Pushable, RuntimeResult};
 use api::generic::A;
 use gc::{Traverseable, Gc, GcPtr};
 use vm::{Thread, RootedThread, Status};
@@ -132,8 +132,7 @@ extern "C" fn resume(vm: &Thread) -> Status {
             context = vm.context();
             context.stack.release_lock(lock);
             match result {
-                Ok(()) |
-                Err(Error::Yield) => {
+                Ok(_) => {
                     let value: Result<(), &str> = Ok(());
                     value.status_push(vm, &mut context)
                 }

--- a/vm/src/future.rs
+++ b/vm/src/future.rs
@@ -1,4 +1,5 @@
-use futures::{Async, Future, Poll};
+use futures::{AndThen, Async, Future, Map, MapErr, OrElse, Poll, Then};
+use futures::future::{Either, FutureResult};
 
 use Error;
 
@@ -8,10 +9,12 @@ use Error;
 pub enum FutureValue<F>
     where F: Future,
 {
-    Value(F::Item),
+    Value(Result<F::Item, F::Error>),
     Future(F),
     Polled,
 }
+
+pub type BoxFutureValue<'a, T, E> = FutureValue<Box<Future<Item = T, Error = E> + Send + 'a>>;
 
 impl<F> FutureValue<F>
     where F: Future<Error = Error>,
@@ -19,13 +22,114 @@ impl<F> FutureValue<F>
     /// Returns the resolved `value` if it was synchronously computed or an error otherwise
     pub fn sync_or_error(self) -> Result<F::Item, Error> {
         match self {
-            FutureValue::Value(v) => Ok(v),
+            FutureValue::Value(v) => v,
             FutureValue::Future(_) => {
                 Err(Error::Message("Future needs to be resolved asynchronously".into()))
             }
             FutureValue::Polled => {
                 panic!("`FutureValue` may not be polled again if it contained a value")
             }
+        }
+    }
+}
+
+impl<T, E> FutureValue<FutureResult<T, E>> {
+    pub fn sync(result: Result<T, E>) -> FutureValue<FutureResult<T, E>> {
+        FutureValue::Value(result)
+    }
+}
+
+impl<'f, F> FutureValue<F>
+    where F: Future + 'f,
+{
+    pub fn boxed(self) -> FutureValue<Box<Future<Item = F::Item, Error = F::Error> + Send + 'f>>
+        where F: Send,
+    {
+        match self {
+            FutureValue::Value(v) => FutureValue::Value(v),
+            FutureValue::Future(f) => FutureValue::Future(Box::new(f)),
+            FutureValue::Polled => FutureValue::Polled,
+        }
+    }
+
+    pub fn map<G, U>(self, g: G) -> FutureValue<Map<F, G>>
+        where G: FnOnce(F::Item) -> U,
+    {
+        match self {
+            FutureValue::Value(v) => FutureValue::Value(v.map(g)),
+            FutureValue::Future(f) => FutureValue::Future(f.map(g)),
+            FutureValue::Polled => FutureValue::Polled,
+        }
+    }
+
+    pub fn map_err<G, U>(self, g: G) -> FutureValue<MapErr<F, G>>
+        where G: FnOnce(F::Error) -> U,
+    {
+        match self {
+            FutureValue::Value(v) => FutureValue::Value(v.map_err(g)),
+            FutureValue::Future(f) => FutureValue::Future(f.map_err(g)),
+            FutureValue::Polled => FutureValue::Polled,
+        }
+    }
+
+    pub fn and_then<G, B>(self, g: G) -> FutureValue<Either<B, AndThen<F, FutureValue<B>, G>>>
+        where G: FnOnce(F::Item) -> FutureValue<B>,
+              B: Future<Error = F::Error>,
+    {
+        match self {
+            FutureValue::Value(v) => {
+                match v {
+                    Ok(v) => {
+                        match g(v) {
+                            FutureValue::Value(v) => FutureValue::Value(v),
+                            FutureValue::Future(f) => FutureValue::Future(Either::A(f)),
+                            FutureValue::Polled => FutureValue::Polled,
+                        }
+                    }
+                    Err(err) => FutureValue::Value(Err(err)),
+                }
+            }
+            FutureValue::Future(f) => FutureValue::Future(Either::B(f.and_then(g))),
+            FutureValue::Polled => FutureValue::Polled,
+        }
+    }
+
+    pub fn then<G, B>(self, g: G) -> FutureValue<Either<B, Then<F, FutureValue<B>, G>>>
+        where G: FnOnce(Result<F::Item, F::Error>) -> FutureValue<B>,
+              B: Future<Error = F::Error>,
+    {
+        match self {
+            FutureValue::Value(v) => {
+                match g(v) {
+                    FutureValue::Value(v) => FutureValue::Value(v),
+                    FutureValue::Future(f) => FutureValue::Future(Either::A(f)),
+                    FutureValue::Polled => FutureValue::Polled,
+                }
+            }
+            FutureValue::Future(f) => FutureValue::Future(Either::B(f.then(g))),
+            FutureValue::Polled => FutureValue::Polled,
+        }
+    }
+
+    pub fn or_else<G, B>(self, g: G) -> FutureValue<Either<B, OrElse<F, FutureValue<B>, G>>>
+        where G: FnOnce(F::Error) -> FutureValue<B>,
+              B: Future<Item = F::Item>,
+    {
+        match self {
+            FutureValue::Value(v) => {
+                match v {
+                    Ok(v) => FutureValue::Value(Ok(v)),
+                    Err(err) => {
+                        match g(err) {
+                            FutureValue::Value(v) => FutureValue::Value(v),
+                            FutureValue::Future(f) => FutureValue::Future(Either::A(f)),
+                            FutureValue::Polled => FutureValue::Polled,
+                        }
+                    }
+                }
+            }
+            FutureValue::Future(f) => FutureValue::Future(Either::B(f.or_else(g))),
+            FutureValue::Polled => FutureValue::Polled,
         }
     }
 }
@@ -40,7 +144,7 @@ impl<F> Future for FutureValue<F>
         match *self {
             FutureValue::Value(_) => {
                 match ::std::mem::replace(self, FutureValue::Polled) {
-                    FutureValue::Value(v) => return Ok(Async::Ready(v)),
+                    FutureValue::Value(v) => return v.map(Async::Ready),
                     _ => unreachable!(),
                 }
             }
@@ -53,7 +157,7 @@ impl<F> Future for FutureValue<F>
 
     fn wait(self) -> Result<F::Item, F::Error> {
         match self {
-            FutureValue::Value(v) => Ok(v),
+            FutureValue::Value(v) => v,
             FutureValue::Future(f) => f.wait(),
             FutureValue::Polled => {
                 panic!("`FutureValue` may not be polled again if it contained a value")

--- a/vm/src/future.rs
+++ b/vm/src/future.rs
@@ -17,14 +17,15 @@ pub enum FutureValue<F>
 pub type BoxFutureValue<'a, T, E> = FutureValue<Box<Future<Item = T, Error = E> + Send + 'a>>;
 
 impl<F> FutureValue<F>
-    where F: Future<Error = Error>,
+    where F: Future,
+          F::Error: From<Error>,
 {
     /// Returns the resolved `value` if it was synchronously computed or an error otherwise
-    pub fn sync_or_error(self) -> Result<F::Item, Error> {
+    pub fn sync_or_error(self) -> Result<F::Item, F::Error> {
         match self {
             FutureValue::Value(v) => v,
             FutureValue::Future(_) => {
-                Err(Error::Message("Future needs to be resolved asynchronously".into()))
+                Err(Error::Message("Future needs to be resolved asynchronously".into()).into())
             }
             FutureValue::Polled => {
                 panic!("`FutureValue` may not be polled again if it contained a value")

--- a/vm/src/future.rs
+++ b/vm/src/future.rs
@@ -2,6 +2,9 @@ use futures::{Async, Future, Poll};
 
 use Error;
 
+/// `FutureValue` holds either an already computed value or a `Future` which can be resolved into
+/// that value. This makes it possible to avoid creating an event loop for computions which run
+/// synchronously.
 pub enum FutureValue<F>
     where F: Future,
 {
@@ -13,6 +16,7 @@ pub enum FutureValue<F>
 impl<F> FutureValue<F>
     where F: Future<Error = Error>,
 {
+    /// Returns the resolved `value` if it was synchronously computed or an error otherwise
     pub fn sync_or_error(self) -> Result<F::Item, Error> {
         match self {
             FutureValue::Value(v) => Ok(v),

--- a/vm/src/future.rs
+++ b/vm/src/future.rs
@@ -1,0 +1,59 @@
+use futures::{Async, Future, Poll};
+
+use Error;
+
+pub enum FutureValue<F>
+    where F: Future,
+{
+    Value(F::Item),
+    Future(F),
+    Polled,
+}
+
+impl<F> FutureValue<F>
+    where F: Future<Error = Error>,
+{
+    pub fn sync_or_error(self) -> Result<F::Item, Error> {
+        match self {
+            FutureValue::Value(v) => Ok(v),
+            FutureValue::Future(_) => {
+                Err(Error::Message("Future needs to be resolved asynchronously".into()))
+            }
+            FutureValue::Polled => {
+                panic!("`FutureValue` may not be polled again if it contained a value")
+            }
+        }
+    }
+}
+
+impl<F> Future for FutureValue<F>
+    where F: Future,
+{
+    type Item = F::Item;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<F::Item, F::Error> {
+        match *self {
+            FutureValue::Value(_) => {
+                match ::std::mem::replace(self, FutureValue::Polled) {
+                    FutureValue::Value(v) => return Ok(Async::Ready(v)),
+                    _ => unreachable!(),
+                }
+            }
+            FutureValue::Future(ref mut f) => f.poll(),
+            FutureValue::Polled => {
+                panic!("`FutureValue` may not be polled again if it contained a value")
+            }
+        }
+    }
+
+    fn wait(self) -> Result<F::Item, F::Error> {
+        match self {
+            FutureValue::Value(v) => Ok(v),
+            FutureValue::Future(f) => f.wait(),
+            FutureValue::Polled => {
+                panic!("`FutureValue` may not be polled again if it contained a value")
+            }
+        }
+    }
+}

--- a/vm/src/future.rs
+++ b/vm/src/future.rs
@@ -165,3 +165,13 @@ impl<F> Future for FutureValue<F>
         }
     }
 }
+
+#[macro_export]
+macro_rules! try_future {
+    ($e: expr) => {
+        match $e {
+            Ok(ok) => ok,
+            Err(err) => return $crate::future::FutureValue::Value(Err(err.into())),
+        }
+    }
+}

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -26,6 +26,7 @@ pub mod api;
 pub mod channel;
 pub mod compiler;
 pub mod debug;
+pub mod future;
 pub mod gc;
 pub mod macros;
 pub mod thread;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -14,6 +14,8 @@ extern crate collect_mac;
 extern crate bitflags;
 extern crate itertools;
 extern crate pretty;
+#[macro_use]
+extern crate futures;
 
 #[macro_use]
 extern crate gluon_base as base;
@@ -70,8 +72,6 @@ quick_error! {
     /// Representation of all possible errors that can occur when interacting with the `vm` crate
     #[derive(Debug, PartialEq)]
     pub enum Error {
-        Yield {
-        }
         Dead {
         }
         UndefinedBinding(symbol: String) {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -26,6 +26,7 @@ pub mod api;
 pub mod channel;
 pub mod compiler;
 pub mod debug;
+#[macro_use]
 pub mod future;
 pub mod gc;
 pub mod macros;

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -4,7 +4,7 @@ use std::result::Result as StdResult;
 
 use {Variants, Error};
 use primitives as prim;
-use api::{generic, Generic, Getable, Pushable, Array, RuntimeResult, primitive, WithVM};
+use api::{generic, Generic, Getable, AsyncPushable, Array, RuntimeResult, primitive, WithVM};
 use api::generic::A;
 use gc::{Gc, Traverseable, DataDef, WriteOnly};
 use Result;

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -606,7 +606,7 @@ impl ThreadInternal for Thread {
         context.stack.push(Closure(closure));
         context.borrow_mut().enter_scope(0, State::Closure(closure));
         context.execute().map(|async| match async {
-            Async::Ready(context) => FutureValue::Value((self, context.unwrap().stack.pop())),
+            Async::Ready(context) => FutureValue::Value(Ok((self, context.unwrap().stack.pop()))),
             Async::NotReady => FutureValue::Future(Execute::new(self)),
         })
     }
@@ -637,7 +637,7 @@ impl ThreadInternal for Thread {
             }
         }
         let _ = context.exit_scope();
-        Ok(FutureValue::Value((self, result)))
+        Ok(FutureValue::Value(Ok((self, result))))
     }
 
     /// Calls a function on the stack.

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -953,15 +953,8 @@ impl<'b> OwnedContext<'b> {
     }
 
     fn execute(self) -> Result<Async<Option<OwnedContext<'b>>>> {
-        let start_frame = self.stack.get_frames().len();
         let mut maybe_context = Some(self);
         while let Some(mut context) = maybe_context {
-            // If the starting frame has been removed (because it is finished) then we return
-            // control back to the caller to continue processing any frames above the start
-            if context.stack.get_frames().len() < start_frame {
-                maybe_context = Some(context);
-                break;
-            }
             debug!("STACK\n{:?}", context.stack.get_frames());
             let state = context.borrow_mut().stack.frame.state;
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -10,6 +10,8 @@ use std::result::Result as StdResult;
 use std::sync::Arc;
 use std::usize;
 
+use futures::{Async, Future, Poll};
+
 use base::metadata::Metadata;
 use base::pos::Line;
 use base::symbol::Symbol;
@@ -33,6 +35,28 @@ use value::{Value, ClosureData, ClosureInitDef, ClosureDataDef, Def, ExternFunct
 use value::Value::{Int, Float, String, Data, Function, PartialApplication, Closure};
 
 pub use gc::Traverseable;
+
+pub struct Execute<T> {
+    thread: T,
+}
+
+impl<T> Execute<T>
+    where T: Deref<Target = Thread>,
+{
+    pub fn new(thread: T) -> Execute<T> {
+        Execute { thread: thread }
+    }
+}
+
+impl<T> Future for Execute<T>
+    where T: Deref<Target = Thread>,
+{
+    type Item = Value;
+    type Error = Error;
+    fn poll(&mut self) -> Poll<Value, Error> {
+        self.thread.resume().map(|async| async.map(|mut context| context.stack.pop()))
+    }
+}
 
 /// Enum signaling a successful or unsuccess ful call to an extern function.
 /// If an error occured the error message is expected to be on the top of the stack.
@@ -84,6 +108,12 @@ impl<T> RootedValue<T>
 {
     pub fn vm(&self) -> &Thread {
         &self.vm
+    }
+
+    pub fn clone_vm(&self) -> T
+        where T: Clone,
+    {
+        self.vm.clone()
     }
 }
 
@@ -379,10 +409,8 @@ impl Thread {
     /// Runs a garbage collection.
     pub fn collect(&self) {
         let mut context = self.current_context();
-        self.with_roots(&mut context, |gc, roots| {
-            unsafe {
-                gc.collect(roots);
-            }
+        self.with_roots(&mut context, |gc, roots| unsafe {
+            gc.collect(roots);
         })
     }
 
@@ -443,14 +471,6 @@ impl Thread {
         };
         f(&mut context.gc, roots)
     }
-
-    fn call_context<'b>(&'b self,
-                        mut context: OwnedContext<'b>,
-                        args: VmIndex)
-                        -> Result<Option<OwnedContext<'b>>> {
-        context.borrow_mut().do_call(args)?;
-        context.execute()
-    }
 }
 
 /// Internal functions for interacting with threads. These functions should be considered both
@@ -479,10 +499,10 @@ pub trait ThreadInternal {
                     -> Result<()>;
 
     /// Evaluates a zero argument function (a thunk)
-    fn call_thunk(&self, closure: GcPtr<ClosureData>) -> Result<Value>;
+    fn call_thunk(&self, closure: GcPtr<ClosureData>) -> Execute<&Self>;
 
     /// Executes an `IO` action
-    fn execute_io(&self, value: Value) -> Result<Value>;
+    fn execute_io(&self, value: Value) -> Result<Async<Value>>;
 
     /// Calls a function on the stack.
     /// When this function is called it is expected that the function exists at
@@ -490,9 +510,9 @@ pub trait ThreadInternal {
     fn call_function<'b>(&'b self,
                          stack: OwnedContext<'b>,
                          args: VmIndex)
-                         -> Result<Option<OwnedContext<'b>>>;
+                         -> Result<Async<Option<OwnedContext<'b>>>>;
 
-    fn resume(&self) -> Result<()>;
+    fn resume(&self) -> Result<Async<OwnedContext>>;
 
     fn global_env(&self) -> &Arc<GlobalVmState>;
 
@@ -508,7 +528,6 @@ pub trait ThreadInternal {
 
     fn can_share_values_with(&self, gc: &mut Gc, other: &Thread) -> bool;
 }
-
 
 impl ThreadInternal for Thread {
     fn context(&self) -> OwnedContext {
@@ -570,16 +589,15 @@ impl ThreadInternal for Thread {
         Ok(())
     }
 
-    fn call_thunk(&self, closure: GcPtr<ClosureData>) -> Result<Value> {
+    fn call_thunk(&self, closure: GcPtr<ClosureData>) -> Execute<&Thread> {
         let mut context = self.current_context();
         context.stack.push(Closure(closure));
         context.borrow_mut().enter_scope(0, State::Closure(closure));
-        context.execute()?;
-        Ok(self.current_context().stack.pop())
+        Execute { thread: self }
     }
 
     /// Calls a module, allowed to to run IO expressions
-    fn execute_io(&self, value: Value) -> Result<Value> {
+    fn execute_io(&self, value: Value) -> Result<Async<Value>> {
         debug!("Run IO {:?}", value);
         let mut context = OwnedContext {
             thread: self,
@@ -592,7 +610,7 @@ impl ThreadInternal for Thread {
         context.stack.push(Int(0));
 
         context.borrow_mut().enter_scope(2, State::Unknown);
-        context = self.call_context(context, 1)?
+        context = try_ready!(self.call_function(context, 1))
             .expect("call_module to have the stack remaining");
         let result = context.stack.pop();
         {
@@ -602,27 +620,28 @@ impl ThreadInternal for Thread {
             }
         }
         let _ = context.exit_scope();
-        Ok(result)
+        Ok(Async::Ready(result))
     }
 
     /// Calls a function on the stack.
     /// When this function is called it is expected that the function exists at
     /// `stack.len() - args - 1` and that the arguments are of the correct type
     fn call_function<'b>(&'b self,
-                         context: OwnedContext<'b>,
+                         mut context: OwnedContext<'b>,
                          args: VmIndex)
-                         -> Result<Option<OwnedContext<'b>>> {
-        self.call_context(context, args)
+                         -> Result<Async<Option<OwnedContext<'b>>>> {
+        context.borrow_mut().do_call(args)?;
+        context.execute()
     }
 
-    fn resume(&self) -> Result<()> {
-        let context = self.current_context();
+    fn resume(&self) -> Result<Async<OwnedContext>> {
+        let mut context = self.current_context();
         if context.stack.get_frames().len() == 1 {
             // Only the top level frame left means that the thread has finished
             return Err(Error::Dead);
         }
-        context.execute()
-            .map(|_| ())
+        context = try_ready!(context.execute()).unwrap();
+        Ok(Async::Ready(context))
     }
 
     fn global_env(&self) -> &Arc<GlobalVmState> {
@@ -645,7 +664,7 @@ impl ThreadInternal for Thread {
         let mut cloner = ::value::Cloner::new(self, &mut context.gc);
         if full_clone {
             cloner.force_full_clone();
-    }
+        }
         cloner.deep_clone(value)
     }
 
@@ -802,6 +821,8 @@ pub struct Context {
     record_map: FieldMap,
     hook: Hook,
     max_stack_size: VmIndex,
+
+    poll_fn: Option<Box<FnMut(&Thread, &mut Context) -> Result<Async<()>> + Send>>,
 }
 
 impl Context {
@@ -816,6 +837,7 @@ impl Context {
                 previous_instruction_index: usize::max_value(),
             },
             max_stack_size: VmIndex::max_value(),
+            poll_fn: None,
         }
     }
 
@@ -852,6 +874,18 @@ impl Context {
 
     pub fn set_max_stack_size(&mut self, limit: VmIndex) {
         self.max_stack_size = limit;
+    }
+
+    pub unsafe fn return_future<'vm, F>(&mut self, mut future: F)
+        where F: Future<Error = Error> + Send + 'static,
+              F::Item: Pushable<'vm>,
+    {
+        use std::mem::transmute;
+        self.poll_fn = Some(Box::new(move |vm, context| {
+            let vm = transmute::<&Thread, &'vm Thread>(vm);
+            let value = try_ready!(future.poll());
+            value.push(vm, context).map(Async::Ready)
+        }));
     }
 }
 
@@ -910,7 +944,7 @@ impl<'b> OwnedContext<'b> {
         if exists { Ok(self) } else { Err(()) }
     }
 
-    fn execute(self) -> Result<Option<OwnedContext<'b>>> {
+    fn execute(self) -> Result<Async<Option<OwnedContext<'b>>>> {
         let mut maybe_context = Some(self);
         while let Some(mut context) = maybe_context {
             debug!("STACK\n{:?}", context.stack.get_frames());
@@ -936,16 +970,28 @@ impl<'b> OwnedContext<'b> {
             }
 
             maybe_context = match state {
-                State::Lock | State::Unknown => return Ok(Some(context)),
+                State::Lock | State::Unknown => return Ok(Async::Ready(Some(context))),
                 State::Excess => context.exit_scope().ok(),
                 State::Extern(ext) => {
                     let instruction_index = context.borrow_mut().stack.frame.instruction_index;
                     if instruction_index != 0 {
                         // This function was already called
-                        return Ok(Some(context));
+                        return Ok(Async::Ready(Some(context)));
                     } else {
+                        let thread = context.thread;
                         context.borrow_mut().stack.frame.instruction_index = 1;
-                        Some(context.execute_function(&ext)?)
+                        let result = context.execute_function(&ext);
+                        match result {
+                            Ok(Async::Ready(context)) => Some(context),
+                            Ok(Async::NotReady) => {
+                                let mut context = thread.current_context();
+                                if context.poll_fn.is_some() {
+                                    context.borrow_mut().stack.frame.instruction_index = 0;
+                                }
+                                return Ok(Async::NotReady);
+                            }
+                            Err(err) => return Err(err),
+                        }
                     }
                 }
                 State::Closure(closure) => {
@@ -978,8 +1024,7 @@ impl<'b> OwnedContext<'b> {
                                    closure.function.instructions.len());
 
                             let new_context = context.execute_(instruction_index,
-                                          &closure.function
-                                              .instructions,
+                                          &closure.function.instructions,
                                           &closure.function)?;
                             if new_context.is_some() {
                                 State::Exists
@@ -991,22 +1036,34 @@ impl<'b> OwnedContext<'b> {
                     match state {
                         State::Exists => Some(context),
                         State::DoesNotExist => None,
-                        State::ReturnContext => return Ok(Some(context)),
+                        State::ReturnContext => return Ok(Async::Ready(Some(context))),
                     }
                 }
             };
         }
-        Ok(maybe_context)
+        Ok(Async::Ready(maybe_context))
     }
 
-    fn execute_function(mut self, function: &ExternFunction) -> Result<OwnedContext<'b>> {
+    fn execute_function(mut self, function: &ExternFunction) -> Result<Async<OwnedContext<'b>>> {
         debug!("CALL EXTERN {} {:?}", function.id, self.stack);
-        // Make sure that the stack is not borrowed during the external function call
-        // Necessary since we do not know what will happen during the function call
-        let thread = self.thread;
-        drop(self);
-        let status = (function.function)(thread);
-        self = thread.current_context();
+        let status = if let Some(mut poll_fn) = self.poll_fn.take() {
+            let result = poll_fn(self.thread, &mut self);
+            self.poll_fn = Some(poll_fn);
+            try_ready!(result);
+            self.poll_fn = None;
+            Status::Ok
+        } else {
+            // Make sure that the stack is not borrowed during the external function call
+            // Necessary since we do not know what will happen during the function call
+            let thread = self.thread;
+            drop(self);
+            let status = (function.function)(thread);
+            self = thread.current_context();
+            if self.poll_fn.is_some() && status == Status::Yield {
+                return Ok(Async::NotReady);
+            }
+            status
+        };
         let result = self.stack.pop();
         {
             let mut stack = self.stack.current_frame();
@@ -1024,8 +1081,8 @@ impl<'b> OwnedContext<'b> {
         self.stack.push(result);
 
         match status {
-            Status::Ok => Ok(self),
-            Status::Yield => Err(Error::Yield),
+            Status::Ok => Ok(Async::Ready(self)),
+            Status::Yield => Ok(Async::NotReady),
             Status::Error => {
                 match self.stack.pop() {
                     String(s) => Err(Error::Panic(s.to_string())),

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -647,7 +647,7 @@ impl fmt::Debug for ExternFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // read the v-table pointer of the Fn(..) type and print that
         let p: *const () = unsafe { ::std::mem::transmute(self.function) };
-        write!(f, "{:?}", p)
+        write!(f, "{} {:?}", self.id, p)
     }
 }
 


### PR DESCRIPTION
This PR makes it possible to perform asynchronous computations in extern functions called from gluon. To make this relatively convenient the `FutureResult` type is provided which wraps a future and lets the virtual machine know that it needs to resolve the future to get hold of the value. `FutureValue` was added so that an event loop won't be required for normal, synchronous computations.