### PR TITLE
fix(check): Only mark the span of `let` and `type` expressions body

### DIFF
--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -7,7 +7,7 @@ extern crate gluon_parser as parser;
 extern crate gluon_check as check;
 
 use base::pos::Spanned;
-use base::types;
+use base::types::{self, Type};
 
 mod support;
 
@@ -388,4 +388,19 @@ type Foo = Test Int
 "#;
     let result = support::typecheck(text);
     assert_err!(result, KindError(TypeMismatch(..)));
+}
+
+#[test]
+fn type_error_span() {
+    use base::pos::Span;
+
+    let _ = ::env_logger::init();
+    let text = r#"
+let y = 1.0
+y
+"#;
+    let result = support::typecheck_expr_expected(text, Some(&Type::int())).1;
+    let errors: Vec<_> = result.unwrap_err().into();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].span, Span::new(13.into(), 14.into()));
 }

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -127,7 +127,9 @@ impl<T> IdentEnv for MockIdentEnv<T>
     }
 }
 
-pub fn typecheck_expr(text: &str) -> (SpannedExpr<Symbol>, Result<ArcType, typecheck::Error>) {
+pub fn typecheck_expr_expected(text: &str,
+                               expected: Option<&ArcType>)
+                               -> (SpannedExpr<Symbol>, Result<ArcType, typecheck::Error>) {
     let mut expr = parse_new(text).unwrap_or_else(|(_, err)| panic!("{}", err));
 
     let env = MockEnv::new();
@@ -135,9 +137,13 @@ pub fn typecheck_expr(text: &str) -> (SpannedExpr<Symbol>, Result<ArcType, typec
     let mut interner = interner.borrow_mut();
     let mut tc = Typecheck::new("test".into(), &mut interner, &env);
 
-    let result = tc.typecheck_expr(&mut expr);
+    let result = tc.typecheck_expr_expected(&mut expr, expected);
 
     (expr, result)
+}
+
+pub fn typecheck_expr(text: &str) -> (SpannedExpr<Symbol>, Result<ArcType, typecheck::Error>) {
+    typecheck_expr_expected(text, None)
 }
 
 #[allow(dead_code)]

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -874,6 +874,20 @@ fn suggestion_from_implicit_prelude() {
     assert!(!result.is_empty());
 }
 
+/// Would cause panics in `Source` as the spans from the implicit prelude were used with the
+/// `Source` from the normal expression
+#[test]
+fn dont_use_the_implicit_prelude_span_in_the_top_expr() {
+    let _ = ::env_logger::init();
+    let vm = make_vm();
+
+    let expr = "1";
+
+    Compiler::new()
+        .typecheck_str(&vm, "example", expr, Some(&Type::float()))
+        .unwrap_err();
+}
+
 #[test]
 fn value_size() {
     assert!(::std::mem::size_of::<Value>() <= 16);


### PR DESCRIPTION
Also fixes an issue with the implicit prelude which would cause a panic in source.rs