### PR TITLE
Prevent the REPL from panicking when parsing an overflowing integer

### DIFF
--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1165,7 +1165,7 @@ impl<'t> Cloner<'t> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gc::Gc;
+    use gc::{Gc, Generation};
     use types::VmInt;
 
     use base::kind::{ArcKind, KindEnv};
@@ -1196,7 +1196,7 @@ mod tests {
 
     #[test]
     fn pretty_variant() {
-        let mut gc = Gc::new(0, usize::max_value());
+        let mut gc = Gc::new(Generation::default(), usize::max_value());
 
         let list = Symbol::from("List");
         let typ: ArcType = Type::variant(vec![Field {
@@ -1236,7 +1236,7 @@ mod tests {
 
     #[test]
     fn pretty_array() {
-        let mut gc = Gc::new(0, usize::max_value());
+        let mut gc = Gc::new(Generation::default(), usize::max_value());
 
         let typ = Type::array(Type::int());
 


### PR DESCRIPTION
Hello, while playing with the REPL I noticed that it would panic when trying to parse a big integer:

```
$ ./target/release/repl -i
> 12345678901234567890
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: ParseIntError { kind: Overflow }', ../src/libcore/result.rs:837
note: Run with `RUST_BACKTRACE=1` for a backtrace.
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Any', ../src/libcore/result.rs:837
```

So I investigated a bit and found out that `numeric_literal` in `parser/src/token.rs` would `unwrap` the integers it tried to parse, causing the panic. So I've added a new `ErrorCode` in this module to represent integer parse errors. There's also an `unwrap` for floating point parsing, but I can't find a way to make it panic so I guess it's fine.

This does not propagate a proper error message to the top level though. However, the behavior is the same as for other kinds of integer parsing issues, so this is probably comes from a larger issue.