### PR TITLE
[WIP] docs: Add examples and move tests into the documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/lib.rs"
 
 name = "gluon"
 path = "src/main.rs"
+doc = false
 
 [dependencies]
 gluon_base = { path = "base", version = "0.3.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,23 @@ impl Compiler {
 
     /// Compiles and runs the expression in `expr_str`. If successful the value from running the
     /// expression is returned
+    ///
+    /// # Examples
+    ///
+    /// Import from gluon's standard library and evaluate a string
+    ///
+    /// ```
+    /// # extern crate gluon;
+    /// # use gluon::{new_vm,Compiler};
+    /// # fn main() {
+    /// let vm = new_vm();
+    /// let (result, _) = Compiler::new()
+    ///     .run_expr::<String>(&vm, "example", " let string  = import! \"std/string.glu\" in string.trim \"  Hello world  \t\" ")
+    ///     .unwrap();
+    /// assert_eq!(result, "Hello world");
+    /// # }
+    /// ```
+    ///
     pub fn run_expr<'vm, T>(&mut self,
                             vm: &'vm Thread,
                             name: &str,
@@ -284,6 +301,30 @@ impl Compiler {
         self.run_expr_async(vm, name, expr_str).wait()
     }
 
+    /// Compiles and runs the expression in `expr_str`. If successful the value from running the
+    /// expression is returned
+    ///
+    /// # Examples
+    ///
+    /// Import from gluon's standard library and evaluate a string
+    ///
+    /// ```
+    /// # extern crate gluon;
+    /// # use gluon::{new_vm,Compiler};
+    /// # use gluon::base::types::Type;
+    /// # fn main() {
+    /// let vm = new_vm();
+    /// let result = Compiler::new()
+    ///     .run_expr_async::<String>(&vm, "example",
+    ///         " let string  = import! \"std/string.glu\" in string.trim \"    Hello world  \t\" ")
+    ///     .sync_or_error()
+    ///     .unwrap();
+    /// let expected = ("Hello world".to_string(), Type::string());
+    /// 
+    /// assert_eq!(result, expected);
+    /// }
+    /// ```
+    ///
     pub fn run_expr_async<'vm, T>(&mut self,
                                   vm: &'vm Thread,
                                   name: &str,

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -356,6 +356,33 @@ impl Thread {
 
     /// Creates a new global value at `name`.
     /// Fails if a global called `name` already exists.
+    ///
+    /// # Examples
+    ///
+    /// Load the `factorial` rust function into gluon and evaluate `factorial 5`
+    ///
+    /// ```
+    /// # extern crate gluon;
+    /// # #[macro_use] extern crate gluon_vm;
+    /// # use gluon::{new_vm,Compiler};
+    /// # use gluon::base::types::Type;
+    /// fn factorial(x: i32) -> i32 {
+    ///     if x <= 1 { 1 } else { x * factorial(x - 1) }
+    /// }
+    /// # fn main() {
+    /// let vm = new_vm();
+    /// vm.define_global("factorial", primitive!(1 factorial)).unwrap();
+    ///
+    /// let result = Compiler::new()
+    ///     .run_expr_async::<i32>(&vm, "example", "factorial 5")
+    ///     .sync_or_error()
+    ///     .unwrap();
+    /// let expected = (120, Type::int());
+    ///
+    /// assert_eq!(result, expected);
+    /// # }
+    /// ```
+    ///
     pub fn define_global<'vm, T>(&'vm self, name: &str, value: T) -> Result<()>
         where T: Pushable<'vm> + VmType,
     {
@@ -371,7 +398,34 @@ impl Thread {
     }
 
     /// Retrieves the global called `name`.
-    /// Fails if the global does not exist or it does not have the correct type.
+    ///
+    /// # Examples
+    ///
+    /// Bind the `(+)` function in gluon's prelude standard library
+    /// to an `add` function in rust
+    ///
+    /// ```rust
+    /// # extern crate gluon;
+    /// # use gluon::{new_vm,Compiler,RootedThread, Thread};
+    /// # use gluon::vm::api::{FunctionRef, Hole, OpaqueValue};
+    /// # fn main() {
+    /// let vm = new_vm();
+    /// Compiler::new()
+    ///     .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example",
+    ///         r#" import! "std/prelude.glu" "#)
+    ///     .sync_or_error()
+    ///     .unwrap();
+    /// let mut add: FunctionRef<fn(i32, i32) -> i32> =
+    ///     vm.get_global("std.prelude.num_Int.(+)").unwrap();
+    /// let result = add.call(1, 2);
+    /// assert_eq!(result, Ok(3));
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// if the global does not exist or it does not have the correct type.
+    ///
     pub fn get_global<'vm, T>(&'vm self, name: &str) -> Result<T>
         where T: Getable<'vm> + VmType,
     {


### PR DESCRIPTION
Examples added to run_expr(), define_global(), and get_global() docs

`doc = false` so one may run `cargo doc --open` at the root 

For [#42](https://github.com/gluon-lang/gluon/issues/42)
