### PR TITLE
feat: Implement nested pattern matching

### DIFF
--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -453,7 +453,9 @@ impl Typed for Pattern<Symbol> {
 }
 
 fn get_return_type(env: &TypeEnv, alias_type: &ArcType, arg_count: usize) -> ArcType {
-    if arg_count == 0 {
+    // We don't want to panic if we attempt to get the return type of a hole so return a type hole
+    // as the return type
+    if arg_count == 0 || **alias_type == Type::Hole {
         return alias_type.clone();
     }
 

--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -65,11 +65,11 @@ pub type SpannedPattern<Id> = Spanned<Pattern<Id>, BytePos>;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Pattern<Id> {
-    Constructor(TypedIdent<Id>, Vec<TypedIdent<Id>>),
+    Constructor(TypedIdent<Id>, Vec<SpannedPattern<Id>>),
     Record {
         typ: ArcType<Id>,
         types: Vec<(Id, Option<Id>)>,
-        fields: Vec<(Id, Option<Id>)>,
+        fields: Vec<(Id, Option<SpannedPattern<Id>>)>,
     },
     Ident(TypedIdent<Id>),
 }
@@ -257,7 +257,7 @@ pub fn walk_mut_pattern<V: ?Sized + MutVisitor>(v: &mut V, p: &mut Pattern<V::Id
         Pattern::Constructor(ref mut id, ref mut args) => {
             v.visit_typ(&mut id.typ);
             for arg in args {
-                v.visit_typ(&mut arg.typ);
+                v.visit_pattern(arg);
             }
         }
         Pattern::Record { ref mut typ, .. } => {
@@ -355,7 +355,7 @@ pub fn walk_pattern<V: ?Sized + Visitor>(v: &mut V, p: &Pattern<V::Ident>) {
         Pattern::Constructor(ref id, ref args) => {
             v.visit_typ(&id.typ);
             for arg in args {
-                v.visit_typ(&arg.typ);
+                v.visit_pattern(&arg);
             }
         }
         Pattern::Record { ref typ, .. } => {

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -6,7 +6,7 @@ use std::mem;
 
 use base::scoped_map::ScopedMap;
 use base::ast::{DisplayEnv, Expr, Literal, MutVisitor, Pattern, SpannedExpr};
-use base::ast::{SpannedPattern, TypeBinding, Typed, TypedIdent, ValueBinding};
+use base::ast::{SpannedPattern, TypeBinding, TypedIdent, ValueBinding};
 use base::error::Errors;
 use base::fnv::{FnvMap, FnvSet};
 use base::resolve;
@@ -746,19 +746,23 @@ impl<'a> Typecheck<'a> {
             }
             Pattern::Record { typ: ref mut curr_typ,
                               types: ref mut associated_types,
-                              ref fields } => {
+                              ref mut fields } => {
                 *curr_typ = match_type.clone();
                 let mut match_type = self.remove_alias(match_type);
 
                 let mut pattern_fields = Vec::with_capacity(associated_types.len() + fields.len());
 
                 let mut duplicated_fields = FnvSet::default();
-                for field in associated_types.iter().chain(fields.iter()) {
-                    if 
-                        self.error_on_duplicated_field(&mut duplicated_fields,
-                                                       span,
-                                                       field.0.clone()) {
-                        pattern_fields.push(field.0.clone());
+                {
+                    let all_fields = associated_types.iter()
+                        .map(|field| &field.0)
+                        .chain(fields.iter().map(|field| &field.0));
+                    for field in all_fields {
+                        if self.error_on_duplicated_field(&mut duplicated_fields,
+                                                          span,
+                                                          field.clone()) {
+                            pattern_fields.push(field.clone());
+                        }
                     }
                 }
 
@@ -793,12 +797,21 @@ impl<'a> Typecheck<'a> {
                 match_type = actual_type;
 
                 for field in fields {
-                    let name = field.1.as_ref().unwrap_or(&field.0);
+                    let name = &field.0;
                     // The field should always exist since the type was constructed from the pattern
                     let field_type = match_type.row_iter()
-                        .find(|f| f.name.name_eq(&field.0))
-                        .expect("ICE: Expected field to exist in type");
-                    self.stack_var(name.clone(), field_type.typ.clone());
+                        .find(|f| f.name.name_eq(name))
+                        .expect("ICE: Expected field to exist in type")
+                        .typ
+                        .clone();
+                    match field.1 {
+                        Some(ref mut pattern) => {
+                            self.typecheck_pattern(pattern, field_type);
+                        }
+                        None => {
+                            self.stack_var(name.clone(), field_type);
+                        }
+                    }
                 }
 
                 // Check that all types declared in the pattern exists
@@ -832,16 +845,22 @@ impl<'a> Typecheck<'a> {
         }
     }
 
-    fn typecheck_pattern_rec(&mut self, args: &[TypedIdent], typ: ArcType) -> TcResult<ArcType> {
-        if args.len() == 0 {
-            return Ok(typ);
-        }
-        match typ.as_function() {
-            Some((arg, ret)) => {
-                self.stack_var(args[0].name.clone(), arg.clone());
-                self.typecheck_pattern_rec(&args[1..], ret.clone())
+    fn typecheck_pattern_rec(&mut self,
+                             args: &mut [SpannedPattern<Symbol>],
+                             typ: ArcType)
+                             -> TcResult<ArcType> {
+        let len = args.len();
+        match args.split_first_mut() {
+            Some((head, tail)) => {
+                match typ.as_function() {
+                    Some((arg, ret)) => {
+                        self.typecheck_pattern(head, arg.clone());
+                        self.typecheck_pattern_rec(tail, ret.clone())
+                    }
+                    None => Err(TypeError::PatternError(typ.clone(), len)),
+                }
             }
-            None => Err(TypeError::PatternError(typ.clone(), args.len())),
+            None => Ok(typ),
         }
     }
 
@@ -912,7 +931,7 @@ impl<'a> Typecheck<'a> {
             if let Some(typ) = self.finish_type(level, &bind.typ) {
                 bind.typ = typ;
             }
-            self.finish_binding(level, bind);
+            self.finish_pattern(level, &mut bind.name, &bind.typ);
         }
         debug!("Typecheck `in`");
         self.type_variables.exit_scope();
@@ -1000,8 +1019,8 @@ impl<'a> Typecheck<'a> {
         Ok(())
     }
 
-    fn finish_binding(&mut self, level: u32, bind: &mut ValueBinding<Symbol>) {
-        match bind.name.value {
+    fn finish_pattern(&mut self, level: u32, pattern: &mut SpannedPattern<Symbol>, typ: &ArcType) {
+        match pattern.value {
             Pattern::Ident(ref mut id) => {
                 if let Some(typ) = self.finish_type(level, &id.typ) {
                     id.typ = typ;
@@ -1012,25 +1031,29 @@ impl<'a> Typecheck<'a> {
                 self.intersect_type(level, &id.name, &id.typ);
             }
             Pattern::Record { ref mut typ, ref mut fields, .. } => {
-                debug!("{{ .. }}: {}",
-                       types::display_type(&self.symbols,
-                                           &bind.expr.env_type_of(&self.environment)));
+                debug!("{{ .. }}: {}", types::display_type(&self.symbols, typ));
                 if let Some(finished) = self.finish_type(level, typ) {
                     *typ = finished;
                 }
                 let record_type = self.remove_alias(typ.clone());
-                with_pattern_types(fields, &record_type, |field_name, binding, field_type| {
-                    let field_name = binding.as_ref().unwrap_or(field_name);
-                    self.intersect_type(level, field_name, field_type);
-                });
+                with_pattern_types(fields,
+                                   &record_type,
+                                   |field_name, binding, field_type| match *binding {
+                                       Some(ref mut pat) => {
+                                           self.finish_pattern(level, pat, field_type);
+                                       }
+                                       None => {
+                                           self.intersect_type(level, field_name, field_type);
+                                       }
+                                   });
             }
-            Pattern::Constructor(ref id, ref args) => {
+            Pattern::Constructor(ref id, ref mut args) => {
                 debug!("{}: {}",
                        self.symbols.string(&id.name),
-                       types::display_type(&self.symbols,
-                                           &bind.expr.env_type_of(&self.environment)));
-                for arg in args {
-                    self.intersect_type(level, &arg.name, &arg.typ);
+                       types::display_type(&self.symbols, typ));
+                for (arg, arg_type) in args.iter_mut()
+                    .zip(function_arg_iter(self, typ.clone()).collect::<Vec<_>>()) {
+                    self.finish_pattern(level, arg, &arg_type);
                 }
             }
         }
@@ -1296,15 +1319,17 @@ impl<'a> Typecheck<'a> {
     }
 }
 
-fn with_pattern_types<F>(fields: &[(Symbol, Option<Symbol>)], typ: &ArcType, mut f: F)
-    where F: FnMut(&Symbol, &Option<Symbol>, &ArcType),
+fn with_pattern_types<F>(fields: &mut [(Symbol, Option<SpannedPattern<Symbol>>)],
+                         typ: &ArcType,
+                         mut f: F)
+    where F: FnMut(&Symbol, &mut Option<SpannedPattern<Symbol>>, &ArcType),
 {
     for field in fields {
         // If the field in the pattern does not exist (undefined field error) then skip it as
         // the error itself will already have been reported
         let opt = typ.row_iter().find(|type_field| type_field.name.name_eq(&field.0));
         if let Some(associated_type) = opt {
-            f(&field.0, &field.1, &associated_type.typ);
+            f(&field.0, &mut field.1, &associated_type.typ);
         }
     }
 }

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -208,7 +208,7 @@ Type = {
 // Patterns
 
 FieldPattern : FieldPattern<Id> = {
-    <id: Ident> "=" <body: Ident> =>
+    <id: Ident> "=" <body: Sp<Pattern>> =>
         FieldPattern::Value(id, Some(body)),
 
     <IdentStr> => {
@@ -261,11 +261,8 @@ AtomicPattern: Pattern<Id> = {
 Pattern = {
     AtomicPattern,
 
-    <id: Ident> <args: Ident+> => {
+    <id: Ident> <args: Sp<AtomicPattern>+> => {
         let id = TypedIdent::new(id);
-        let args = args.into_iter()
-                       .map(TypedIdent::new)
-                       .collect();
 
         Pattern::Constructor(id, args)
     },

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -11,7 +11,7 @@ extern crate lalrpop_util;
 
 use std::cell::RefCell;
 
-use base::ast::{Expr, IdentEnv, SpannedExpr};
+use base::ast::{Expr, IdentEnv, SpannedExpr, SpannedPattern};
 use base::error::Errors;
 use base::pos::{self, BytePos, Span, Spanned};
 use base::symbol::Symbol;
@@ -202,7 +202,7 @@ impl<'a, I> Iterator for SharedIter<'a, I>
 
 pub enum FieldPattern<Id> {
     Type(Id, Option<Id>),
-    Value(Id, Option<Id>),
+    Value(Id, Option<SpannedPattern<Id>>),
 }
 
 pub enum FieldExpr<Id> {

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -164,7 +164,7 @@ match None with
     assert_eq!(e,
                Ok(case(id("None"),
                        vec![(Pattern::Constructor(TypedIdent::new(intern("Some")),
-                                                  vec![TypedIdent::new(intern("x"))]),
+                                                  vec![no_loc(Pattern::Ident(TypedIdent::new(intern("x"))))]),
                              id("x")),
                             (Pattern::Constructor(TypedIdent::new(intern("None")), vec![]),
                              int(0))])));
@@ -207,7 +207,8 @@ fn record_pattern() {
     let pattern = Pattern::Record {
         typ: Type::hole(),
         types: Vec::new(),
-        fields: vec![(intern("y"), None), (intern("x"), Some(intern("z")))],
+        fields: vec![(intern("y"), None),
+                     (intern("x"), Some(no_loc(Pattern::Ident(TypedIdent::new(intern("z"))))))],
     };
     assert_eq!(e, case(id("x"), vec![(pattern, id("z"))]));
 }
@@ -229,6 +230,21 @@ fn let_pattern() {
                                                  expr: id("test"),
                                              }],
                                         Box::new(id("x")))));
+}
+
+#[test]
+fn nested_pattern() {
+    let _ = ::env_logger::init();
+    let e = parse_new!("match x with | { y = Some x } -> z");
+    let nested =
+        no_loc(Pattern::Constructor(TypedIdent::new(intern("Some")),
+                                    vec![no_loc(Pattern::Ident(TypedIdent::new(intern("x"))))]));
+    let pattern = Pattern::Record {
+        typ: Type::hole(),
+        types: Vec::new(),
+        fields: vec![(intern("y"), Some(nested))],
+    };
+    assert_eq!(e, case(id("x"), vec![(pattern, id("z"))]));
 }
 
 #[test]

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -248,6 +248,17 @@ fn nested_pattern() {
 }
 
 #[test]
+fn nested_pattern_parens() {
+    let _ = ::env_logger::init();
+    let e = parse_new!("match x with | (Some (Some z)) -> z");
+
+    let inner_pattern = no_loc(Pattern::Constructor(TypedIdent::new(intern("Some")), vec![no_loc(Pattern::Ident(TypedIdent::new(intern("z"))))]));
+    let pattern = Pattern::Constructor(TypedIdent::new(intern("Some")), vec![inner_pattern]);
+    assert_eq!(e, case(id("x"), vec![(pattern, id("z"))]));
+}
+
+
+#[test]
 fn span_identifier() {
     let _ = ::env_logger::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,16 +13,12 @@ extern crate gluon_parser as parser;
 #[macro_use]
 extern crate gluon_vm as vm;
 
-#[cfg(not(test))]
 use gluon::{new_vm, Compiler, Thread, Error, Result};
-#[cfg(not(test))]
 use gluon::vm::thread::ThreadInternal;
-#[cfg(not(test))]
 use gluon::vm::Error as VMError;
 
 mod repl;
 
-#[cfg(not(test))]
 fn run_files<'s, I>(vm: &Thread, files: I) -> Result<()>
     where I: Iterator<Item = &'s str>,
 {
@@ -33,15 +29,14 @@ fn run_files<'s, I>(vm: &Thread, files: I) -> Result<()>
     Ok(())
 }
 
-#[cfg(all(not(test), feature = "env_logger"))]
+#[cfg(feature = "env_logger")]
 fn init_env_logger() {
     ::env_logger::init().unwrap();
 }
 
-#[cfg(all(not(test), not(feature = "env_logger")))]
+#[cfg(not(feature = "env_logger"))]
 fn init_env_logger() {}
 
-#[cfg(not(test))]
 fn main() {
     const GLUON_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
@@ -78,4 +73,14 @@ fn main() {
         .unwrap()
         .join()
         .unwrap();
+}
+
+
+#[cfg(test)]
+mod tests {
+    // If nothing else this suppresses the unused imports warnings when compiling in test mode
+    #[test]
+    fn execute_repl_help() {
+        super::main();
+    }
 }

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -127,47 +127,47 @@ let eq_Char = {
 let eq_Option a : Eq a -> Eq (Option a) = {
     (==) = \l r ->
         match l with
-            | Some l_val ->
-                (match r with
-                    | Some r_val -> a.(==) l_val r_val
-                    | None -> False)
-            | None ->
-                (match r with
-                    | Some _ -> False
-                    | None -> True)
+        | Some l_val ->
+            match r with
+            | Some r_val -> a.(==) l_val r_val
+            | None -> False
+        | None ->
+            match r with
+            | Some _ -> False
+            | None -> True
 }
 
 let eq_Result e a : Eq e -> Eq a -> Eq (Result e a) = {
     (==) = \l r ->
         match l with
-            | Ok l_val ->
-                (match r with
-                    | Ok r_val -> a.(==) l_val r_val
-                    | Err _ -> False)
-            | Err l_val ->
-                (match r with
-                    | Ok _ -> False
-                    | Err r_val -> e.(==) l_val r_val)
+        | Ok l_val ->
+            match r with
+            | Ok r_val -> a.(==) l_val r_val
+            | Err _ -> False
+        | Err l_val ->
+            match r with
+            | Ok _ -> False
+            | Err r_val -> e.(==) l_val r_val
 }
 
 let eq_List a : Eq a -> Eq (List a) =
     let (==) l r =
         match l with
-            | Nil ->
-                match r with
-                    | Nil -> True
-                    | Cons x y -> False
-            | Cons x xs ->
-                match r with
-                    | Nil -> False
-                    | Cons y ys -> a.(==) x y && xs == ys
+        | Nil ->
+            match r with
+            | Nil -> True
+            | Cons x y -> False
+        | Cons x xs ->
+            match r with
+            | Nil -> False
+            | Cons y ys -> a.(==) x y && xs == ys
     { (==) }
 
 let monoid_Ordering = {
     append = \x y ->
         match x with
-            | EQ -> y
-            | _ -> x,
+        | EQ -> y
+        | _ -> x,
     empty = EQ
 }
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -542,6 +542,26 @@ f 0 (\r -> { x = r #Int+ 1 })
 1i32
 }
 
+test_expr!{ nested_pattern,
+r#"
+match Some (Some 123) with
+| None -> 0
+| Some None -> 1
+| Some (Some x) -> x
+"#,
+123i32
+}
+
+test_expr!{ nested_pattern2,
+r#"
+match Some None with
+| None -> 0
+| Some None -> 1
+| Some (Some x) -> x
+"#,
+1i32
+}
+
 #[test]
 fn overloaded_bindings() {
     let _ = ::env_logger::init();
@@ -790,9 +810,21 @@ g 10
     match result {
         Err(Error::VM(..)) => {
             let stacktrace = vm.context().stack.stacktrace(1);
-            let g = stacktrace.frames[0].as_ref().unwrap().name.clone();
-            let f = stacktrace.frames[1].as_ref().unwrap().name.clone();
-            let end = stacktrace.frames[6].as_ref().unwrap().name.clone();
+            let g = stacktrace.frames[0]
+                .as_ref()
+                .unwrap()
+                .name
+                .clone();
+            let f = stacktrace.frames[1]
+                .as_ref()
+                .unwrap()
+                .name
+                .clone();
+            let end = stacktrace.frames[6]
+                .as_ref()
+                .unwrap()
+                .name
+                .clone();
             assert_eq!(stacktrace.frames,
                        vec![// Removed due to being a tail call
                             // Some(StacktraceFrame { name: f.clone(), line: 9 }),
@@ -903,9 +935,7 @@ fn dont_use_the_implicit_prelude_span_in_the_top_expr() {
 
     let expr = "1";
 
-    Compiler::new()
-        .typecheck_str(&vm, "example", expr, Some(&Type::float()))
-        .unwrap_err();
+    Compiler::new().typecheck_str(&vm, "example", expr, Some(&Type::float())).unwrap_err();
 }
 
 #[test]

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -564,6 +564,27 @@ match Some None with
 1i32
 }
 
+test_expr!{ nested_record_pattern,
+r#"
+type Test a = | A a | B
+match { x = A 1 } with
+| { x = A y } -> y
+| { x = B } -> 100
+"#,
+1i32
+}
+
+test_expr!{ nested_record_pattern2,
+r#"
+type Test a = | A a | B
+match { x = B } with
+| { x = A y } -> y
+| { x = B } -> 100
+"#,
+100i32
+}
+
+
 #[test]
 fn overloaded_bindings() {
     let _ = ::env_logger::init();

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -544,6 +544,7 @@ f 0 (\r -> { x = r #Int+ 1 })
 
 test_expr!{ nested_pattern,
 r#"
+type Option a = | Some a | None
 match Some (Some 123) with
 | None -> 0
 | Some None -> 1
@@ -554,6 +555,7 @@ match Some (Some 123) with
 
 test_expr!{ nested_pattern2,
 r#"
+type Option a = | Some a | None
 match Some None with
 | None -> 0
 | Some None -> 1

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -25,6 +25,7 @@ smallvec = "0.2.1"
 
 gluon_base = { path = "../base", version = "0.3.0" }
 gluon_check = { path = "../check", version = "0.3.0" }
+gluon_parser = { path = "../parser", version = "0.3.0", optional = true }
 
 [features]
-test = ["env_logger"]
+test = ["env_logger", "gluon_parser"]

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -491,6 +491,7 @@ impl<'a> Compiler<'a> {
                                  ArcType::from(expr.env_type_of(&self.globals).clone()));
 
         env.start_function(self, 0, id, typ);
+        debug!("COMPILING: {}", expr);
         self.compile(&expr, &mut env, true)?;
         let current_line = self.source.line_number_at_byte(expr.span().end);
         let FunctionEnv { function, .. } = env.end_function(self, current_line);

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -649,7 +649,8 @@ impl<'a> Compiler<'a> {
                                     panic!("ICE: Could not find tag for {}::{} when matching on \
                                             expression `{}`",
                                            types::display_type(&self.symbols, &typ),
-                                           self.symbols.string(&id.name))
+                                           self.symbols.string(&id.name),
+                                           expr)
                                 });
                             function.emit(TestTag(tag));
                             start_jumps.push(function.function.instructions.len());

--- a/vm/src/core.rs
+++ b/vm/src/core.rs
@@ -749,7 +749,7 @@ impl<'a, 'e> PatternTranslator<'a, 'e> {
     {
 
         let mut identifiers = Vec::new();
-        let mut record_fields = Vec::new();
+        let mut record_fields: Vec<(TypedIdent<Symbol>, _)> = Vec::new();
         let mut ident = None;
 
         for pattern in patterns {
@@ -765,7 +765,7 @@ impl<'a, 'e> PatternTranslator<'a, 'e> {
                 ast::Pattern::Record { ref typ, ref fields, .. } => {
                     for (i, field) in fields.iter().enumerate() {
                         // Don't add one field twice
-                        if identifiers.iter().all(|id| id.name != field.0) {
+                        if record_fields.iter().all(|id| id.0.name != field.0) {
                             let x = field.1
                                 .as_ref()
                                 .map(|pattern| self.extract_ident(i, &pattern.value).name);

--- a/vm/src/core.rs
+++ b/vm/src/core.rs
@@ -736,7 +736,6 @@ impl<'a, 'e> PatternTranslator<'a, 'e> {
         match *pattern {
             ast::Pattern::Ident(ref id) => id.clone(),
             _ => {
-                println!("{:?}", pattern);
                 TypedIdent {
                     name: Symbol::from(format!("pattern_{}", index)),
                     typ: pattern.env_type_of(&self.0.env),


### PR DESCRIPTION
Makes it possible to write gluon code where pattern matches are nested!

```f#
match { x = Some (Some 123) } with
| { x = Some None } -> 0
| { x = Some (Some x) } -> x
| { x = None } -> -1
```

To make this more efficient we could do some analysis to determine which variant to start generating match expressions on http://marijnhaverbeke.nl/hob/saga/pattern_matching.html.

Closes #1