### PR TITLE
chore: Fix grammatical errors and touchup docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,30 +2,33 @@
 
 ## Filing bug reports
 
-It does not matter if you found a soundness issue in typechecker or found the documentation confusing. Either way filing a an issue to the [issue tracker][] is extremely helpful.
+It does not matter if you found a soundness issue in typechecker or found the documentation confusing. Either way filing an issue to the [issue tracker][] is extremely helpful.
 
 [issue tracker]:https://github.com/gluon-lang/gluon/issues
 
 ## Finding something to work on
 
-A good place to start is to look at the issues marked as [beginner][] which are issues that should be possible to work on without knowledge on the inner workings of Gluon.
+A good place to start is to look at the issues marked as [beginner][]. These are issues that should be possible to work on without knowledge on the inner workings of Gluon.
 
-If you find something that looks interesting then please leave a comment on the issue, that way you can get assistance quicker and there is no risk of duplicating work.
+If you find something that looks interesting, please leave a comment on the issue. That way, you can get assistance quicker and there is no risk of duplicating work.
 
 [beginner]:https://github.com/gluon-lang/gluon/labels/Beginner
 
 ## Building
 
-Gluon can build with version 1.9.0 of Rust or later but we recommend to use version 1.11.0 or later to avoid some very long compile times for the `gluon_parser` crate.
+Gluon can build with version 1.9.0 of Rust or later but we recommend version 1.11.0 or later to avoid some very long compile times for the `gluon_parser` crate.
 
 ## Testing
 
-To build and run all tests for Gluon you can use the `test.sh` script. If you look inside it you can see that it actually builds from the `c-api` directory (this is necessary as the `gluon_c-api` crate depends on the `gluon` crate). This means that all build artifacts end up in `c-api/target`. For this reason if you want to run tests only for a single crate you should run something like `(cd c-api && cargo test --features test -p gluon_check testname)`.
+To build and run all tests for Gluon you can use the `test.sh` script. If you look inside it, you can see that it actually builds from the `c-api` directory (this is necessary as the `gluon_c-api` crate depends on the `gluon` crate). This means that all build artifacts end up in `c-api/target`. For this reason, if you want to run tests only for a single crate, you should run something like `(cd c-api && cargo test --features test -p gluon_check testname)`.
 
-If you are building with a nightly version of rust which supports workspaces you can use the `test-nightly.sh` script instead which puts the build artifacts in the root folder instead of in `c-api`.
+If you are building with a nightly version of rust which supports workspaces, you can use the `test-nightly.sh` script instead which puts the build artifacts in the root folder instead of in `c-api`.
 
 ## Pull requests
 
-Once you have made some changes you will need to file a pull request to get your changes merged into the main repository. If the code is still a work in progress it can still be a good idea to submit a PR as that will let other contributors see your progress and provide assistance (you may prefix the PR message with [WIP] to make it explicit that the PR is incomplete).
+Once you have made some changes, you will need to file a pull request to get your changes merged into the main repository. If the code is still a work in progress, it can still be a good idea to submit a PR. That will let other contributors see your progress and provide assistance (you may prefix the PR message with [WIP] to make it explicit that the PR is incomplete).
 
-You may see that some of the [commits](https://github.com/gluon-lang/gluon/commit/9b36d699c63e482969239ed9f84779f7cd1ad2f3) follow the [commit message convention of Angular](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format). Following this convention is optional but if you enjoy using it then feel free to do so! 
+You may see that some of the [commits][] follow the [commit message convention of Angular][]. Following this convention is optional but if you enjoy using it, feel free to do so! 
+
+[commits]:https://github.com/gluon-lang/gluon/commit/9b36d699c63e482969239ed9f84779f7cd1ad2f3
+[commit message convention of Angular]:https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Gluon is a small, statically-typed, functional programming language designed for
 
 * **Statically typed** - Static typing makes it easier to write safe and efficient interfaces between gluon and the host application.
 
-* **Type inference** - Type inference ensures that types rarely have to be written explicitly giving the all the benefits of static types with none of the typing.
+* **Type inference** - Type inference ensures that types rarely have to be written explicitly giving all the benefits of static types with none of the typing.
 
-* **Simple embedding** - Marshalling values to and from gluon requires next to no boiler plate allowing functions defined in [Rust][] to be [directly passed to gluon][easy_embed].
+* **Simple embedding** - Marshalling values to and from gluon requires next to no boilerplate, allowing functions defined in [Rust][] to be [directly passed to gluon][easy_embed].
 
 * **UTF-8 by default** - Gluon supports unicode out of the box with utf-8 encoded strings and unicode codepoints as characters.
 
-* **Separate heaps** - Gluon is a garbage collected language but uses a separate heap for each executing gluon thread. This keeps each heap small, reducing the overhead of the garbage collector.
+* **Separate heaps** - Gluon is a garbage-collected language but uses a separate heap for each executing gluon thread. This keeps each heap small, reducing the overhead of the garbage collector.
 
-* **Thread safe** - Gluon is written in Rust which guarantees thread safety and gluon keeps the same guarantees allowing multiple gluon programs to run in parallel ([example][parallel])\*
+* **Thread safe** - Gluon is written in Rust, which guarantees thread safety. Gluon keeps the same guarantees, allowing multiple gluon programs to run in parallel ([example][parallel])\*
 
 [easy_embed]:https://github.com/gluon-lang/gluon/blob/master/TUTORIAL.md#embedding-api
 [parallel]:https://github.com/gluon-lang/gluon/blob/master/tests/parallel.rs
@@ -33,11 +33,11 @@ You can try gluon in your browser at the [try_gluon](http://ec2-52-29-1-213.eu-c
 
 #### Rust
 
-Gluon requires a recent Rust compiler to build (1.9.0 or later) and is available at [crates.io](https://crates.io/crates/gluon) and can easily be included in a Cargo project by adding the lines below.
+Gluon requires a recent Rust compiler to build (1.9.0 or later) and is available at [crates.io](https://crates.io/crates/gluon). It can easily be included in a Cargo project by adding the lines below.
 
 ```toml
 [dependencies]
-gluon = "0.2.0"
+gluon = "0.3.0"
 ```
 
 #### Other languages
@@ -57,7 +57,7 @@ The [gluon extension][] for Visual Studio Code provides syntax highlighting and 
 
 ### REPL
 
-Gluon has a small executable which can be used to run gluon programs directly or to run a small REPL. The REPL can be started by passing the `-i` flag to the built repl executable which can be run through `cargo run -- -i`).
+Gluon has a small executable which can be used to run gluon programs directly or in a small REPL. The REPL can be started by passing the `-i` flag to the built repl executable which can be run with `cargo run -- -i`.
 
 REPL features:
 * Evaluating expressions (expressions of type IO will be evaluated in the IO context).
@@ -77,8 +77,7 @@ REPL features:
 
 ### Vim plugin
 
-@salpalvv has created a vim plugin which provides syntax highlighting. You can find it here
-https://github.com/salpalvv/vim-gluon
+[vim-gluon](https://github.com/salpalvv/vim-gluon) is a vim plugin which provides basic syntax highlighting and indentation.
 
 ## Documentation
 
@@ -163,24 +162,25 @@ else
 
 ## Contributing
 
-There are many ways to contribute to gluon. The two simplest ways of starting out is opening issues or working on an issue marked as [beginner][]. For more extensive information about contributing you can look at [CONTRIBUTING.md][].
+There are many ways to contribute to gluon. The two simplest ways are opening issues or working on issues marked as [beginner][]. For more extensive information about contributing, you can look at [CONTRIBUTING.md][].
 
 [beginner]:https://github.com/gluon-lang/gluon/labels/Beginner
 [CONTRIBUTING.md]:https://github.com/gluon-lang/gluon/blob/master/CONTRIBUTING.md
 
 ## Goals
-These goals may change or be refined over time as I experiment with what is possible to with the language.
+These goals may change or be refined over time as I experiment with what is possible with the language.
 
-* **Embeddable** - Similiar to [Lua][Lua] it is meant to be able to be included in another program which can use the virtual machine to extend its own functionality.
+* **Embeddable** - Similiar to [Lua][Lua] - it is meant to be included in another program which may use the virtual machine to extend its own functionality.
 
-* **Statically typed** - The language uses a Hindley-Milner based type system with some extensions which allows for simple and general type inference.
+* **Statically typed** - The language uses a [Hindley-Milner based type system][hm] with some extensions, allowing simple and general type inference.
 
-* **Tiny** - By being tiny the langauge is easy to learn and makes the implementation small.
+* **Tiny** - By being tiny, the language is easy to learn and has a small implementation footprint.
 
-* **Strict** - Strict languages are usually easier to reason about, especially considering that is what most people are accustomed with. For cases where lazines is desired an explict type is provided.
+* **Strict** - Strict languages are usually easier to reason about, especially considering that it is what most people are accustomed to. For cases where laziness is desired, an explict type is provided.
 
-* **Modular** - The library is split into parser, typechecker and virtual machine + compiler. Each of these components can be use independently of each other allowing applications to pick and choose exactly what they need.
+* **Modular** - The library is split into parser, typechecker, and virtual machine + compiler. Each of these components can be use independently of each other, allowing applications to pick and choose exactly what they need.
 
+[hm]:https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system
 [prelude]:https://github.com/gluon-lang/gluon/blob/master/std/prelude.glu
 
 ## Inspiration

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -20,7 +20,7 @@ This tutorial aims the explain the basics of gluon's syntax and semantics.
 
 ## Hello world
 
-In traditional form we will begin with the classic hello world program.
+In traditional form, we will begin with the classic hello world program.
 
 ```f#,rust
 io.println "Hello world"
@@ -36,10 +36,9 @@ If, on the other hand, you are familiar with functional languages you will be ri
 
 ### Identifiers and Literals
 
-The simplest syntactical elements in gluon are identifiers and literals and none of them should be especially
-surprising if you are experienced in programming. Identifiers are a sequence of alphanumeric characters including
-underscore ('_') which has to start with a letter or an underscore. Literals come in four different forms
-integer, float, string and character literals.
+The simplest syntactical elements in gluon are identifiers and literals and none of them should be especially surprising if you are experienced in programming. 
+
+Identifiers are a sequence of alphanumeric characters including underscore ("\_") which are required to start with either a letter or an underscore. Literals come in four different forms - integer, float, string and character literals.
 
 ```f#
 // An identifier
@@ -56,8 +55,11 @@ abc123_
 
 ### Comments
 
-Comments should be immediately familiar if you are accustomed to C-like languages. `//` starts a line comment which is ended
-by a newline and `/*` starts a block comment which is ended by `*/`.
+Comments should be immediately familiar if you are accustomed to C-like languages. 
+
+`//` starts a line comment which is ended by a newline
+
+`/*` starts a block comment which is ended by `*/`
 
 ### Functions
 
@@ -65,9 +67,7 @@ by a newline and `/*` starts a block comment which is ended by `*/`.
 f x "argument" 3
 ```
 
-Being a functional language functions are everywhere and because of this calling functions have an intentional minimalistic
-syntax where there is no need to enclose the arguments in a parenthesized list of arguments. Instead arguments are just
-separated by whitespace.
+Being a functional language, functions are everywhere. Because of this, calling functions have an intentionally minimalistic syntax where there is no need to enclose arguments as a parenthesized list of arguments. Instead, arguments are separated by whitespace.
 
 Another way of calling a function is through infix notation since gluon implements all operators as just functions.
 
@@ -93,9 +93,7 @@ allowing it to be used later.
 let x = 1 + 2 in x // Returns 3
 ```
 
-You may rightly be wondering about the `in x` part. gluon takes a strong stance against statements in an effort to keep
-things consistent. Thus only writing `let x = 1 + 2` will be met with a syntax error about a missing `in` keyword which is
-what defines the actual value returned from the `let` expression.
+You may rightly be wondering about the `in x` part. gluon takes a strong stance against statements in an effort to keep things consistent. Thus only writing `let x = 1 + 2` will be met with a syntax error about a missing `in` keyword which is what defines the actual value returned from the `let` expression.
 
 Let bindings also allow functions to be defined which is done by listing the arguments between the bound identifier and `=`
 
@@ -114,8 +112,7 @@ in f 1 // Never returns
 
 ### If expressions
 
-The simplest control flow expression is the `if` expression which evaluates a boolean expression and then takes the
-first branch if the boolean is evaluated to `True` and the second if it evaluates to `False`
+The simplest control flow expression is the `if` expression. It evaluates a boolean expression, taking the first branch if the boolean evaluates to `True`, and taking the second if it evaluates to `False`
 
 ```f#,rust
 if True then 1 else 0
@@ -123,20 +120,20 @@ if True then 1 else 0
 
 ### Record expressions
 
-To create more complex data types gluon has first class records which can be used to group data which belong together easily.
+To create more complex data types, gluon has first class records. Records can be used to couple data that is logically grouped into a single type.
 
 ```f#,rust
 { pi = 3.14, add1 = (+) 1.0 }
 ```
 
-To access the fields of a record `.` is used.
+To access the fields of a record, `.` is used.
 
 ```f#,rust
 let record = { pi = 3.14, add1 = (+) 1.0 }
 in record.pi // Returns 3.14
 ```
 
-The assignment to a field can be omitted if there is a variable in scope with the same name as the field.
+Field assignments can be omitted if there is a variable in scope with the same name as the field.
 
 ```f#,rust
 let id x = x
@@ -145,7 +142,7 @@ in { id }
 
 ### Variants
 
-While records are great for grouping related data together there is often a need to have data which can be one of several variants. Unlike records, variants need to be defined before they can be used.
+While records are great for grouping related data together, there is often a need to have data which can be one of several variants. Unlike records, variants need to be defined before they can be used.
 
 ```f#,rust
 type MyOption a = | Some a | None
@@ -154,7 +151,7 @@ Some 1
 
 ### Case expressions
 
-To allow variants to be unpacked so that their contents can be retrieved gluon has the `case` expression.
+To allow variants to be unpacked so their contents can be retrieved, gluon has the `case` expression.
 
 ```f#,rust
 match None with
@@ -162,7 +159,7 @@ match None with
 | None -> 0
 ```
 
-Here we write out a pattern for each of the variant's constructors and the value we pass in (`None` in this case) is matched to each of these patterns. When a matching pattern is found the expression on the right of `->` is evaluated with each of the constructor's arguments bound to variables.
+Here, we write out a pattern for each of the variant's constructors and the value we pass in (`None` in this case) is matched to each of these patterns. When a matching pattern is found, the expression on the right of `->` is evaluated with each of the constructor's arguments bound to variables.
 
 `case` expressions can also be used to unpack records.
 
@@ -171,7 +168,7 @@ match { x = 1.0, pi = 3.14 } with
 | { x = y, pi } -> y + pi
 ```
 
-`let` bindings can also unpack records letting the expression above be written as.
+`let` bindings can also unpack records allowing the expression above to be written as:
 
 ```f#,rust
 let { x = y, pi } = { x = 1.0, pi = 3.14 }
@@ -191,7 +188,7 @@ let f x y = x + y - 10 in f
 
 ### Type expressions
 
-gluon allows new types to be defined through the `type` expression which just like `let` requires `in <expression>` to be written at the end to ensure it returns a value.
+gluon allows new types to be defined through the `type` expression which, just like `let`, requires `in <expression>` to be written at the end to ensure it returns a value.
 
 ```f#,rust
 // type <identifier> <identifier>* = <type> in <expression>
@@ -226,16 +223,16 @@ in Atom "name"
 
 ### Indentation
 
-If you have been following along this far you may be thinking think that the syntax so far is pretty limiting. In particular you wouldn't be wrong in thinking that the `let` and `type` syntax are clunky due to their need to be closed by the `in` keyword. Luckily gluon offers a more convenient way of writing bindings by relying on indentation.
+If you have been following along this far, you may be think that the syntax so far is pretty limiting. In particular, you wouldn't be wrong in thinking that the `let` and `type` syntax are clunky due to their need to be closed by the `in` keyword. Luckily, gluon offers a more convenient way of writing bindings by relying on indentation.
 
-When a token starts on the same column as an unclosed `let` or `type` expression the lexer implicitly inserts an `in` token which closes the declaration part and makes the following expression into the body.
+When a token starts on the same column as an unclosed `let` or `type` expression, the lexer implicitly inserts an `in` token which closes the declaration part and makes the following expression into the body.
 
 ```f#,rust
 let add1 x = x + 1
 add1 11 // `in` will be inserted automatically since `add1 11` starts on the same line as the opening `let`
 ```
 
-If a token starts on the same column as an earlier expression but there is not an unclosed `type` or `let` expression gluon treats the code as a block expression which means each expression are run sequentially, returning the value of the last expression.
+If a token starts on the same column as an earlier expression, but there is not an unclosed `type` or `let` expression, gluon treats the code as a block expression, meaning each expression is run sequentially, returning the value of the last expression.
 
 ```f#
 do_something1 ()
@@ -247,7 +244,7 @@ match x with
 | Private y -> do_something4 x
 ```
 
-Indented blocks can can be used to limit the scope of some variables.
+Indented blocks can be used to limit the scope of some variables.
 
 ```f#,rust
 let module =
@@ -276,7 +273,7 @@ module.id module.pi
 <type> -> <type>
 ```
 
-Function types are written using the `(->)` operator which is right associative. This means that the function type `Int -> (Int -> Int)` (A function taking one argument of Int and returning a function of `Int -> Int`) can be written as `Int -> Int -> Int`.
+Function types are written using the `(->)` operator, which is right associative. This means that the function type `Int -> (Int -> Int)` (A function taking one argument of Int and returning a function of `Int -> Int`) can be written as `Int -> Int -> Int`.
 
 ### Record type
 
@@ -285,9 +282,9 @@ Function types are written using the `(->)` operator which is right associative.
 { pi : Float, sin : Float -> Float }
 ```
 
-Records are gluon's main way of creating associating related data and they should look quite familiar if you are familiar with dynamic languages such as javascript. Looks can be deceiving however as gluon's records are more similar to a struct in Rust or C as the order of the fields are significant, `{ x : Int, y : String } != { y : String, x : Int }`. Furthermore records are immutable meaning fields cannot be added or removed and the values within cannot be modified.
+Records are gluon's main way of creating associating related data and they should look quite familiar if you are familiar with dynamic languages such as javascript. Looks can be deceiving however as gluon's records are more similar to a struct in Rust or C as the order of the fields are significant, `{ x : Int, y : String } != { y : String, x : Int }`. Furthermore, records are immutable, meaning fields cannot be added nor removed and the values within cannot be modified.
 
-In addition to storing values, records also have a secondary function of storing types which is gluon's way of exporting types. If you have used modules in an ML language this may look rather familiar, looks can be deceiving however as 'type fields' must match exactly in gluon which means there is no subtyping relationship between records (`{ Test = { x : Int } }` is not a subtype of `{ Test = Float }`). This may change in the future.
+In addition to storing values, records also have a secondary function of storing types which is gluon's way of exporting types. If you have used modules in an ML language, this may look rather familiar. Looks can be deceiving however as 'type fields' must match exactly in gluon which means there is no subtyping relationship between records (`{ Test = { x : Int } }` is not a subtype of `{ Test = Float }`). This may change in the future.
 
 ```f#
 { Test = { x : Int } }
@@ -301,7 +298,7 @@ In addition to storing values, records also have a secondary function of storing
 | Err e | Ok t
 ```
 
-Gluon also has a second way of grouping data which is the enumeration type which allows you to represent a value being one of several variants. In the example above is the representation of gluon's standard `Result` type which represents either the value having been successfully computed (`Ok t`) or that an error occurred (`Err e`).
+Gluon also has a second way of grouping data which is the enumeration type which allows you to represent a value being one of several variants. In the example above is the representation of gluon's standard `Result` type. It represents either the value having been successfully computed (`Ok t`) or that an error occurred (`Err e`).
 
 ### Alias type
 
@@ -313,19 +310,19 @@ Option Int
 Ref String
 ```
 
-The last kind of type which gluon has is the alias type. An alias type is a type which explicitly names some underlying type which can either be one of the three types mentioned above or an abstract type which is the case for the `Int`, `String` and `Ref` types. If the underlying type is abstract then the type is only considered equivalent to itself (ie if you define an abstract type of `MyInt` which happens to have the same representation as `Int` the typechecker will consider these two types as being distinct).
+The last kind of type which gluon has is the alias type. An alias type explicitly names some underlying type which can either be one of the three types mentioned above or an abstract type which is the case for the `Int`, `String` and `Ref` types. If the underlying type is abstract, then the type is only considered equivalent to itself (ie if you define an abstract type of `MyInt` which happens to have the same representation as `Int` the typechecker will consider these two types as being distinct).
 
 ### Higher-kinded types
 
-Higher-kinded types are a fairly abstract concept in gluon and you may very well create entire programs without any knowledge about them. Sometimes they are a very valuable tool to have as they can be used to create very powerful abstractions.
+Higher-kinded types are a fairly abstract concept in gluon and you may create entire programs without any knowledge about them. Sometimes they are a very valuable tool to have, as they can be used to create very powerful abstractions.
 
-Just as all values such as `0 : Int`, `"Hello World!" : String` and `Some 4.0 : Option Float` each have a type these types themselves have their own 'type' or the 'kind' as it is called. For the types of concrete values the `Kind` is always `Type` so for the earlier examples `Int : Type`, `String : Type` and `Option Float : Type`. That is not very useful on its own but it becomes more interesting when we consider the kind of `Option : Type -> Type`. `Type -> Type` looks rather like the type of a functions such as `show_int : Int -> String` but instead of taking a value it takes a type and produces a new type. In effect this lets us abstract over types instead of just over values. This abstraction facility can be seen in the `Functor : (Type -> Type) -> Type` type which takes a type with kind `Type -> Type` as argument which is exactly the kind of `Option` (or `List`, `Result a`).
+Just as all values such as `0 : Int`, `"Hello World!" : String` and `Some 4.0 : Option Float` each have a type, these types themselves have their own 'type' or the 'kind' as it is called. For the types of concrete values the `Kind` is always `Type` so for the earlier examples `Int : Type`, `String : Type` and `Option Float : Type`. That is not very useful on its own but it becomes more interesting when we consider the kind of `Option : Type -> Type`. `Type -> Type` looks rather like the type of a function such as `show_int : Int -> String` but, instead of taking a value, it takes a type and produces a new type. In effect, this lets us abstract over types instead of just over values. This abstraction facility can be seen in the `Functor : (Type -> Type) -> Type` type which takes a type with kind `Type -> Type` as argument which is exactly the kind of `Option` (or `List`, `Result a`).
 
 ### Overloading
 
-Sometimes there there is a need to overload a name with multiple differing implementations and let the compiler chose the correct implementation. If you have written any amount of Gluon code so far you are likely to have already encountered this with numeric operators such as `(+)` or comparison operators such as `(==)`. While these operators are core parts of gluon they are not special cased by the compiler which lets you define and use overloaded bindings yourself.
+Sometimes, there is a need to overload a name with multiple differing implementations and let the compiler chose the correct implementation. If you have written any amount of Gluon code so far, you are likely to have already encountered this with numeric operators such as `(+)` or comparison operators such as `(==)`. While these operators are core parts of gluon they are not special-cased by the compiler which lets you define and use overloaded bindings yourself.
 
-To explain how overloading works first look at the example below where `show_type` has two implementations, one which takes an `Int` and one which takes a `Float`.
+To explain how overloading works, first look at the example below where `show_type` has two implementations; one which takes an `Int` and one which takes a `Float`.
 
 ```f#,rust
 let show_type _ : Int -> String = "Int"
@@ -336,15 +333,15 @@ show_type 0.0 // Returns "Float"
 // show_type "" // Would be a type error
 ```
 
-When the typechecker encounters the second `show_type` binding in this example it does not simply shadow the first binding as is common in many programming languages. Instead the typechecker checks the type of the binding already in scope and calculates the 'intersection' of the two bindings. In the example above the first binding has the type `Int -> String` while the second is `Float -> String`. By calculating the 'intersection' the typechecker calculates the most specialized type which both bindings can still successfully unify to which in this case is `a -> String`. Any subsequent use of `show_type` will then be observed as `a -> String` which succeeds with both a `Int` and `Float` argument.
+When the typechecker encounters the second `show_type` binding in this example, it does not simply shadow the first binding as is common in many programming languages. Instead, the typechecker checks the type of the binding already in scope and calculates the 'intersection' of the two bindings. In the example above, the first binding has the type `Int -> String` while the second is `Float -> String`. By calculating the 'intersection', the typechecker calculates the most specialized type which both bindings can still successfully unify to which in this case is `a -> String`. Any subsequent use of `show_type` will then be observed as `a -> String` which succeeds with both a `Int` and `Float` argument.
 
-Unfortunately it would also succeed if a `String` (or any other) type were used as the argument which is not acceptable as we have only implemented `show_type` for `Int` and `Float`. To catch this case (and to figure out which overload should be use where) the typechecker does an extra pass after successfully typechecking the entire expression. In this pass all uses of overloaded bindings are checked against the overload candidates until a match is found. Thus the third call, were it not commented out, would produce an error as there is no overloaded binding matching the type `String -> String`.
+Unfortunately, it would also succeed if a `String` (or any other) type were used as the argument which is not acceptable as we have only implemented `show_type` for `Int` and `Float`. To catch this case (and to figure out which overload should be use where), the typechecker does an extra pass after successfully typechecking the entire expression. In this pass, all uses of overloaded bindings are checked against the overload candidates until a match is found. Thus, the third call, were it not commented out, would produce an error as there is no overloaded binding matching the type `String -> String`.
 
 ## Importing modules
 
-As is often the case it is convenient to separate code into multiple files which can later be imported and used from multiple other files. To do this we can use the `import!` macro which takes a single string literal as argument and loads and compiles that file at compile time before the importing module is compiled.
+As is often the case, it is convenient to separate code into multiple files which can later be imported and used from multiple other files. To do this, we can use the `import!` macro which takes a single string literal as argument and loads and compiles that file at compile time before the importing module is compiled.
 
-So say that we need the `assert` function from the `test` module which can be found at `std/test.glu`. Then we might write something like this.
+For example, say that we need the `assert` function from the `test` module which can be found at `std/test.glu`. We might write something like this:
 
 ```f#,rust
 let { assert }  = import! "std/test.glu"
@@ -353,7 +350,7 @@ assert (1 == 1)
 
 ## Writing modules
 
-Importing standard modules is all well and good but it is also necessary to write your own once a program starts getting to big for a single file. As it turns out, if you have been following along so far, you already know everything about writing a module! Creating and loading a module in gluon just entails writing creating a file containing an expression which is then loaded and evaluated using `import!`. `import!` is then just the value of evaluating the expression.
+Importing standard modules is all well and good but it is also necessary to write your own once a program starts getting too big for a single file. As it turns out, if you have been following along so far, you already know everything about writing a module! Creating and loading a module in gluon entails creating a file containing an expression which is then loaded and evaluated using `import!`. `import!` is then just the value of the evaluated expression.
 
 ```f#
 // module.glu
@@ -368,7 +365,7 @@ let namedFloat : Named Float = { name = "pi", value = 3.14 }
 addTwice 10
 ```
 
-Though modules are most commonly a record this does not have to be the case. If you wanted you could write a module returning any other value as well.
+Though modules are most commonly a record, this does not have to be the case. If you wanted, you could write a module returning any other value as well.
 
 ```f#
 // pi.glu
@@ -381,15 +378,15 @@ let pi  = import! "pi.glu"
 
 ## Embedding API
 
-The API with which the host language interacts with gluon is very important part of the library. While the complete API can be found in the [Rustdoc][] this section will explain the most important parts. Please note that the API can change at any point and there are still some public functions which should actually be internal.
+The API with which the host language interacts with gluon is very important part of the library. While the complete API can be found in the [Rustdoc][], this section will explain the most important parts. Please note that the API can change at any point and there are still some public functions which should actually be internal.
 
 ### Creating a virtual machine
 
-Before you are able to do anything with the library you will need to create a virtual machine. The virtual machine is responsible for running gluon programs and can be created with the [new_vm][] function.
+Before you are able to do anything with the library, you will need to create a virtual machine. The virtual machine is responsible for running gluon programs and can be created with the [new_vm][] function.
 
 ### Compiling and running gluon code
 
-Once in possession of a [RootedThread][] you can compile and execute code using the [run_expr][] method on the [Compiler][] builder type.
+Once in possession of a [RootedThread][], you can compile and execute code using the [run_expr][] method on the [Compiler][] builder type.
 
 ```rust,ignore
 let vm = new_vm();
@@ -399,7 +396,7 @@ let (result, _) = Compiler::new()
 assert_eq!(result, Some(3));
 ```
 
-Often it is either inconvenient or inefficient to compile and run code directly from source code. To write the above example in a more efficient way we could instead load the `(+)` function and call it directly.
+Often, it is either inconvenient or inefficient to compile and run code directly from source code. To write the above example in a more efficient way, we could instead load the `(+)` function and call it directly.
 
 ```rust,ignore
 let vm = new_vm();
@@ -459,7 +456,7 @@ TODO
 
 ### Prelude
 
-When compiling an expression, the compiler automatically inserts a small prelude before the expression itself which gives automatic access to basic operators such as `+`, `-`, etc as well as types such as `Option` and `Result`.
+When compiling an expression, the compiler automatically inserts a small prelude before the expression itself, which gives automatic access to basic operators such as `+`, `-`, etc as well as types such as `Option` and `Result`.
 
 ### Threads and channels
 


### PR DESCRIPTION
Mostly commas and slight rewording in markdown files.

I also bumped the README Cargo.toml to 0.3 due to the changes in documentation of `import!`

I tried not to be too opinionated on wording as a first pass.