### PR TITLE
fix: Fix issue #255

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -12,6 +12,7 @@ use vm::thread::{Thread, Status};
 use vm::api::{Array, Hole, VmType, Getable, OpaqueValue, Pushable, IO, WithVM, Userdata, primitive};
 use vm::api::generic::{A, B};
 use vm::stack::StackFrame;
+use vm::internal::ValuePrinter;
 
 use vm::internal::Value;
 
@@ -176,7 +177,14 @@ fn run_expr(WithVM { vm, value: expr }: WithVM<&str>) -> IO<String> {
     let mut context = vm.context();
     let stack = StackFrame::current(&mut context.stack);
     match run_result {
-        Ok((value, typ)) => IO::Value(format!("{:?} : {}", value, typ)),
+        Ok((value, typ)) => {
+            let env = vm.global_env().get_env();
+            unsafe {
+                IO::Value(format!("{} : {}",
+                                  ValuePrinter::new(&*env, &typ, value.get_value()).width(80),
+                                  typ))
+            }
+        }
         Err(err) => clear_frames(err, frame_level, stack),
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -164,7 +164,7 @@ fn clear_frames(err: Error, frame_level: usize, mut stack: StackFrame) -> IO<Str
 
 fn run_expr(WithVM { vm, value: expr }: WithVM<&str>) -> IO<String> {
     let frame_level = vm.context().stack.get_frames().len();
-    let run_result = Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(vm, "<top>", expr);
+    let run_result = Compiler::new().run_io_expr::<OpaqueValue<&Thread, Hole>>(vm, "<top>", expr);
     let mut context = vm.context();
     let stack = StackFrame::current(&mut context.stack);
     match run_result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,6 @@ use gluon::vm::Error as VMError;
 
 mod repl;
 
-const GLUON_VERSION: &'static str = env!("CARGO_PKG_VERSION");
-
-
 #[cfg(not(test))]
 fn run_files<'s, I>(vm: &Thread, files: I) -> Result<()>
     where I: Iterator<Item = &'s str>,
@@ -36,7 +33,6 @@ fn run_files<'s, I>(vm: &Thread, files: I) -> Result<()>
     Ok(())
 }
 
-
 #[cfg(all(not(test), feature = "env_logger"))]
 fn init_env_logger() {
     ::env_logger::init().unwrap();
@@ -47,6 +43,8 @@ fn init_env_logger() {}
 
 #[cfg(not(test))]
 fn main() {
+    const GLUON_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
     // Need the extra stack size when compiling the program using the msvc compiler
     ::std::thread::Builder::new()
         .stack_size(2 * 1024 * 1024)

--- a/std/repl.glu
+++ b/std/repl.glu
@@ -95,7 +95,7 @@ let loop editor : Editor -> IO () =
             store (string.slice line 4 (string.length line))
         else
             io.catch (io.run_expr line) pure
-                >>= io.print
+                >>= io.println
                 *> pure True
 
     rustyline.readline editor "> " >>= \line_opt ->

--- a/vm/src/api.rs
+++ b/vm/src/api.rs
@@ -982,6 +982,10 @@ impl<T, V> Clone for OpaqueValue<T, V>
 impl<T, V> OpaqueValue<T, V>
     where T: Deref<Target = Thread>,
 {
+    pub fn vm(&self) -> &Thread {
+        self.0.vm()
+    }
+
     /// Unsafe as `Value` are not rooted
     pub unsafe fn get_value(&self) -> Value {
         *self.0
@@ -1677,7 +1681,7 @@ impl<'vm, F> Getable<'vm> for Function<&'vm Thread, F> {
         Some(Function {
             value: vm.root_value_ref(*value.0),
             _marker: PhantomData,
-        })//TODO not type safe
+        }) //TODO not type safe
     }
 }
 
@@ -1686,7 +1690,7 @@ impl<'vm, F> Getable<'vm> for Function<RootedThread, F> {
         Some(Function {
             value: vm.root_value(*value.0),
             _marker: PhantomData,
-        })//TODO not type safe
+        }) //TODO not type safe
     }
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1057,7 +1057,9 @@ impl<'b> OwnedContext<'b> {
                         initial_call: bool,
                         function: &ExternFunction)
                         -> Result<Async<OwnedContext<'b>>> {
-        debug!("CALL EXTERN {} {:?}", function.id, self.stack);
+        info!("CALL EXTERN {} {:?}",
+              function.id,
+              &self.stack.current_frame()[..]);
         let mut status = Status::Ok;
         if initial_call {
             // Make sure that the stack is not borrowed during the external function call
@@ -1102,7 +1104,7 @@ impl<'b> OwnedContext<'b> {
                 .map_err(|_| {
                     Error::Message(StdString::from("Poped the last frame in execute_function"))
                 })?;
-        self.stack.pop();// Pop function
+        self.stack.pop(); // Pop function
         self.stack.push(result);
 
         match status {
@@ -1519,7 +1521,7 @@ impl<'b> ExecuteContext<'b> {
                                     *var = self.stack.pop();
                                 }
                             }
-                            self.stack.pop();//Remove the closure
+                            self.stack.pop(); //Remove the closure
                         }
                         x => panic!("Expected closure, got {:?}", x),
                     }


### PR DESCRIPTION
I think this should fix the missing output on osx, I changed `io.print` to not output a newline a while back and had forgotten to change the call in the repl which prints the result.

Also fixes a panic when exiting the repl, see 6afc82c8166f93e3222a2d93591bf58850a512bc for the fix and cause.

Fixes #255