### PR TITLE
fix(parser): Return tokenizer errors from the parser

### DIFF
--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -13,7 +13,7 @@ grammar<'input, 'env, Id>(src: &'input str, env: MutIdentEnv<'env, Id>, errors: 
 
 extern {
     type Location = BytePos;
-    type Error = Error;
+    type Error = Spanned<Error, BytePos>;
 
     enum Token<'input> {
         "Identifier" => Token::Identifier(<&'input str>),
@@ -100,7 +100,7 @@ AtomicKind: ArcKind = {
             "Type" => Ok(Kind::typ()),
             "Row" => Ok(Kind::row()),
             id => Err(ParseError::User {
-                error: Error::UnexpectedToken("Identifier".to_string()),
+                error: pos::spanned2(l.into(), r.into(), Error::UnexpectedToken("Identifier".to_string())),
             }),
         }
     },

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -17,16 +17,22 @@ use base::pos::{self, BytePos, Span, Spanned};
 use base::symbol::Symbol;
 use base::types::ArcType;
 
-use infix::{OpTable, Reparser, Error as InfixError};
-use layout::{Layout, Error as LayoutError};
-use token::{Token, Tokenizer, Error as TokenizeError};
+use infix::{OpTable, Reparser};
+use layout::Layout;
+use token::{Token, Tokenizer};
+
+pub use infix::Error as InfixError;
+pub use layout::Error as LayoutError;
+pub use token::Error as TokenizeError;
 
 mod grammar;
 mod infix;
 mod layout;
 mod token;
 
-type LalrpopError<'input> = lalrpop_util::ParseError<BytePos, Token<'input>, Error>;
+type LalrpopError<'input> = lalrpop_util::ParseError<BytePos,
+                                                     Token<'input>,
+                                                     Spanned<Error, BytePos>>;
 
 /// Shrink hidden spans to fit the visible expressions and flatten singleton blocks.
 fn shrink_hidden_spans<Id>(mut expr: SpannedExpr<Id>) -> SpannedExpr<Id> {
@@ -121,7 +127,7 @@ impl Error {
             ExtraToken { token: (lpos, token, rpos) } => {
                 pos::spanned2(lpos, rpos, Error::ExtraToken(token.to_string()))
             }
-            User { error } => pos::spanned2(0.into(), 0.into(), error),
+            User { error } => error,
         }
     }
 }
@@ -151,6 +157,7 @@ impl<I, E> ResultOkIter<I, E> {
 
 impl<I, T, E> Iterator for ResultOkIter<I, E>
     where I: Iterator<Item = Result<T, E>>,
+          E: ::std::fmt::Debug,
 {
     type Item = T;
 
@@ -215,15 +222,18 @@ pub fn parse_partial_expr<Id>(symbols: &mut IdentEnv<Ident = Id>,
     where Id: Clone,
 {
     let tokenizer = Tokenizer::new(input);
-    let result_ok_iter = RefCell::new(ResultOkIter {
-        iter: tokenizer,
-        error: None,
-    });
+    let result_ok_iter = RefCell::new(ResultOkIter::new(tokenizer));
 
     let layout = Layout::new(SharedIter::new(&result_ok_iter)).map(|token| {
         /// Return the tokenizer error if one exists
-        result_ok_iter.borrow_mut().result(())?;
-        let token = token?;
+        result_ok_iter.borrow_mut()
+            .result(())
+            .map_err(|err| {
+                pos::spanned2(err.span.start.absolute,
+                              err.span.end.absolute,
+                              err.value.into())
+            })?;
+        let token = token.map_err(|err| pos::spanned2(0.into(), 0.into(), err.into()))?;
         debug!("Lex {:?}", token.value);
         let Span { start, end, .. } = token.span;
         Ok((start.absolute, token.value, end.absolute))

--- a/parser/tests/error_handling.rs
+++ b/parser/tests/error_handling.rs
@@ -8,7 +8,7 @@ mod support;
 use base::ast::{TypedIdent, Pattern};
 use base::pos::{self, BytePos};
 
-use parser::{Error, ParseErrors};
+use parser::{Error, ParseErrors, TokenizeError};
 
 use support::*;
 
@@ -72,4 +72,34 @@ fn unclosed_string() {
 "abc
 "#);
     assert!(result.is_err());
+}
+
+#[test]
+fn tokenizer_error_is_returned() {
+    let _ = ::env_logger::init();
+
+    let result = parse(r#"
+12345678901234567890 test
+"#);
+
+    let error = Error::Token(TokenizeError::NonParseableInt);
+    let span = pos::span(BytePos::from(0), BytePos::from(0));
+    let errors = ParseErrors::from(vec![pos::spanned(span, error)]);
+
+    assert_eq!(result.map_err(|(_, err)| err), Err(errors));
+}
+
+#[test]
+fn tokenizer_error_at_eof_is_returned() {
+    let _ = ::env_logger::init();
+
+    let result = parse(r#"
+12345678901234567890
+"#);
+
+    let error = Error::Token(TokenizeError::NonParseableInt);
+    let span = pos::span(BytePos::from(0), BytePos::from(0));
+    let errors = ParseErrors::from(vec![pos::spanned(span, error)]);
+
+    assert_eq!(result.map_err(|(_, err)| err), Err(errors));
 }

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -659,7 +659,7 @@ fn get_binding_with_alias_type() {
 fn get_binding_with_generic_params() {
     let _ = ::env_logger::init();
 
-    let mut vm = make_vm();
+    let vm = make_vm();
     run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import "std/prelude.glu" "#);
     let mut id: FunctionRef<fn(String) -> String> = vm.get_global("std.prelude.id")
         .unwrap_or_else(|err| panic!("{}", err));

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -933,7 +933,7 @@ unsafe impl<'a> DataDef for &'a ValueArray {
             let result = &mut *result.as_mut_ptr();
             result.repr = self.repr;
             on_array!(self,
-                      |array: &Array<_>| result.unsafe_array_mut().initialize(array.iter().cloned()));
+                      |array: &Array<_>| { result.unsafe_array_mut().initialize(array.iter().cloned()) });
             result
         }
     }


### PR DESCRIPTION
Fixes the problem mentioned in #247 where tokenizer errors would not be propagated out from the parser