### PR TITLE
feat: Implement tuples

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -149,9 +149,9 @@ type MyOption a = | Some a | None
 Some 1
 ```
 
-### Case expressions
+### Match expressions
 
-To allow variants to be unpacked so their contents can be retrieved, gluon has the `case` expression.
+To allow variants to be unpacked so their contents can be retrieved, gluon has the `match` expression.
 
 ```f#,rust
 match None with
@@ -161,18 +161,30 @@ match None with
 
 Here, we write out a pattern for each of the variant's constructors and the value we pass in (`None` in this case) is matched to each of these patterns. When a matching pattern is found, the expression on the right of `->` is evaluated with each of the constructor's arguments bound to variables.
 
-`case` expressions can also be used to unpack records.
+`match` expressions can also be used to unpack records.
 
 ```f#,rust
 match { x = 1.0, pi = 3.14 } with
 | { x = y, pi } -> y + pi
+
+// Patterns can be nested as well
+match { x = Some (Some 123) } with
+| { x = Some None } -> 0
+| { x = Some (Some x) } -> x
+| { x = None } -> -1
 ```
 
-`let` bindings can also unpack records allowing the expression above to be written as:
+`let` bindings can also match and unpack on data but only with irrefutable patterns. In other words, only with patterns which cannot fail.
 
-```f#,rust
+```f#
+// Matching on records will always succeed since they are the only variant
 let { x = y, pi } = { x = 1.0, pi = 3.14 }
 in y + pi
+
+// These will be rejected however as `let` can only handle one variant (`Some` in this example)
+let Some x = None
+let Some y = Some 123
+x + y
 ```
 
 ### Lambda expressions

--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -260,8 +260,13 @@ pub fn walk_mut_pattern<V: ?Sized + MutVisitor>(v: &mut V, p: &mut Pattern<V::Id
                 v.visit_pattern(arg);
             }
         }
-        Pattern::Record { ref mut typ, .. } => {
+        Pattern::Record { ref mut typ, ref mut fields, .. } => {
             v.visit_typ(typ);
+            for field in fields {
+                if let Some(ref mut pattern) = field.1 {
+                    v.visit_pattern(pattern);
+                }
+            }
         }
         Pattern::Ident(ref mut id) => v.visit_typ(&mut id.typ),
     }
@@ -358,8 +363,13 @@ pub fn walk_pattern<V: ?Sized + Visitor>(v: &mut V, p: &Pattern<V::Ident>) {
                 v.visit_pattern(&arg);
             }
         }
-        Pattern::Record { ref typ, .. } => {
+        Pattern::Record { ref typ, ref fields, .. } => {
             v.visit_typ(typ);
+            for field in fields {
+                if let Some(ref pattern) = field.1 {
+                    v.visit_pattern(pattern);
+                }
+            }
         }
         Pattern::Ident(ref id) => v.visit_typ(&id.typ),
     }

--- a/base/src/symbol.rs
+++ b/base/src/symbol.rs
@@ -355,6 +355,12 @@ impl DisplayEnv for Symbols {
     }
 }
 
+impl IdentEnv for Symbols {
+    fn from_str(&mut self, s: &str) -> Symbol {
+        self.symbol(s)
+    }
+}
+
 impl<'s> DisplayEnv for SymbolModule<'s> {
     type Ident = Symbol;
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -65,8 +65,6 @@ pub enum BuiltinType {
     Int,
     /// Floating point number
     Float,
-    /// The unit type
-    Unit,
     /// Type constructor for arrays, `Array a : Type -> Type`
     Array,
     /// Type constructor for functions, `(->) a b : Type -> Type -> Type`
@@ -104,7 +102,6 @@ impl BuiltinType {
             BuiltinType::Char => "Char",
             BuiltinType::Int => "Int",
             BuiltinType::Float => "Float",
-            BuiltinType::Unit => "()",
             BuiltinType::Array => "Array",
             BuiltinType::Function => "->",
         }
@@ -511,7 +508,7 @@ impl<Id, T> Type<Id, T>
     }
 
     pub fn unit() -> T {
-        Type::builtin(BuiltinType::Unit)
+        Type::record(vec![], vec![])
     }
 }
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -8,7 +8,7 @@ use pretty::{DocAllocator, Arena, DocBuilder};
 
 use smallvec::{SmallVec, VecLike};
 
-use ast::{self, DisplayEnv};
+use ast::{self, IdentEnv, DisplayEnv};
 use kind::{ArcKind, Kind, KindEnv};
 use merge::merge;
 use symbol::{Symbol, SymbolRef};
@@ -404,6 +404,23 @@ impl<Id, T> Type<Id, T>
 
     pub fn poly_variant(fields: Vec<Field<Id, T>>, rest: T) -> T {
         T::from(Type::Variant(Type::extend_row(Vec::new(), fields, rest)))
+    }
+
+    pub fn tuple<S, I>(symbols: &mut S, elems: I) -> T
+        where S: ?Sized + IdentEnv<Ident = Id>,
+              I: IntoIterator<Item = T>,
+              Id: From<String>,
+    {
+        Type::record(vec![],
+                     elems.into_iter()
+                         .enumerate()
+                         .map(|(i, typ)| {
+                             Field {
+                                 name: symbols.from_str(&format!("_{}", i)),
+                                 typ: typ,
+                             }
+                         })
+                         .collect())
     }
 
     pub fn record(types: Vec<Field<Id, Alias<Id, T>>>, fields: Vec<Field<Id, T>>) -> T {

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -406,7 +406,6 @@ impl<Id, T> Type<Id, T>
     pub fn tuple<S, I>(symbols: &mut S, elems: I) -> T
         where S: ?Sized + IdentEnv<Ident = Id>,
               I: IntoIterator<Item = T>,
-              Id: From<String>,
     {
         Type::record(vec![],
                      elems.into_iter()

--- a/check/src/completion.rs
+++ b/check/src/completion.rs
@@ -92,6 +92,7 @@ impl<E: TypeEnv> OnFound for Suggest<E> {
             Pattern::Ident(ref id) => {
                 self.stack.insert(id.name.clone(), id.typ.clone());
             }
+            Pattern::Tuple { elems: ref args, .. } |
             Pattern::Constructor(_, ref args) => {
                 for arg in args {
                     self.on_pattern(arg);
@@ -288,7 +289,7 @@ impl<F> FindVisitor<F>
                 }
                 self.visit_expr(&lambda.body)
             }
-            Expr::Tuple(ref args) => self.visit_one(args),
+            Expr::Tuple { elems: ref exprs, .. } |
             Expr::Block(ref exprs) => self.visit_one(exprs),
             Expr::Error => (),
         };

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -171,7 +171,7 @@ impl<'a> KindCheck<'a> {
     fn builtin_kind(&self, typ: BuiltinType) -> ArcKind {
         match typ {
             BuiltinType::String | BuiltinType::Byte | BuiltinType::Char | BuiltinType::Int |
-            BuiltinType::Float | BuiltinType::Unit => self.type_kind(),
+            BuiltinType::Float => self.type_kind(),
             BuiltinType::Array => self.function1_kind(),
             BuiltinType::Function => self.function2_kind(),
         }

--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -62,6 +62,7 @@ pub fn metadata(env: &MetadataEnv, expr: &mut SpannedExpr<Symbol>) -> Metadata {
                 Pattern::Ident(ref mut id) => {
                     self.stack_var(id.name.clone(), metadata);
                 }
+                Pattern::Tuple { .. } |
                 Pattern::Constructor(..) => (),
             }
         }

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -124,6 +124,11 @@ pub fn rename(symbols: &mut SymbolModule,
                     let new_name = self.stack_var(id.name.clone(), pattern.span, id.typ.clone());
                     id.name = new_name;
                 }
+                ast::Pattern::Tuple { ref typ, ref mut elems } => {
+                    for (field, elem) in typ.row_iter().zip(elems) {
+                        self.new_pattern(&field.typ, elem);
+                    }
+                }
                 ast::Pattern::Constructor(ref mut id, ref mut args) => {
                     let typ = self.env
                         .find_type(&id.name)

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -962,3 +962,16 @@ fn field_access_tuple() {
 
     assert_eq!(result, Ok(Type::int()));
 }
+
+
+#[test]
+fn unit_tuple_match() {
+    let _ = ::env_logger::init();
+    let text = r#"
+match () with
+| () -> ()
+"#;
+    let result = support::typecheck(text);
+
+    assert_eq!(result, Ok(Type::unit()));
+}

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -28,11 +28,9 @@ macro_rules! assert_pass {
 fn make_ident_type(typ: ArcType) -> ArcType {
     use base::types::walk_move_type;
     walk_move_type(typ,
-                   &mut |typ| {
-                       match *typ {
-                           Type::Alias(ref alias) => Some(Type::ident(alias.name.clone())),
-                           _ => None,
-                       }
+                   &mut |typ| match *typ {
+                       Type::Alias(ref alias) => Some(Type::ident(alias.name.clone())),
+                       _ => None,
                    })
 }
 
@@ -913,4 +911,54 @@ Test 0
         Type::Alias(_) => (),
         ref typ => panic!("Expected alias, got {:?}", typ),
     }
+}
+
+#[test]
+fn simple_tuple_type() {
+    let _ = ::env_logger::init();
+    let text = r#"
+("test", 123)
+"#;
+    let result = support::typecheck(text);
+
+    let interner = support::get_local_interner();
+    let mut interner = interner.borrow_mut();
+    assert_eq!(result, Ok(Type::tuple(&mut *interner, vec![Type::string(), Type::int()])));
+}
+
+#[test]
+fn match_tuple_type() {
+    let _ = ::env_logger::init();
+    let text = r#"
+match (1, "test") with
+| (x, y) -> (y, x)
+"#;
+    let result = support::typecheck(text);
+
+    let interner = support::get_local_interner();
+    let mut interner = interner.borrow_mut();
+    assert_eq!(result, Ok(Type::tuple(&mut *interner, vec![Type::string(), Type::int()])));
+}
+
+#[test]
+fn match_tuple_record() {
+    let _ = ::env_logger::init();
+    let text = r#"
+match (1, "test") with
+| { _1, _0 } -> _1
+"#;
+    let result = support::typecheck(text);
+
+    assert_eq!(result, Ok(Type::string()));
+}
+
+#[test]
+fn field_access_tuple() {
+    let _ = ::env_logger::init();
+    let text = r#"
+(1, "test")._0
+"#;
+    let result = support::typecheck(text);
+
+    assert_eq!(result, Ok(Type::int()));
 }

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -229,14 +229,11 @@ AtomicPattern: Pattern<Id> = {
             Pattern::Ident(TypedIdent::new(id))
         },
 
-    "(" <elems: Comma<Pattern>> ")" =>
+    "(" <elems: Comma<Sp<Pattern>>> ")" =>
         match elems.len() {
-            // Unit pattern
-            0 => unimplemented!(),
             // Parenthesized pattern
-            1 => elems.into_iter().next().unwrap(),
-            // TODO: Tuples
-            _ => unimplemented!(),
+            1 => elems.into_iter().next().unwrap().value,
+            _ => Pattern::Tuple { typ: Type::hole(), elems: elems },
         },
 
     "{" <fields: Comma<FieldPattern>> "}" => {
@@ -342,13 +339,10 @@ AtomicExpr: Expr<Id> = {
 
     "(" <elems: Comma<SpExpr>> ")" =>
         match elems.len() {
-            // Unit expression
-            0 => Expr::Tuple(vec![]),
             // Parenthesized expression - wrap in a block to ensure
             // that it survives operator reparsing
             1 => Expr::Block(elems),
-            // TODO: Tuples
-            _ => unimplemented!(),
+            _ => Expr::Tuple { typ: Type::hole(), elems: elems },
         },
 
     "[" <elems: Comma<SpExpr>> "]" => Expr::Array(Array {

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -179,12 +179,9 @@ AtomicType: ArcType<Id> = {
 
     "(" <elems: Comma<Type>> ")" =>
         match elems.len() {
-            // Unit type
-            0 => Type::unit(),
             // Parenthesized type
             1 => elems.into_iter().next().unwrap(),
-            // TODO: Tuples
-            _ => unimplemented!(),
+            _ => Type::tuple(env, elems),
         },
 
     "{" <row: Comma<RecordField>> "}" =>

--- a/parser/src/layout.rs
+++ b/parser/src/layout.rs
@@ -178,6 +178,7 @@ impl<'input, Tokens> Layout<'input, Tokens>
 
             match (&token.value, offside.context) {
                 (&Token::Comma, Context::Brace) |
+                (&Token::Comma, Context::Paren) |
                 (&Token::Comma, Context::Bracket) => return Ok(token),
 
                 // If it is closing token we remove contexts until a context for that token is found

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -61,7 +61,7 @@ fn shrink_hidden_spans<Id>(mut expr: SpannedExpr<Id>) -> SpannedExpr<Id> {
         Expr::Infix(_, _, _) |
         Expr::Array(_) |
         Expr::Record { .. } |
-        Expr::Tuple(_) |
+        Expr::Tuple { .. } |
         Expr::Error => (),
     }
     expr

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -114,6 +114,16 @@ fn type_mutually_recursive() {
 }
 
 #[test]
+fn tuple_type() {
+    let _ = ::env_logger::init();
+
+    let expr = r#"
+        let _: (Int, String, Option Int) = (1, "", None)
+        1"#;
+    parse_new!(expr);
+}
+
+#[test]
 fn field_access_test() {
     let _ = ::env_logger::init();
     let e = parse_new!("{ x = 1 }.x");

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -49,12 +49,11 @@ let monoid_List =
 
 let monoid_Option m : Monoid a -> Monoid (Option a) = {
     append = \l r ->
-        match l with
-        | Some x ->
-            match r with
-            | Some y -> Some (m.append x y)
-            | None -> l
-        | None -> r,
+        match (l, r) with
+        | (Some x, Some y) -> Some (m.append x y)
+        | (Some _, None) -> l
+        | (None, Some _) -> r
+        | (None, None) -> None,
     empty = None
 }
 
@@ -126,41 +125,26 @@ let eq_Char = {
 
 let eq_Option a : Eq a -> Eq (Option a) = {
     (==) = \l r ->
-        match l with
-        | Some l_val ->
-            match r with
-            | Some r_val -> a.(==) l_val r_val
-            | None -> False
-        | None ->
-            match r with
-            | Some _ -> False
-            | None -> True
+        match (l, r) with
+        | (Some l_val, Some r_val) -> a.(==) l_val r_val
+        | (None, None) -> True
+        | _ -> False
 }
 
 let eq_Result e a : Eq e -> Eq a -> Eq (Result e a) = {
     (==) = \l r ->
-        match l with
-        | Ok l_val ->
-            match r with
-            | Ok r_val -> a.(==) l_val r_val
-            | Err _ -> False
-        | Err l_val ->
-            match r with
-            | Ok _ -> False
-            | Err r_val -> e.(==) l_val r_val
+        match (l, r) with
+        | (Ok l_val, Ok r_val) -> a.(==) l_val r_val
+        | (Err l_val, Err r_val) -> e.(==) l_val r_val
+        | _ -> False
 }
 
 let eq_List a : Eq a -> Eq (List a) =
     let (==) l r =
-        match l with
-        | Nil ->
-            match r with
-            | Nil -> True
-            | Cons x y -> False
-        | Cons x xs ->
-            match r with
-            | Nil -> False
-            | Cons y ys -> a.(==) x y && xs == ys
+        match (l, r) with
+        | (Nil, Nil) -> True
+        | (Cons x xs, Cons y ys) -> a.(==) x y && xs == ys
+        | _ -> False
     { (==) }
 
 let monoid_Ordering = {
@@ -227,29 +211,21 @@ let ord_Char = {
 let ord_Option a : Ord a -> Ord (Option a) = {
     eq = eq_Option a.eq,
     compare = \l r ->
-        match l with
-            | Some l_val ->
-                match r with
-                    | Some r_val -> a.compare l_val r_val
-                    | None -> LT
-            | None ->
-                match r with
-                    | Some r_val -> GT
-                    | None -> EQ
+        match (l, r) with
+        | (Some l_val, Some r_val) -> a.compare l_val r_val
+        | (None, Some _) -> LT
+        | (Some _, None) -> GT
+        | (None, None) -> EQ
 }
 
 let ord_Result e a : Ord e -> Ord a -> Ord (Result e a) = {
     eq = eq_Result e.eq a.eq,
     compare = \l r ->
-        match l with
-            | Ok l_val ->
-                match r with
-                    | Ok r_val -> a.compare l_val r_val
-                    | Err _ -> GT
-            | Err l_val ->
-                match r with
-                    | Ok _ -> LT
-                    | Err r_val -> e.compare l_val r_val
+        match (l, r) with
+        | (Ok l_val, Ok r_val) -> a.compare l_val r_val
+        | (Err l_val, Err r_val) -> e.compare l_val r_val
+        | (Ok _, Err _) -> LT
+        | (Err _, Ok _) -> GT
 }
 
 /// Creates the `<=`, `<`, `>` and `>=` operators from an instance with `Ord`
@@ -409,24 +385,19 @@ let const : a -> b -> a =
 let applicative_Option : Applicative Option = {
     functor = functor_Option,
     apply = \f x ->
-        match f with
-        | Some g ->
-            match x with
-            | Some y -> Some (g y)
-            | None -> None
-        | None -> None,
+        match (f, x) with
+        | (Some g, Some y) -> Some (g y)
+        | _ -> None,
     pure = \x -> Some x
 }
 
 let applicative_Result : Applicative (Result e) = {
     functor = functor_Result,
     apply = \f x ->
-        match f with
-        | Ok g ->
-            match x with
-            | Ok y -> Ok (g y)
-            | Err _ -> x
-        | Err x -> Err x,
+        match (f, x) with
+        | (Ok g, Ok y) -> Ok (g y)
+        | (Ok _, Err _) -> x
+        | (Err x, _) -> Err x,
     pure = \x -> Ok x
 }
 

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -4,18 +4,18 @@ type List a = | Nil | Cons a (List a)
 
 let unwrap opt : Option a -> a =
     match opt with
-        | Some x -> x
-        | None -> error "Option was None"
+    | Some x -> x
+    | None -> error "Option was None"
 
 let unwrap_ok res : Result e a -> a =
     match res with
-        | Ok x -> x
-        | Err _ -> error "Result was an Err"
+    | Ok x -> x
+    | Err _ -> error "Result was an Err"
 
 let unwrap_err res : Result e a -> e =
     match res with
-        | Ok _ -> error "Result was an Ok"
-        | Err x -> x
+    | Ok _ -> error "Result was an Ok"
+    | Err x -> x
 
 /**
 
@@ -42,19 +42,19 @@ let monoid_Function m : Monoid b -> (Monoid (a -> b)) = {
 let monoid_List =
     let append xs ys =
         match xs with
-            | Cons x zs -> Cons x (append zs ys)
-            | Nil -> ys
+        | Cons x zs -> Cons x (append zs ys)
+        | Nil -> ys
 
     { append, empty = Nil }
 
 let monoid_Option m : Monoid a -> Monoid (Option a) = {
     append = \l r ->
         match l with
-            | Some x ->
-                match r with
-                    | Some y -> Some (m.append x y)
-                    | None -> l
-            | None -> r,
+        | Some x ->
+            match r with
+            | Some y -> Some (m.append x y)
+            | None -> l
+        | None -> r,
     empty = None
 }
 
@@ -90,14 +90,14 @@ let not x = if x then False else True
 /// Folds a lift from the left
 let foldl f x xs =
     match xs with
-        | Cons y ys -> foldl f (f x y) ys
-        | Nil -> x
+    | Cons y ys -> foldl f (f x y) ys
+    | Nil -> x
 
 /// Folds a lift from the right
 let foldr f x xs =
     match xs with
-        | Cons y ys -> f y (foldr f x ys)
-        | Nil -> x
+    | Cons y ys -> f y (foldr f x ys)
+    | Nil -> x
 
 /// `Eq a` defines equality (==) on `a`
 type Eq a = {
@@ -260,24 +260,24 @@ let make_Ord ord =
         compare,
         (<=) = \l r ->
             match compare l r with
-                | LT -> True
-                | EQ -> True
-                | GT -> False,
+            | LT -> True
+            | EQ -> True
+            | GT -> False,
         (<) = \l r ->
             match compare l r with
-                | LT -> True
-                | EQ -> False
-                | GT -> False,
+            | LT -> True
+            | EQ -> False
+            | GT -> False,
         (>) = \l r ->
             match compare l r with
-                | LT -> False
-                | EQ -> False
-                | GT -> True,
+            | LT -> False
+            | EQ -> False
+            | GT -> True,
         (>=) = \l r ->
             match compare l r with
-                | LT -> False
-                | EQ -> True
-                | GT -> True
+            | LT -> False
+            | EQ -> True
+            | GT -> True
     }
 
 /**
@@ -366,22 +366,24 @@ let functor_Function : Functor ((->) a) = {
 }
 
 let functor_Option : Functor Option = {
-    map = \f x -> match x with
-                    | Some y -> Some (f y)
-                    | None -> None
+    map = \f x ->
+        match x with
+        | Some y -> Some (f y)
+        | None -> None
 }
 
 let functor_Result : Functor (Result e) = {
-    map = \f x -> match x with
-                    | Ok y -> Ok (f y)
-                    | Err _ -> x
+    map = \f x ->
+        match x with
+        | Ok y -> Ok (f y)
+        | Err _ -> x
 }
 
 let functor_List : Functor List =
     let map f xs =
         match xs with
-            | Cons y ys -> Cons (f y) (map f ys)
-            | Nil -> Nil
+        | Cons y ys -> Cons (f y) (map f ys)
+        | Nil -> Nil
     { map }
 
 let functor_IO : Functor IO = {
@@ -408,11 +410,11 @@ let applicative_Option : Applicative Option = {
     functor = functor_Option,
     apply = \f x ->
         match f with
-            | Some g ->
-                match x with
-                    | Some y -> Some (g y)
-                    | None -> None
-            | None -> None,
+        | Some g ->
+            match x with
+            | Some y -> Some (g y)
+            | None -> None
+        | None -> None,
     pure = \x -> Some x
 }
 
@@ -420,11 +422,11 @@ let applicative_Result : Applicative (Result e) = {
     functor = functor_Result,
     apply = \f x ->
         match f with
-            | Ok g ->
-                match x with
-                    | Ok y -> Ok (g y)
-                    | Err _ -> x
-            | Err x -> Err x,
+        | Ok g ->
+            match x with
+            | Ok y -> Ok (g y)
+            | Err _ -> x
+        | Err x -> Err x,
     pure = \x -> Ok x
 }
 
@@ -433,8 +435,8 @@ let applicative_List : Applicative List =
 
     let apply f xs =
         match f with
-            | Cons g gs -> (functor_List.map g xs) <> (apply gs xs)
-            | Nil -> Nil
+        | Cons g gs -> (functor_List.map g xs) <> (apply gs xs)
+        | Nil -> Nil
     let pure x = Cons x Nil
 
     { functor = functor_List, apply, pure }
@@ -466,8 +468,8 @@ let alternative_Option : Alternative Option = {
     applicative = applicative_Option,
     or = \x y ->
         match x with
-            | Some _ -> x
-            | None -> y,
+        | Some _ -> x
+        | None -> y,
     empty = None
 }
 
@@ -507,8 +509,8 @@ let monad_Option : Monad Option = {
     applicative = applicative_Option,
     flat_map = \f m ->
         match m with
-            | Some x -> f x
-            | None -> None
+        | Some x -> f x
+        | None -> None
 }
 
 let monad_List : Monad List =
@@ -516,8 +518,8 @@ let monad_List : Monad List =
 
     let flat_map f xs =
         match xs with
-            | Cons x ys -> (f x) <> (flat_map f ys)
-            | Nil -> Nil
+        | Cons x ys -> (f x) <> (flat_map f ys)
+        | Nil -> Nil
 
     { applicative = applicative_List, flat_map }
 
@@ -536,8 +538,8 @@ let make_Monad m =
     let join mm /* : m (m a) -> m a */ = mm >>= id
     let forM_ xs f /* : List a -> (a -> m b) -> m () */ =
         match xs with
-            | Cons y ys -> f y *> forM_ ys f
-            | Nil -> pure ()
+        | Cons y ys -> f y *> forM_ ys f
+        | Nil -> pure ()
 
     { applicative, flat_map, (=<<), (>>=), join, forM_ }
 
@@ -572,26 +574,26 @@ let show_List : Show a -> Show (List a) = \d ->
     let show xs =
         let show2 ys =
             match ys with
-                | Cons y ys2 ->
-                    match ys2 with
-                        | Cons z zs -> d.show y ++ ", " ++ show2 ys2
-                        | Nil -> d.show y ++ "]"
-                | Nil -> "]"
+            | Cons y ys2 ->
+                match ys2 with
+                | Cons z zs -> d.show y ++ ", " ++ show2 ys2
+                | Nil -> d.show y ++ "]"
+            | Nil -> "]"
         "[" ++ show2 xs
     { show }
 
 let show_Option : Show a -> Show (Option a) = \d ->
     let show o =
         match o with
-            | Some x -> "Some (" ++ d.show x ++ ")"
-            | None -> "None"
+        | Some x -> "Some (" ++ d.show x ++ ")"
+        | None -> "None"
     { show }
 
 let show_Result : Show e -> Show t -> Show (Result e t) = \e t ->
     let show o =
         match o with
-            | Ok x -> "Ok (" ++ t.show x ++ ")"
-            | Err x -> "Err (" ++ e.show x ++ ")"
+        | Ok x -> "Ok (" ++ t.show x ++ ")"
+        | Err x -> "Err (" ++ e.show x ++ ")"
     { show }
 
 {

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -374,6 +374,11 @@ in y
 1i32
 }
 
+test_expr!{ return_unit,
+"()",
+()
+}
+
 test_expr!{ let_not_in_tail_position,
 r#"
 1 #Int+ (let x = 2 in x)

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -735,9 +735,6 @@ impl<'a> Compiler<'a> {
                     Type::App(ref array, _) if **array == Type::Builtin(BuiltinType::Array) => {
                         function.emit(ConstructArray(exprs.len() as VmIndex));
                     }
-                    Type::Builtin(BuiltinType::Unit) => {
-                        function.emit(Construct { tag: 0, args: 0 })
-                    }
                     Type::Variant(ref variants) => {
                         function.emit(Construct {
                             tag: variants.row_iter()

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -1020,6 +1020,7 @@ impl<'a, 'e> PatternTranslator<'a, 'e> {
                              },
                              Some(self.extract_ident(i, &elem.value).name))
                         }));
+                    break;
                 }
                 ast::Pattern::Record { ref typ, ref fields, .. } => {
                     for (i, field) in fields.iter().enumerate() {


### PR DESCRIPTION
Tuples are currently syntax sugar over `{ _0: ..., _1: ..., ... }` which not only reduced the implementation complexity but also ensures that tuples can be projected from via `tuple._1`.