### PR TITLE
fix(compiler): Propagate catch-all patterns correctly during translation

### DIFF
--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -759,6 +759,7 @@ impl<'a> Compiler<'a> {
                          function: &mut FunctionEnvs,
                          tail_position: bool)
                          -> Result<()> {
+        assert!(args.len() == 2, "Invalid primitive application: {}", op);
         let lhs = &args[0];
         let rhs = &args[1];
         if op.as_ref() == "&&" {

--- a/vm/src/core/grammar.lalrpop
+++ b/vm/src/core/grammar.lalrpop
@@ -19,6 +19,10 @@ Identifier: Symbol = {
     <r"[A-Za-z_][A-Za-z0-9_]*"> => symbols.symbol(<>)
 };
 
+Field: (Symbol, Option<Symbol>) = {
+    <field: Identifier> <binding: ("=" <Identifier>)?> => (field, binding)
+};
+
 Pattern: Pattern = {
     <id: Identifier> => {
         if id.as_ref().starts_with(char::is_uppercase) {
@@ -29,7 +33,9 @@ Pattern: Pattern = {
     },
     <id: Identifier> <args: Identifier+> =>
         Pattern::Constructor(TypedIdent::new(id), args.into_iter().map(TypedIdent::new).collect()),
-    "{" <Comma<Identifier>> "}" => Pattern::Record(<>.into_iter().map(|field| (TypedIdent::new(field), None)).collect()),
+    "{" <Comma<Field>> "}" => Pattern::Record(<>.into_iter()
+        .map(|(field, binding)| (TypedIdent::new(field), binding))
+        .collect()),
 };
 
 Alternative: Alternative<'a> = {
@@ -53,7 +59,13 @@ AtomicExpr: Expr<'a> = {
         let args = allocator.arena.alloc_extend(args);
         Expr::Data(id, args, BytePos::default(), ExpansionId::default())
     },
-    <Identifier> => Expr::Ident(TypedIdent::new(<>), Span::default()),
+    <id: Identifier> => {
+        if id.as_ref().starts_with(char::is_uppercase) {
+            Expr::Data(TypedIdent::new(id), &[], BytePos::default(), ExpansionId::default())
+        } else {
+            Expr::Ident(TypedIdent::new(id), Span::default())
+        }
+    },
     <r"[0-9]+"> => Expr::Const(Literal::Int(<>.parse().unwrap()), Span::default()),
 };
 


### PR DESCRIPTION
This rewrites the entire pattern translation into the algorithm in [Derivation of a pattern matching compiler](http://homepages.inf.ed.ac.uk/wadler/papers/pattern/pattern.pdf) as well as [ 	The Implementation of Functional Programming Languages](https://www.microsoft.com/en-us/research/publication/the-implementation-of-functional-programming-languages/?from=http%3A%2F%2Fresearch.microsoft.com%2Fen-us%2Fum%2Fpeople%2Fsimonpj%2Fpapers%2Fslpj-book-1987%2Fstart.htm).

The implementation is currently a bit of a mess but it fixes some serious bugs which exist in the current implementation so I will do a cleanup later.