### PR TITLE
fix(compiler): Pop the correct amount of variables in the compiler

### DIFF
--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -326,6 +326,14 @@ match { x = 1, y = "abc" } with
 4i32
 }
 
+test_expr!{ match_stack,
+r#"
+1 #Int+ (match string_prim with
+         | { length } -> length "abc")
+"#,
+4i32
+}
+
 test_expr!{ let_record_pattern,
 r#"
 let (+) x y = x #Int+ y


### PR DESCRIPTION
See compiler.rs:919-929. By using `Split` all fields in the value are pushed but when `Compiler::pop_pattern` is called to remove these variables it only removes the number of fields in the pattern (which may be fewer). To fix this I refactored the code a bit to use `ScopedMap` which is already used to do this kind of cleanup.

Extracted from #213, it has a few changes which aren't strictly necessary (new_stack_var taking a `&Compiler` argument) but is otherwise a pretty clean extraction.