### PR TITLE
feat(vm): Add a from_ut8 method for converting `Array Byte` into `String`

### DIFF
--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -22,6 +22,21 @@ mod rename;
 pub mod completion;
 pub mod metadata;
 
+use base::types::{ArcType, TypeEnv};
+
+/// Checks if `actual` can be assigned to a binding with the type signature `signature`
+pub fn check_signature(env: &TypeEnv, signature: &ArcType, actual: &ArcType) -> bool {
+    use base::scoped_map::ScopedMap;
+    use base::fnv::FnvMap;
+
+    use substitution::Substitution;
+
+    let subs = Substitution::new();
+    let state = unify_type::State::new(env, &subs);
+    let actual = unify_type::instantiate_generic_variables(&mut FnvMap::default(), &subs, actual);
+    unify_type::merge_signature(&subs, &mut ScopedMap::new(), 0, state, &signature, &actual).is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;

--- a/std/string.glu
+++ b/std/string.glu
@@ -35,5 +35,6 @@ let show : Show String = {
     slice = string_prim.slice,
     starts_with = string_prim.starts_with,
     ends_with = string_prim.ends_with,
+    from_utf8 = string_prim.from_utf8,
     monoid
 }

--- a/tests/pass/string.glu
+++ b/tests/pass/string.glu
@@ -9,6 +9,9 @@ let string = import "std/string.glu"
 
 let assert_oieq = assert_eq (prelude.show_Option prelude.show_Int) (prelude.eq_Option prelude.eq_Int)
 let assert_beq = assert_eq prelude.show_Bool prelude.eq_Bool
+let assert_req =
+    assert_eq (prelude.show_Result prelude.show_Unit string.show)
+              (prelude.eq_Result prelude.eq_Unit string.eq)
 
 let slice_tests =
     assert_seq (string.slice "ab" 0 1) "a"
@@ -46,7 +49,14 @@ let trim_tests =
         *> assert_seq (string.trim_left " ab ") "ab "
         *> assert_seq (string.trim_right " ab ") " ab"
 
+let from_utf8_tests =
+    assert_req (string.from_utf8 []) (Ok "") *>
+        assert_req (string.from_utf8 [32b]) (Ok " ") *>
+        assert_req (string.from_utf8 [195b, 165b, 195b, 164b, 195b, 182b]) (Ok "åäö") *>
+        assert_req (string.from_utf8 [195b, 165b, 195b, 164b, 195b]) (Err ()) *>
+        assert_req (string.from_utf8 [195b, 165b, 195b, 195b, 182b]) (Err ())
+
 let tests =
-    slice_tests *> append_tests *> find_tests
+    slice_tests *> append_tests *> find_tests *> from_utf8_tests
 
 run tests

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -1,0 +1,54 @@
+extern crate env_logger;
+
+extern crate gluon;
+
+mod support;
+
+use gluon::vm::api::{FunctionRef, OpaqueValue};
+use gluon::vm::reference::Reference;
+use gluon::{Compiler, RootedThread, Thread};
+
+use support::*;
+
+fn verify_value_cloned(from: &Thread, to: &Thread) {
+    let expr = r#" ref 0 "#;
+
+    let (value, _) = Compiler::new()
+        .run_expr::<OpaqueValue<RootedThread, Reference<i32>>>(&from, "example", expr)
+        .unwrap_or_else(|err| panic!("{}", err));
+
+    // Load the prelude
+    type Fn<'t> = FunctionRef<'t, fn(OpaqueValue<RootedThread, Reference<i32>>)>;
+    let (mut store_1, _) = Compiler::new()
+        .run_expr::<Fn>(&to, "store_1", r#"\r -> r <- 1"#)
+        .unwrap();
+    assert_eq!(store_1.call(value.clone()), Ok(()));
+
+    let mut load: FunctionRef<fn(OpaqueValue<RootedThread, Reference<i32>>) -> i32> =
+        from.get_global("load").unwrap();
+    assert_eq!(load.call(value), Ok(0));
+}
+
+#[test]
+fn cant_transfer_opaque_value_between_sibling_threads() {
+    let _ = ::env_logger::init();
+    //     vm
+    //  /     \
+    // vm1    vm2
+    // Passing a value directly from vm1 to vm2 requires the value to be cloned in its entirety
+    let vm = make_vm();
+    let vm1 = vm.new_thread().unwrap();
+    let vm2 = vm.new_thread().unwrap();
+    verify_value_cloned(&vm1, &vm2);
+}
+
+#[test]
+fn cant_transfer_opaque_value_between_disjoint_threads() {
+    let _ = ::env_logger::init();
+    // vm1    vm2
+    // Passing a value directly from vm1 to vm2 requires the value to be cloned in its entirety
+    // since the vms do not share the same global vm
+    let vm1 = make_vm();
+    let vm2 = make_vm();
+    verify_value_cloned(&vm1, &vm2);
+}

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -642,6 +642,31 @@ fn access_operator_without_parentheses() {
 }
 
 #[test]
+fn get_binding_with_alias_type() {
+    let _ = ::env_logger::init();
+    let text = r#"
+        type Test = Int
+        let x: Test = 0
+        { Test, x }
+        "#;
+    let mut vm = make_vm();
+    load_script(&mut vm, "test", text).unwrap_or_else(|err| panic!("{}", err));
+    let test_x = vm.get_global("test.x");
+    assert_eq!(test_x, Ok(0));
+}
+
+#[test]
+fn get_binding_with_generic_params() {
+    let _ = ::env_logger::init();
+
+    let mut vm = make_vm();
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import "std/prelude.glu" "#);
+    let mut id: FunctionRef<fn(String) -> String> = vm.get_global("std.prelude.id")
+        .unwrap_or_else(|err| panic!("{}", err));
+    assert_eq!(id.call("test".to_string()), Ok("test".to_string()));
+}
+
+#[test]
 fn test_prelude() {
     let _ = ::env_logger::init();
     let vm = make_vm();

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -17,6 +17,7 @@ quick-error = "1.1.0"
 mopa = "0.2.2"
 collect-mac = "0.1.0"
 gluon_base = { path = "../base", version = "0.2.2" }
+gluon_check = { path = "../check", version = "0.2.2" }
 
 [features]
 test = ["env_logger"]

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -905,6 +905,13 @@ impl<T, V> fmt::Debug for OpaqueValue<T, V>
     }
 }
 
+impl<T, V> Clone for OpaqueValue<T, V>
+    where T: Deref<Target = Thread> + Clone,
+{
+    fn clone(&self) -> Self {
+        OpaqueValue(self.0.clone(), self.1.clone())
+    }
+}
 
 impl<T, V> OpaqueValue<T, V>
     where T: Deref<Target = Thread>,
@@ -1525,6 +1532,17 @@ pub struct Function<T, F>
 {
     value: RootedValue<T>,
     _marker: PhantomData<F>,
+}
+
+impl<T, F> Clone for Function<T, F>
+    where T: Deref<Target = Thread> + Clone,
+{
+    fn clone(&self) -> Self {
+        Function {
+            value: self.value.clone(),
+            _marker: self._marker.clone(),
+        }
+    }
 }
 
 impl<T, F> Function<T, F>

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -1572,10 +1572,20 @@ impl<'vm, T, F: Any> Pushable<'vm> for Function<T, F>
         Ok(())
     }
 }
+
 impl<'vm, F> Getable<'vm> for Function<&'vm Thread, F> {
     fn from_value(vm: &'vm Thread, value: Variants) -> Option<Function<&'vm Thread, F>> {
         Some(Function {
             value: vm.root_value_ref(*value.0),
+            _marker: PhantomData,
+        })//TODO not type safe
+    }
+}
+
+impl<'vm, F> Getable<'vm> for Function<RootedThread, F> {
+    fn from_value(vm: &'vm Thread, value: Variants) -> Option<Self> {
+        Some(Function {
+            value: vm.root_value(*value.0),
             _marker: PhantomData,
         })//TODO not type safe
     }

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -11,7 +11,7 @@ use api::generic::A;
 use gc::{Traverseable, Gc, GcPtr};
 use vm::{Thread, RootedThread, Status};
 use thread::ThreadInternal;
-use value::{Userdata, Value};
+use value::{GcStr, Userdata, Value};
 use stack::{State, StackFrame};
 
 pub struct Sender<T> {
@@ -143,7 +143,9 @@ extern "C" fn resume(vm: &Thread) -> Status {
                 }
                 Err(err) => {
                     let fmt = format!("{}", err);
-                    let result = Value::String(context.alloc_ignore_limit(&fmt[..]));
+                    let result = unsafe {
+                        Value::String(GcStr::from_utf8_unchecked(context.alloc_ignore_limit(fmt.as_bytes())))
+                    };
                     context.stack.push(result);
                     Status::Error
                 }

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -117,7 +117,7 @@ fn recv(receiver: &Receiver<Generic<A>>) -> Result<Generic<A>, ()> {
 }
 
 fn send(sender: &Sender<Generic<A>>, value: Generic<A>) -> Result<(), ()> {
-    let value = sender.thread.deep_clone_value(value.0).map_err(|_| ())?;
+    let value = sender.thread.deep_clone_value(&sender.thread, value.0).map_err(|_| ())?;
     Ok(sender.send(Generic::from(value)))
 }
 

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -5,12 +5,12 @@ use std::ops::Deref;
 use Result;
 use base::fnv::FnvMap;
 
-use gc::{GcPtr, Gc, Traverseable};
-use array::Str;
+use gc::{Gc, Traverseable};
+use value::GcStr;
 
 /// Interned strings which allow for fast equality checks and hashing
 #[derive(Copy, Clone, Eq)]
-pub struct InternedStr(GcPtr<Str>);
+pub struct InternedStr(GcStr);
 
 impl PartialEq<InternedStr> for InternedStr {
     fn eq(&self, other: &InternedStr) -> bool {
@@ -60,7 +60,7 @@ impl AsRef<str> for InternedStr {
 }
 
 impl InternedStr {
-    pub fn inner(&self) -> GcPtr<Str> {
+    pub fn inner(&self) -> GcStr {
         self.0
     }
 }
@@ -91,7 +91,7 @@ impl Interner {
             Some(interned_str) => return Ok(*interned_str),
             None => (),
         }
-        let gc_str = InternedStr(gc.alloc(s)?);
+        let gc_str = unsafe { InternedStr(GcStr::from_utf8_unchecked(gc.alloc(s.as_bytes())?)) };
         // The key will live as long as the value it refers to and the static str never escapes
         // outside interner so this is safe
         let key: &'static str = unsafe { ::std::mem::transmute::<&str, &'static str>(&gc_str) };

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -12,6 +12,7 @@ extern crate mopa;
 extern crate collect_mac;
 
 extern crate gluon_base as base;
+extern crate gluon_check as check;
 
 #[macro_use]
 pub mod api;

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -23,6 +23,7 @@ pub mod gc;
 pub mod macros;
 pub mod thread;
 pub mod primitives;
+pub mod reference;
 pub mod stack;
 pub mod types;
 
@@ -30,7 +31,6 @@ mod array;
 mod field_map;
 mod interner;
 mod lazy;
-mod reference;
 mod source_map;
 mod value;
 mod vm;

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -1,14 +1,16 @@
 //! Module containing functions for interacting with gluon's primitive types.
 use std::string::String as StdString;
+use std::result::Result as StdResult;
 
 use {Variants, Error};
 use primitives as prim;
-use api::{generic, Generic, Getable, Array, RuntimeResult, primitive, WithVM};
+use api::{generic, Generic, Getable, Pushable, Array, RuntimeResult, primitive, WithVM};
 use api::generic::A;
 use gc::{Gc, Traverseable, DataDef, WriteOnly};
 use Result;
 use vm::{Thread, Status};
-use value::{Value, ValueArray};
+use value::{Def, GcStr, Value, ValueArray};
+use stack::StackFrame;
 use thread::ThreadInternal;
 use types::VmInt;
 
@@ -80,7 +82,6 @@ fn array_append<'vm>(lhs: Array<'vm, Generic<generic::A>>,
 }
 
 fn string_append(lhs: WithVM<&str>, rhs: &str) -> RuntimeResult<String, Error> {
-    use array::Str;
     struct StrAppend<'b> {
         lhs: &'b str,
         rhs: &'b str,
@@ -89,20 +90,18 @@ fn string_append(lhs: WithVM<&str>, rhs: &str) -> RuntimeResult<String, Error> {
     impl<'b> Traverseable for StrAppend<'b> {}
 
     unsafe impl<'b> DataDef for StrAppend<'b> {
-        type Value = Str;
+        type Value = ValueArray;
         fn size(&self) -> usize {
-            ::array::Str::size_of(self.lhs.len() + self.rhs.len())
+            use std::mem::size_of;
+            size_of::<ValueArray>() + (self.lhs.len() + self.rhs.len()) * size_of::<u8>()
         }
-        fn initialize<'w>(self, mut result: WriteOnly<'w, Str>) -> &'w mut Str {
+        fn initialize<'w>(self, mut result: WriteOnly<'w, ValueArray>) -> &'w mut ValueArray {
+            use value::Repr;
             unsafe {
                 let result = &mut *result.as_mut_ptr();
-                {
-                    let array = Str::as_mut_array(result);
-                    ::array::Array::set_len(array, self.lhs.len() + self.rhs.len());
-                    let (l, r) = array.split_at_mut(self.lhs.len());
-                    l.clone_from_slice(self.lhs.as_bytes());
-                    r.clone_from_slice(self.rhs.as_bytes());
-                }
+                result.set_repr(Repr::Byte);
+                result.unsafe_array_mut::<u8>()
+                    .initialize(self.lhs.as_bytes().iter().chain(self.rhs.as_bytes()).cloned());
                 result
             }
         }
@@ -110,14 +109,14 @@ fn string_append(lhs: WithVM<&str>, rhs: &str) -> RuntimeResult<String, Error> {
 
     let vm = lhs.vm;
     let lhs = lhs.value;
-    let value = {
+    let value = unsafe {
         let mut context = vm.context();
         let result = context.alloc(StrAppend {
             lhs: lhs,
             rhs: rhs,
         });
         match result {
-            Ok(x) => x,
+            Ok(x) => GcStr::from_utf8_unchecked(x),
             Err(err) => return RuntimeResult::Panic(err),
         }
     };
@@ -137,6 +136,40 @@ fn string_slice(s: &str, start: usize, end: usize) -> RuntimeResult<&str, String
                                      start,
                                      end,
                                      &s[..(s.len() - iter.as_str().len())]))
+    }
+}
+
+extern "C" fn from_utf8(thread: &Thread) -> Status {
+    let mut context = thread.context();
+    let value = StackFrame::current(&mut context.stack)[0];
+    match value {
+        Value::Array(array) => {
+            match GcStr::from_utf8(array) {
+                Ok(string) => {
+                    let value = Value::String(string);
+                    let result = context.alloc_with(thread,
+                                                    Def {
+                                                        tag: 1,
+                                                        elems: &[value],
+                                                    });
+                    match result {
+                        Ok(data) => {
+                            context.stack.push(Value::Data(data));
+                            Status::Ok
+                        }
+                        Err(err) => {
+                            let result: RuntimeResult<(), _> = RuntimeResult::Panic(err);
+                            result.status_push(thread, &mut context)
+                        }
+                    }
+                }
+                Err(()) =>{
+                    let err: StdResult<&str, ()> = Err(());
+                    err.status_push(thread, &mut context)
+                }
+            }
+        }
+        _ => unreachable!(),
     }
 }
 
@@ -263,7 +296,8 @@ pub fn load(vm: &Thread) -> Result<()> {
         compare => primitive!(2 str::cmp),
         append => primitive!(2 prim::string_append),
         eq => primitive!(2 <str as PartialEq>::eq),
-        slice => primitive!(3 prim::string_slice)
+        slice => primitive!(3 prim::string_slice),
+        from_utf8 => primitive::<fn(Vec<u8>) -> StdResult<String, ()>>("from_utf8", prim::from_utf8)
     ))?;
     vm.define_global("char",
                        record!(

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -12,7 +12,7 @@ use value::{Value, Cloner};
 use api::{RuntimeResult, Generic, Userdata, VmType, WithVM};
 use api::generic::A;
 
-struct Reference<T> {
+pub struct Reference<T> {
     value: Mutex<Value>,
     thread: GcPtr<Thread>,
     _marker: PhantomData<T>,
@@ -60,7 +60,7 @@ impl<T> VmType for Reference<T>
 }
 
 fn set(r: &Reference<A>, a: Generic<A>) -> RuntimeResult<(), String> {
-    match r.thread.deep_clone_value(a.0) {
+    match r.thread.deep_clone_value(&r.thread, a.0) {
         Ok(a) => {
             *r.value.lock().unwrap() = a;
             RuntimeResult::Return(())

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -4,12 +4,11 @@ use std::sync::Mutex;
 use std::marker::PhantomData;
 
 use base::types::{Type, ArcType};
-use base::fnv::FnvMap;
 use Result;
 use gc::{Gc, GcPtr, Move, Traverseable};
 use vm::Thread;
 use thread::ThreadInternal;
-use value::{Value, deep_clone};
+use value::{Value, Cloner};
 use api::{RuntimeResult, Generic, Userdata, VmType, WithVM};
 use api::generic::A;
 
@@ -22,19 +21,15 @@ struct Reference<T> {
 impl<T> Userdata for Reference<T>
     where T: Any + Send + Sync,
 {
-    fn deep_clone(&self,
-                  visited: &mut FnvMap<*const (), Value>,
-                  gc: &mut Gc,
-                  thread: &Thread)
-                  -> Result<GcPtr<Box<Userdata>>> {
+    fn deep_clone(&self, deep_cloner: &mut Cloner) -> Result<GcPtr<Box<Userdata>>> {
         let value = self.value.lock().unwrap();
-        let cloned_value = deep_clone(*value, visited, gc, thread)?;
+        let cloned_value = deep_cloner.deep_clone(*value)?;
         let data: Box<Userdata> = Box::new(Reference {
             value: Mutex::new(cloned_value),
-            thread: unsafe { GcPtr::from_raw(thread) },
+            thread: unsafe { GcPtr::from_raw(deep_cloner.thread()) },
             _marker: PhantomData::<A>,
         });
-        gc.alloc(Move(data))
+        deep_cloner.gc().alloc(Move(data))
     }
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -347,11 +347,12 @@ impl Thread {
     pub fn get_global<'vm, T>(&'vm self, name: &str) -> Result<T>
         where T: Getable<'vm> + VmType,
     {
+        use check::check_signature;
         let env = self.get_env();
         let (value, actual) = env.get_binding(name)?;
         // Finally check that type of the returned value is correct
         let expected = T::make_type(self);
-        if expected == *actual {
+        if check_signature(&*env, &expected, &actual) {
             T::from_value(self, Variants(&value))
                 .ok_or_else(|| Error::UndefinedBinding(name.into()))
         } else {

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -14,7 +14,6 @@ use base::metadata::Metadata;
 use base::symbol::Symbol;
 use base::types::ArcType;
 use base::types;
-use base::fnv::FnvMap;
 
 use {Variants, Error, Result};
 use field_map::FieldMap;
@@ -644,18 +643,13 @@ impl ThreadInternal for Thread {
                   metadata: Metadata,
                   value: Value)
                   -> Result<()> {
-        let mut visited = FnvMap::default();
-        let value = ::value::deep_clone(value,
-                                        &mut visited,
-                                        &mut self.global_env().gc.lock().unwrap(),
-                                        self)?;
+        let value = ::value::Cloner::new(self, &mut self.global_env().gc.lock().unwrap()).deep_clone(value)?;
         self.global_env().set_global(name, typ, metadata, value)
     }
 
     fn deep_clone_value(&self, value: Value) -> Result<Value> {
-        let mut visited = FnvMap::default();
         let mut context = self.current_context();
-        ::value::deep_clone(value, &mut visited, &mut context.gc, self)
+        ::value::Cloner::new(self, &mut context.gc).deep_clone(value)
     }
 }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -16,7 +16,7 @@ use macros::MacroEnv;
 use {Error, Result};
 use types::*;
 use interner::{Interner, InternedStr};
-use gc::{Gc, GcPtr, Traverseable, Move};
+use gc::{Gc, GcPtr, Generation, Traverseable, Move};
 use compiler::{CompiledFunction, Variable, CompilerEnv};
 use api::IO;
 use lazy::Lazy;
@@ -325,7 +325,7 @@ impl GlobalVmState {
             generics: RwLock::new(FnvMap::default()),
             typeids: RwLock::new(FnvMap::default()),
             interner: RwLock::new(Interner::new()),
-            gc: Mutex::new(Gc::new(0, usize::MAX)),
+            gc: Mutex::new(Gc::new(Generation::default(), usize::MAX)),
             macros: MacroEnv::new(),
             generation_0_threads: RwLock::new(Vec::new()),
         };


### PR DESCRIPTION
The bulk of these changes are to replace the use of `GcPtr<Str>` with a type backed by the normal array type. This makes it possible to convert `Array Byte` directly into `String` without copying any data.

Based on #235 