### PR TITLE
style: Update rustfmt

### DIFF
--- a/benches/check.rs
+++ b/benches/check.rs
@@ -19,8 +19,12 @@ fn typecheck_prelude(b: &mut ::test::Bencher) {
     let mut compiler = Compiler::new();
     let MacroValue { expr } = {
         let mut text = String::new();
-        File::open("std/prelude.glu").unwrap().read_to_string(&mut text).unwrap();
-        text.expand_macro(&mut compiler, &vm, "std.prelude").unwrap_or_else(|err| panic!("{}", err))
+        File::open("std/prelude.glu")
+            .unwrap()
+            .read_to_string(&mut text)
+            .unwrap();
+        text.expand_macro(&mut compiler, &vm, "std.prelude")
+            .unwrap_or_else(|err| panic!("{}", err))
     };
     b.iter(|| {
         let result = MacroValue { expr: expr.clone() }.typecheck(&mut compiler, &vm, "<top>", "");
@@ -38,7 +42,10 @@ fn clone_prelude(b: &mut ::test::Bencher) {
     let mut compiler = Compiler::new();
     let TypecheckValue { expr, .. } = {
         let mut text = String::new();
-        File::open("std/prelude.glu").unwrap().read_to_string(&mut text).unwrap();
+        File::open("std/prelude.glu")
+            .unwrap()
+            .read_to_string(&mut text)
+            .unwrap();
         text.typecheck(&mut compiler, &vm, "std.prelude", &text)
             .unwrap_or_else(|err| panic!("{}", err))
     };

--- a/benches/function_call.rs
+++ b/benches/function_call.rs
@@ -24,9 +24,9 @@ fn factorial(b: &mut ::test::Bencher) {
         .unwrap();
     let mut factorial: FunctionRef<fn(i32) -> i32> = vm.get_global("factorial").unwrap();
     b.iter(|| {
-        let result = factorial.call(100).unwrap();
-        ::test::black_box(result)
-    })
+               let result = factorial.call(100).unwrap();
+               ::test::black_box(result)
+           })
 }
 
 #[bench]
@@ -44,9 +44,9 @@ fn factorial_tail_call(b: &mut ::test::Bencher) {
         .unwrap();
     let mut factorial: FunctionRef<fn(i32) -> i32> = vm.get_global("factorial").unwrap();
     b.iter(|| {
-        let result = factorial.call(100).unwrap();
-        ::test::black_box(result)
-    })
+               let result = factorial.call(100).unwrap();
+               ::test::black_box(result)
+           })
 }
 
 #[bench]
@@ -57,7 +57,8 @@ fn gluon_rust_boundary_overhead(b: &mut ::test::Bencher) {
         Status::Ok
     }
 
-    vm.define_global("test_fn", primitive::<fn(i32)>("test_fn", test_fn)).unwrap();
+    vm.define_global("test_fn", primitive::<fn(i32)>("test_fn", test_fn))
+        .unwrap();
 
     let text = r#"
     let for n f =
@@ -77,13 +78,11 @@ fn gluon_rust_boundary_overhead(b: &mut ::test::Bencher) {
             for (n #Int- 10) f
     \n -> for n test_fn
     "#;
-    Compiler::new()
-        .load_script(&vm, "test", text)
-        .unwrap();
+    Compiler::new().load_script(&vm, "test", text).unwrap();
 
     let mut test: FunctionRef<fn(i32) -> ()> = vm.get_global("test").unwrap();
     b.iter(|| {
-        let result = test.call(1000).unwrap();
-        ::test::black_box(result)
-    })
+               let result = test.call(1000).unwrap();
+               ::test::black_box(result)
+           })
 }

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -19,8 +19,8 @@ fn prelude(b: &mut ::test::Bencher) {
     b.iter(|| {
         let mut symbols = Symbols::new();
         let mut symbols = SymbolModule::new("".into(), &mut symbols);
-        let expr = parser::parse_expr(&mut symbols, &text)
-            .unwrap_or_else(|err| panic!("{:?}", err));
+        let expr =
+            parser::parse_expr(&mut symbols, &text).unwrap_or_else(|err| panic!("{:?}", err));
         ::test::black_box(expr)
     })
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 newline_style = "Native"
-where_trailing_comma = true
 use_try_shorthand = true

--- a/src/import.rs
+++ b/src/import.rs
@@ -78,7 +78,8 @@ impl Importer for DefaultImporter {
               -> Result<(), MacroError> {
         use compiler_pipeline::*;
 
-        MacroValue { expr: expr }.load_script(compiler, vm, modulename, input, None)
+        MacroValue { expr: expr }
+            .load_script(compiler, vm, modulename, input, None)
             .sync_or_error()?;
         Ok(())
     }
@@ -106,7 +107,8 @@ impl Importer for CheckImporter {
         self.0.lock().unwrap().insert(module_name.into(), expr);
         let metadata = Metadata::default();
         // Insert a global to ensure the globals type can be looked up
-        vm.global_env().set_global(Symbol::from(module_name), typ, metadata, Value::Int(0))?;
+        vm.global_env()
+            .set_global(Symbol::from(module_name), typ, metadata, Value::Int(0))?;
         Ok(())
     }
 }
@@ -133,7 +135,7 @@ impl<I> Import<I> {
     }
 
     pub fn read_file<P>(&self, filename: P) -> Result<Cow<'static, str>, MacroError>
-        where P: AsRef<Path>,
+        where P: AsRef<Path>
     {
         self.read_file_(filename.as_ref())
     }
@@ -142,35 +144,38 @@ impl<I> Import<I> {
 
         // Retrieve the source, first looking in the standard library included in the
         // binary
-        let std_file = filename.to_str()
+        let std_file = filename
+            .to_str()
             .and_then(|filename| STD_LIBS.iter().find(|tup| tup.0 == filename));
         Ok(match std_file {
-            Some(tup) => Cow::Borrowed(tup.1),
-            None => {
-                let file = self.paths
-                    .read()
-                    .unwrap()
-                    .iter()
-                    .filter_map(|p| {
-                        let base = p.join(filename);
-                        match File::open(&base) {
-                            Ok(file) => Some(file),
-                            Err(_) => None,
-                        }
-                    })
-                    .next();
-                let mut file = file.ok_or_else(|| {
-                        Error::String(format!("Could not find file '{}'", filename.display()))
-                    })?;
-                file.read_to_string(&mut buffer)?;
-                Cow::Owned(buffer)
-            }
-        })
+               Some(tup) => Cow::Borrowed(tup.1),
+               None => {
+            let file = self.paths
+                .read()
+                .unwrap()
+                .iter()
+                .filter_map(|p| {
+                                let base = p.join(filename);
+                                match File::open(&base) {
+                                    Ok(file) => Some(file),
+                                    Err(_) => None,
+                                }
+                            })
+                .next();
+            let mut file = file.ok_or_else(|| {
+                                               Error::String(format!("Could not find file '{}'",
+                                                                     filename.display()))
+                                           })?;
+            file.read_to_string(&mut buffer)?;
+            Cow::Owned(buffer)
+        }
+           })
     }
 }
 
 fn get_state<'m>(macros: &'m mut MacroExpander) -> &'m mut State {
-    macros.state
+    macros
+        .state
         .entry(String::from("import"))
         .or_insert_with(|| Box::new(State { visited: Vec::new() }))
         .downcast_mut::<State>()
@@ -183,7 +188,7 @@ struct State {
 }
 
 impl<I> Macro for Import<I>
-    where I: Importer,
+    where I: Importer
 {
     fn expand(&self,
               macros: &mut MacroExpander,
@@ -217,8 +222,8 @@ impl<I> Macro for Import<I>
 
                     let mut compiler = Compiler::new().implicit_prelude(modulename != "std.types");
                     let errors = macros.errors.len();
-                    let macro_result =
-                        file_contents.expand_macro_with(&mut compiler, macros, &modulename)?;
+                    let macro_result = file_contents
+                        .expand_macro_with(&mut compiler, macros, &modulename)?;
                     if errors != macros.errors.len() {
                         // If macro expansion of the imported module fails we need to stop
                         // compilation of that module. To return an error we return one of the

--- a/src/io.rs
+++ b/src/io.rs
@@ -8,7 +8,8 @@ use vm::gc::{Gc, Traverseable};
 use vm::types::*;
 use vm::thread::ThreadInternal;
 use vm::thread::Thread;
-use vm::api::{Array, FunctionRef, Generic, Hole, VmType, Getable, OpaqueValue, IO, WithVM, Userdata};
+use vm::api::{Array, FunctionRef, Generic, Hole, VmType, Getable, OpaqueValue, IO, WithVM,
+              Userdata};
 use vm::api::generic::{A, B};
 use vm::stack::StackFrame;
 use vm::internal::ValuePrinter;
@@ -182,7 +183,9 @@ fn run_expr(WithVM { vm, value: expr }: WithVM<&str>) -> IO<String> {
 
 fn load_script(WithVM { vm, value: name }: WithVM<&str>, expr: &str) -> IO<String> {
     let frame_level = vm.context().stack.get_frames().len();
-    let run_result = Compiler::new().load_script_async(vm, name, expr).sync_or_error();
+    let run_result = Compiler::new()
+        .load_script_async(vm, name, expr)
+        .sync_or_error();
     let mut context = vm.context();
     let stack = StackFrame::current(&mut context.stack);
     match run_result {
@@ -201,7 +204,8 @@ pub fn load(vm: &Thread) -> Result<()> {
                            Call(1), // [f, m_ret]       Call m ()
                            PushInt(0), // [f, m_ret, ()]   Add a dummy argument ()
                            TailCall(2) /* [f_ret]          Call f m_ret () */];
-    let io_flat_map_type = <fn (fn (A) -> IO<B>, IO<A>) -> IO<B> as VmType>::make_type(vm);
+    let io_flat_map_type =
+        <fn(fn(A) -> IO<B>, IO<A>) -> IO<B> as VmType>::make_type(vm);
     vm.add_bytecode("io_flat_map", io_flat_map_type, 3, io_flat_map)?;
 
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -17,13 +17,16 @@ use gluon::Compiler;
 use gluon::import::Import;
 
 fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<()> {
-    Compiler::new().load_script_async(vm, filename, input).sync_or_error()
+    Compiler::new()
+        .load_script_async(vm, filename, input)
+        .sync_or_error()
 }
 
 fn make_vm() -> RootedThread {
     let vm = ::gluon::new_vm();
     let import = vm.get_macros().get("import");
-    import.as_ref()
+    import
+        .as_ref()
         .and_then(|import| import.downcast_ref::<Import>())
         .expect("Import macro")
         .add_path("..");
@@ -43,8 +46,7 @@ let mul : Float -> Float -> Float = \x y -> x #Float* y in mul
     load_script(&mut vm, "add10", &add10).unwrap_or_else(|err| panic!("{}", err));
     load_script(&mut vm, "mul", &mul).unwrap_or_else(|err| panic!("{}", err));
     {
-        let mut f: FunctionRef<fn(VmInt) -> VmInt> = vm.get_global("add10")
-            .unwrap();
+        let mut f: FunctionRef<fn(VmInt) -> VmInt> = vm.get_global("add10").unwrap();
         let result = f.call(2).unwrap();
         assert_eq!(result, 12);
     }
@@ -77,8 +79,7 @@ fn root_data() {
     vm.define_global("test", primitive!(2 test)).unwrap();
     load_script(&vm, "script_fn", expr).unwrap_or_else(|err| panic!("{}", err));
     let mut script_fn: FunctionRef<fn(Test) -> VmInt> = vm.get_global("script_fn").unwrap();
-    let result = script_fn.call(Test(123))
-        .unwrap();
+    let result = script_fn.call(Test(123)).unwrap();
     assert_eq!(result, 124);
 }
 
@@ -118,7 +119,8 @@ sum_bytes [100b, 42b, 3b, 15b]
     }
 
     let vm = make_vm();
-    vm.define_global("sum_bytes", primitive!(1 sum_bytes)).unwrap();
+    vm.define_global("sum_bytes", primitive!(1 sum_bytes))
+        .unwrap();
 
     let result = Compiler::new()
         .run_expr::<u8>(&vm, "<top>", expr)
@@ -162,15 +164,17 @@ fn return_delayed_future() {
         let (ping_c, ping_p) = channel();
         let (pong_c, pong_p) = channel();
         spawn(move || {
-            ping_p.wait().expect("wait");
-            pong_c.send(i).expect("send");
-        });
+                  ping_p.wait().expect("wait");
+                  pong_c.send(i).expect("send");
+              });
         FutureResult(lazy(move || {
-                ping_c.send(()).unwrap();
-                Ok(())
-            })
-            .and_then(|_| pong_p.map_err(|err| Error::Message(format!("{}", err))))
-            .boxed())
+                              ping_c.send(()).unwrap();
+                              Ok(())
+                          })
+                             .and_then(|_| {
+                                           pong_p.map_err(|err| Error::Message(format!("{}", err)))
+                                       })
+                             .boxed())
     }
 
     let expr = r#"

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -15,9 +15,10 @@ fn lib_dir(out_dir: &Path, lib_name: &str) -> PathBuf {
         .unwrap()
         .filter_map(|entry| {
             let entry = entry.expect("dir entry");
-            if entry.path()
-                .to_str()
-                .map_or(false, |name| name.contains(lib_name)) {
+            if entry
+                   .path()
+                   .to_str()
+                   .map_or(false, |name| name.contains(lib_name)) {
                 Some(entry)
             } else {
                 None
@@ -25,8 +26,12 @@ fn lib_dir(out_dir: &Path, lib_name: &str) -> PathBuf {
         })
         .collect();
     gluon_rlibs.sort_by(|l, r| {
-        l.metadata().unwrap().modified().unwrap().cmp(&r.metadata().unwrap().modified().unwrap())
-    });
+                            l.metadata()
+                                .unwrap()
+                                .modified()
+                                .unwrap()
+                                .cmp(&r.metadata().unwrap().modified().unwrap())
+                        });
     gluon_rlibs.last().expect("libgluon not found").path()
 }
 

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -33,18 +33,23 @@ fn function_hook() {
         let functions = functions.clone();
         let mut context = thread.context();
         context.set_hook(Some(Box::new(move |_, debug_context| {
-            functions.lock()
+            functions
+                .lock()
                 .unwrap()
-                .push(debug_context.stack_info(0)
-                    .unwrap()
-                    .function_name()
-                    .expect("function_name")
-                    .to_string());
+                .push(debug_context
+                          .stack_info(0)
+                          .unwrap()
+                          .function_name()
+                          .expect("function_name")
+                          .to_string());
             Ok(Async::Ready(()))
         })));
         context.set_hook_mask(CALL_FLAG);
     }
-    Compiler::new().implicit_prelude(false).run_expr::<i32>(&thread, "test", SIMPLE_EXPR).unwrap();
+    Compiler::new()
+        .implicit_prelude(false)
+        .run_expr::<i32>(&thread, "test", SIMPLE_EXPR)
+        .unwrap();
 
     assert_eq!(*functions.lock().unwrap(),
                vec!["test".to_string(), "g".to_string(), "f".to_string()]);
@@ -81,7 +86,10 @@ fn line_hook() {
     }
 
     assert_eq!(lines,
-               vec![1, 3, 4, 3, 1].into_iter().map(Line::from).collect::<Vec<_>>());
+               vec![1, 3, 4, 3, 1]
+                   .into_iter()
+                   .map(Line::from)
+                   .collect::<Vec<_>>());
 }
 
 #[test]
@@ -121,7 +129,10 @@ fn line_hook_after_call() {
     }
 
     assert_eq!(lines,
-               vec![1, 2, 1, 3].into_iter().map(Line::from).collect::<Vec<_>>());
+               vec![1, 2, 1, 3]
+                   .into_iter()
+                   .map(Line::from)
+                   .collect::<Vec<_>>());
 }
 
 #[test]
@@ -131,14 +142,15 @@ fn implicit_prelude_lines_not_counted() {
     let thread = new_vm();
     {
         let mut context = thread.context();
-        context.set_hook(Some(Box::new(move |_, debug_info| if debug_info.stack_info(0)
-            .unwrap()
-            .source_name() ==
-                                                                    "test" {
-            Ok(Async::NotReady)
-        } else {
-            Ok(Async::Ready(()))
-        })));
+        context.set_hook(Some(Box::new(move |_, debug_info| if debug_info
+                                              .stack_info(0)
+                                              .unwrap()
+                                              .source_name() ==
+                                                               "test" {
+                                           Ok(Async::NotReady)
+                                       } else {
+                                           Ok(Async::Ready(()))
+                                       })));
         context.set_hook_mask(LINE_FLAG);
     }
     let mut execute = Compiler::new()
@@ -175,12 +187,16 @@ fn read_variables() {
         let mut context = thread.context();
         context.set_hook(Some(Box::new(move |_, debug_context| {
             let stack_info = debug_context.stack_info(0).unwrap();
-            result.lock().unwrap().insert(stack_info.line().unwrap().to_usize(),
-                                          stack_info.locals()
-                                              .map(|local| {
-                                                  (local.name.declared_name().to_string(), local.typ.clone())
-                                              })
-                                              .collect::<Vec<_>>());
+            result
+                .lock()
+                .unwrap()
+                .insert(stack_info.line().unwrap().to_usize(),
+                        stack_info
+                            .locals()
+                            .map(|local| {
+                                     (local.name.declared_name().to_string(), local.typ.clone())
+                                 })
+                            .collect::<Vec<_>>());
             Ok(Async::Ready(()))
         })));
         context.set_hook_mask(LINE_FLAG);
@@ -195,7 +211,10 @@ fn read_variables() {
     let z = 1.0
     1
     "#;
-    Compiler::new().implicit_prelude(false).run_expr::<i32>(&thread, "test", expr).unwrap();
+    Compiler::new()
+        .implicit_prelude(false)
+        .run_expr::<i32>(&thread, "test", expr)
+        .unwrap();
 
     let map = result.lock().unwrap();
     assert_eq!(*map,
@@ -205,9 +224,11 @@ fn read_variables() {
                          vec![("x".to_string(), Type::int()),
                               ("y2".to_string(), Type::string())]),
                         (6,
-                         vec![("x".to_string(), Type::int()), ("y".to_string(), Type::unit())]),
+                         vec![("x".to_string(), Type::int()),
+                              ("y".to_string(), Type::unit())]),
                         (7,
-                         vec![("x".to_string(), Type::int()), ("y".to_string(), Type::unit())]),
+                         vec![("x".to_string(), Type::int()),
+                              ("y".to_string(), Type::unit())]),
                         (8,
                          vec![("x".to_string(), Type::int()),
                               ("y".to_string(), Type::unit()),
@@ -225,13 +246,16 @@ fn argument_types() {
         let mut context = thread.context();
         context.set_hook(Some(Box::new(move |_, debug_context| {
             let stack_info = debug_context.stack_info(0).unwrap();
-            result.lock().unwrap().push((stack_info.line().unwrap().to_usize(),
-                                         stack_info.locals()
-                                             .map(|local| {
-                                                 (local.name.declared_name().to_string(),
-                                                  local.typ.clone())
-                                             })
-                                             .collect::<Vec<_>>()));
+            result
+                .lock()
+                .unwrap()
+                .push((stack_info.line().unwrap().to_usize(),
+                       stack_info
+                           .locals()
+                           .map(|local| {
+                                    (local.name.declared_name().to_string(), local.typ.clone())
+                                })
+                           .collect::<Vec<_>>()));
             Ok(Async::Ready(()))
         })));
         context.set_hook_mask(LINE_FLAG);
@@ -242,7 +266,10 @@ fn argument_types() {
     let f z = g z
     f 1
     "#;
-    Compiler::new().implicit_prelude(false).run_expr::<i32>(&thread, "test", expr).unwrap();
+    Compiler::new()
+        .implicit_prelude(false)
+        .run_expr::<i32>(&thread, "test", expr)
+        .unwrap();
 
     let int_function: ArcType = Type::function(vec![Type::int()], Type::int());
 
@@ -272,10 +299,11 @@ fn source_name() {
         let result = result.clone();
         let mut context = thread.context();
         context.set_hook(Some(Box::new(move |_, debug_context| {
-            let stack_info = debug_context.stack_info(0).unwrap();
-            *result.lock().unwrap() = stack_info.source_name().to_string();
-            Ok(Async::Ready(()))
-        })));
+                                           let stack_info = debug_context.stack_info(0).unwrap();
+                                           *result.lock().unwrap() =
+                                               stack_info.source_name().to_string();
+                                           Ok(Async::Ready(()))
+                                       })));
         context.set_hook_mask(LINE_FLAG);
     }
     let expr = r#"
@@ -288,7 +316,10 @@ fn source_name() {
     let z = { x }
     1
     "#;
-    Compiler::new().implicit_prelude(false).run_expr::<i32>(&thread, "test", expr).unwrap();
+    Compiler::new()
+        .implicit_prelude(false)
+        .run_expr::<i32>(&thread, "test", expr)
+        .unwrap();
 
     let name = result.lock().unwrap();
     assert_eq!(*name, "test");
@@ -307,7 +338,10 @@ fn upvars() {
         context.set_hook(Some(Box::new(move |_, debug_info| {
             let stack_info = debug_info.stack_info(0).unwrap();
             if stack_info.source_name() == "test" {
-                result.lock().unwrap().push(stack_info.upvars().to_owned());
+                result
+                    .lock()
+                    .unwrap()
+                    .push(stack_info.upvars().to_owned());
             }
             Ok(Async::Ready(()))
         })));
@@ -356,21 +390,29 @@ fn implicit_prelude_variable_names() {
         let mut context = thread.context();
         context.set_hook(Some(Box::new(move |_, debug_context| {
             let stack_info = debug_context.stack_info(0).unwrap();
-            functions.lock()
+            functions
+                .lock()
                 .unwrap()
-                .extend(stack_info.locals()
-                    .filter(|local| local.name.declared_name() == "__implicit_prelude")
-                    .map(|local| local.typ.clone()));
+                .extend(stack_info
+                            .locals()
+                            .filter(|local| {
+                                        local.name.declared_name() == "__implicit_prelude"
+                                    })
+                            .map(|local| local.typ.clone()));
             Ok(Async::Ready(()))
         })));
         context.set_hook_mask(LINE_FLAG);
     }
-    Compiler::new().run_expr::<i32>(&thread, "test", "\n1").unwrap();
+    Compiler::new()
+        .run_expr::<i32>(&thread, "test", "\n1")
+        .unwrap();
     let f = functions.lock().unwrap();
     match *f[0] {
         Type::Record(ref row) => {
-            assert!(row.row_iter().any(|field| field.name.declared_name() == "id"));
-            assert!(row.row_iter().any(|field| field.name.declared_name() == "not"));
+            assert!(row.row_iter()
+                        .any(|field| field.name.declared_name() == "id"));
+            assert!(row.row_iter()
+                        .any(|field| field.name.declared_name() == "not"));
         }
         _ => panic!(),
     }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -10,6 +10,8 @@ fn dont_panic_when_error_span_is_at_eof() {
     let _ = ::env_logger::init();
     let vm = support::make_vm();
     let text = r#"abc"#;
-    let result = Compiler::new().load_script_async(&vm, "test", text).sync_or_error();
+    let result = Compiler::new()
+        .load_script_async(&vm, "test", text)
+        .sync_or_error();
     assert!(result.is_err());
 }

--- a/tests/http.rs
+++ b/tests/http.rs
@@ -21,11 +21,11 @@ fn test_server(easy: &mut Easy,
     easy.url(&format!("localhost:{}{}", port, path)).unwrap();
     let out = Arc::new(Mutex::new(Vec::new()));
     easy.read_function(move |buffer| {
-            let len = cmp::min(buffer.len(), message.len());
-            buffer[..len].copy_from_slice(&message[..len]);
-            message = &message[len..];
-            Ok(len)
-        })?;
+                           let len = cmp::min(buffer.len(), message.len());
+                           buffer[..len].copy_from_slice(&message[..len]);
+                           message = &message[len..];
+                           Ok(len)
+                       })?;
     {
         let out = out.clone();
         easy.write_function(move |data| Ok(out.lock().unwrap().write(data).unwrap()))

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -22,8 +22,9 @@ fn read_file() {
             assert (array.index bytes 1 #Byte== 112b) // p
             pure (array.index bytes 8)
         "#;
-    let result =
-        Compiler::new().run_io_expr_async::<IO<u8>>(&thread, "<top>", text).sync_or_error();
+    let result = Compiler::new()
+        .run_io_expr_async::<IO<u8>>(&thread, "<top>", text)
+        .sync_or_error();
 
     match result {
         Ok((IO::Value(value), _)) => assert_eq!(value, b']'),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -39,13 +39,13 @@ fn test_files(path: &str) -> Result<Vec<PathBuf>, Box<Error>> {
     let paths: Vec<_> = dir.filter_map(|f| {
             f.ok()
                 .and_then(|f| {
-                    let path = f.path();
-                    if path.extension().and_then(|e| e.to_str()) == Some("glu") {
-                        Some(path)
-                    } else {
-                        None
-                    }
-                })
+                              let path = f.path();
+                              if path.extension().and_then(|e| e.to_str()) == Some("glu") {
+                                  Some(path)
+                              } else {
+                                  None
+                              }
+                          })
         })
         .collect();
     assert!(!paths.is_empty(), "Expected test files");
@@ -55,7 +55,9 @@ fn test_files(path: &str) -> Result<Vec<PathBuf>, Box<Error>> {
 fn main_() -> Result<(), Box<Error>> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
-    compiler.load_file_async(&vm, "std/prelude.glu").sync_or_error()?;
+    compiler
+        .load_file_async(&vm, "std/prelude.glu")
+        .sync_or_error()?;
     let mut text = String::new();
     let _ = ::env_logger::init();
     for filename in test_files("tests/pass")? {
@@ -64,7 +66,9 @@ fn main_() -> Result<(), Box<Error>> {
         file.read_to_string(&mut text)?;
         let name = filename.to_str().unwrap_or("<unknown>");
         println!("test {}", name);
-        compiler.run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, name, &text).sync_or_error()?;
+        compiler
+            .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, name, &text)
+            .sync_or_error()?;
     }
     for filename in test_files("tests/fail")? {
         let mut file = File::open(&filename)?;
@@ -72,13 +76,14 @@ fn main_() -> Result<(), Box<Error>> {
         file.read_to_string(&mut text)?;
         let name = filename.to_str().unwrap_or("<unknown>");
         println!("test {}", name);
-        match compiler.run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, name, &text)
-            .sync_or_error() {
+        match compiler
+                  .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, name, &text)
+                  .sync_or_error() {
             Ok(x) => {
                 return Err(StringError(format!("Expected test '{}' to fail got {:?}",
                                                filename.to_str().unwrap(),
                                                x))
-                    .into())
+                                   .into())
             }
             Err(er) => println!("{}", er),
         }

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -8,7 +8,8 @@ use gluon::Compiler;
 fn make_vm() -> RootedThread {
     let vm = ::gluon::new_vm();
     let import = vm.get_macros().get("import");
-    import.as_ref()
+    import
+        .as_ref()
         .and_then(|import| import.downcast_ref::<Import>())
         .expect("Import macro")
         .add_path("..");
@@ -23,7 +24,10 @@ fn metadata_from_other_module() {
 let { List, id }  = import! "std/prelude.hs"
 { List, id }
 "#;
-    Compiler::new().load_script_async(&vm, "test", text).sync_or_error().unwrap();
+    Compiler::new()
+        .load_script_async(&vm, "test", text)
+        .sync_or_error()
+        .unwrap();
 
     let env = vm.get_env();
     assert!(env.get_metadata("test.id").is_ok());

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -18,7 +18,8 @@ fn parallel() {
 fn parallel_() -> Result<(), Error> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
-    let (value, _) = compiler.run_expr_async(&vm, "<top>", " channel 0 ")
+    let (value, _) = compiler
+        .run_expr_async(&vm, "<top>", " channel 0 ")
         .sync_or_error()?;
     let value: ChannelRecord<OpaqueValue<RootedThread, Sender<i32>>,
                              OpaqueValue<RootedThread, Receiver<i32>>> = value;
@@ -34,10 +35,10 @@ fn parallel_() -> Result<(), Error> {
         f
         "#;
         let mut compiler = Compiler::new();
-        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Sender<i32>>)> =
-            compiler.run_expr_async(&child, "<top>", expr)
-                .sync_or_error()?
-                .0;
+        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Sender<i32>>)> = compiler
+            .run_expr_async(&child, "<top>", expr)
+            .sync_or_error()?
+            .0;
         Ok(f.call(sender)?)
     });
 
@@ -55,10 +56,10 @@ fn parallel_() -> Result<(), Error> {
         f
         "#;
         let mut compiler = Compiler::new();
-        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Receiver<i32>>)> =
-            compiler.run_expr_async(&child2, "<top>", expr)
-                .sync_or_error()?
-                .0;
+        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Receiver<i32>>)> = compiler
+            .run_expr_async(&child2, "<top>", expr)
+            .sync_or_error()?
+            .0;
         Ok(f.call(receiver)?)
     });
 

--- a/tests/regex_bind.rs
+++ b/tests/regex_bind.rs
@@ -19,7 +19,9 @@ fn regex_match() {
         let match_hello = regex.new "hello, .*" |> unwrap_ok
         regex.is_match match_hello "hello, world"
         "#;
-    let result = Compiler::new().run_expr_async::<bool>(&thread, "<top>", text).sync_or_error();
+    let result = Compiler::new()
+        .run_expr_async::<bool>(&thread, "<top>", text)
+        .sync_or_error();
 
     assert!(result.unwrap().0);
 }
@@ -34,7 +36,9 @@ fn regex_error() {
 
         regex.new ")" |> unwrap_err |> regex.error_to_string
         "#;
-    let result = Compiler::new().run_expr_async::<String>(&thread, "<top>", text).sync_or_error();
+    let result = Compiler::new()
+        .run_expr_async::<String>(&thread, "<top>", text)
+        .sync_or_error();
 
     assert_eq!(result.unwrap().0,
                "Error parsing regex near \')\' at character offset 0: Unopened parenthesis.");

--- a/tests/stack_overflow.rs
+++ b/tests/stack_overflow.rs
@@ -731,5 +731,8 @@ let _ = 1
 in 1
 "#;
     let vm = new_vm();
-    Compiler::new().load_script_async(&vm, "", text).sync_or_error().unwrap();
+    Compiler::new()
+        .load_script_async(&vm, "", text)
+        .sync_or_error()
+        .unwrap();
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -17,7 +17,7 @@ pub fn load_script(vm: &Thread, filename: &str, input: &str) -> ::gluon::Result<
 
 #[allow(dead_code)]
 pub fn run_expr_<'vm, T>(vm: &'vm Thread, s: &str, implicit_prelude: bool) -> T
-    where T: Getable<'vm> + VmType + Send + 'vm,
+    where T: Getable<'vm> + VmType + Send + 'vm
 {
     Compiler::new()
         .implicit_prelude(implicit_prelude)
@@ -29,7 +29,7 @@ pub fn run_expr_<'vm, T>(vm: &'vm Thread, s: &str, implicit_prelude: bool) -> T
 
 #[allow(dead_code)]
 pub fn run_expr<'vm, T>(vm: &'vm Thread, s: &str) -> T
-    where T: Getable<'vm> + VmType + Send + 'vm,
+    where T: Getable<'vm> + VmType + Send + 'vm
 {
     run_expr_(vm, s, false)
 }
@@ -38,7 +38,8 @@ pub fn run_expr<'vm, T>(vm: &'vm Thread, s: &str) -> T
 pub fn make_vm() -> RootedThread {
     let vm = ::gluon::new_vm();
     let import = vm.get_macros().get("import");
-    import.as_ref()
+    import
+        .as_ref()
         .and_then(|import| import.downcast_ref::<Import>())
         .expect("Import macro")
         .add_path("..");

--- a/tests/tutorial.rs
+++ b/tests/tutorial.rs
@@ -12,7 +12,8 @@ use gluon::Compiler;
 fn new_vm() -> RootedThread {
     let vm = ::gluon::new_vm();
     let import = vm.get_macros().get("import");
-    import.as_ref()
+    import
+        .as_ref()
         .and_then(|import| import.downcast_ref::<Import>())
         .expect("Import macro")
         .add_path("..");
@@ -43,7 +44,8 @@ fn call_rust_from_gluon() {
         if x <= 1 { 1 } else { x * factorial(x - 1) }
     }
     let vm = new_vm();
-    vm.define_global("factorial", primitive!(1 factorial)).unwrap();
+    vm.define_global("factorial", primitive!(1 factorial))
+        .unwrap();
 
     let result = Compiler::new()
         .run_expr_async::<i32>(&vm, "example", "factorial 5")

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -63,7 +63,9 @@ fn record() {
     let vm = make_vm();
     let value = run_expr::<OpaqueValue<&Thread, Hole>>(&vm, text);
     assert_eq!(value.get_ref(),
-               vm.context().new_data(&vm, 0, &mut [Int(0), Float(1.0), Value::Tag(0)]).unwrap());
+               vm.context()
+                   .new_data(&vm, 0, &mut [Int(0), Float(1.0), Value::Tag(0)])
+                   .unwrap());
 }
 
 #[test]
@@ -77,7 +79,9 @@ add { x = 0, y = 1 } { x = 1, y = 1 }
     let vm = make_vm();
     let value = run_expr::<OpaqueValue<&Thread, Hole>>(&vm, text);
     assert_eq!(value.get_ref(),
-               vm.context().new_data(&vm, 0, &mut [Int(1), Int(2)]).unwrap());
+               vm.context()
+                   .new_data(&vm, 0, &mut [Int(1), Int(2)])
+                   .unwrap());
 }
 #[test]
 fn script() {
@@ -314,7 +318,9 @@ match A with
 | B -> True
 ";
     let mut vm = make_vm();
-    let result = Compiler::new().run_expr_async::<bool>(&mut vm, "<top>", text).sync_or_error();
+    let result = Compiler::new()
+        .run_expr_async::<bool>(&mut vm, "<top>", text)
+        .sync_or_error();
     assert!(result.is_err());
 }
 
@@ -603,7 +609,9 @@ in
     let vm = make_vm();
     let result = run_expr::<OpaqueValue<&Thread, Hole>>(&vm, text);
     assert_eq!(result.get_ref(),
-               vm.context().new_data(&vm, 0, &mut [Int(3), Float(3.0)]).unwrap());
+               vm.context()
+                   .new_data(&vm, 0, &mut [Int(3), Float(3.0)])
+                   .unwrap());
 }
 
 test_expr!{ through_overloaded_alias,
@@ -782,7 +790,9 @@ let s = "åäö"
 string.slice s 1 (string.length s)
 "#;
     let mut vm = make_vm();
-    let result = Compiler::new().run_expr_async::<String>(&mut vm, "<top>", text).sync_or_error();
+    let result = Compiler::new()
+        .run_expr_async::<String>(&mut vm, "<top>", text)
+        .sync_or_error();
     match result {
         Err(Error::VM(..)) => (),
         Err(err) => panic!("Unexpected error `{}`", err),
@@ -813,8 +823,8 @@ fn partially_applied_constructor_is_lambda() {
     let _ = ::env_logger::init();
     let vm = make_vm();
 
-    let result = Compiler::new()
-        .run_expr::<FunctionRef<fn(i32) -> Option<i32>>>(&vm, "test", "Some");
+    let result =
+        Compiler::new().run_expr::<FunctionRef<fn(i32) -> Option<i32>>>(&vm, "test", "Some");
     assert!(result.is_ok(), "{}", result.err().unwrap());
     assert_eq!(result.unwrap().0.call(123), Ok(Some(123)));
 }
@@ -834,56 +844,46 @@ and g x = 1 + f (x / 2)
 g 10
 "#;
     let mut vm = make_vm();
-    let result = Compiler::new().run_expr_async::<i32>(&mut vm, "<top>", text).sync_or_error();
+    let result = Compiler::new()
+        .run_expr_async::<i32>(&mut vm, "<top>", text)
+        .sync_or_error();
     match result {
         Err(Error::VM(..)) => {
             let stacktrace = vm.context().stack.stacktrace(1);
-            let g = stacktrace.frames[0]
-                .as_ref()
-                .unwrap()
-                .name
-                .clone();
-            let f = stacktrace.frames[1]
-                .as_ref()
-                .unwrap()
-                .name
-                .clone();
-            let end = stacktrace.frames[6]
-                .as_ref()
-                .unwrap()
-                .name
-                .clone();
+            let g = stacktrace.frames[0].as_ref().unwrap().name.clone();
+            let f = stacktrace.frames[1].as_ref().unwrap().name.clone();
+            let end = stacktrace.frames[6].as_ref().unwrap().name.clone();
             assert_eq!(stacktrace.frames,
                        vec![// Removed due to being a tail call
                             // Some(StacktraceFrame { name: f.clone(), line: 9 }),
                             Some(StacktraceFrame {
-                                name: g.clone(),
-                                line: 7.into(),
-                            }),
+                                     name: g.clone(),
+                                     line: 7.into(),
+                                 }),
                             Some(StacktraceFrame {
-                                name: f.clone(),
-                                line: 6.into(),
-                            }),
+                                     name: f.clone(),
+                                     line: 6.into(),
+                                 }),
                             Some(StacktraceFrame {
-                                name: g.clone(),
-                                line: 7.into(),
-                            }),
+                                     name: g.clone(),
+                                     line: 7.into(),
+                                 }),
                             Some(StacktraceFrame {
-                                name: f.clone(),
-                                line: 6.into(),
-                            }),
+                                     name: f.clone(),
+                                     line: 6.into(),
+                                 }),
                             Some(StacktraceFrame {
-                                name: g.clone(),
-                                line: 7.into(),
-                            }),
+                                     name: g.clone(),
+                                     line: 7.into(),
+                                 }),
                             Some(StacktraceFrame {
-                                name: f.clone(),
-                                line: 4.into(),
-                            }),
+                                     name: f.clone(),
+                                     line: 4.into(),
+                                 }),
                             Some(StacktraceFrame {
-                                name: end.clone(),
-                                line: 1.into(),
-                            })]);
+                                     name: end.clone(),
+                                     line: 1.into(),
+                                 })]);
         }
         Err(err) => panic!("Unexpected error `{}`", err),
         Ok(_) => panic!("Expected an error"),
@@ -963,7 +963,9 @@ fn dont_use_the_implicit_prelude_span_in_the_top_expr() {
 
     let expr = "1";
 
-    Compiler::new().typecheck_str(&vm, "example", expr, Some(&Type::float())).unwrap_err();
+    Compiler::new()
+        .typecheck_str(&vm, "example", expr, Some(&Type::float()))
+        .unwrap_err();
 }
 
 #[test]


### PR DESCRIPTION
There does not seem to be a way to retain the behaviour of `where_trailing_comma = true` without having a traling comma on things like `Struct { field: 1, }` (single line) so I am just using the defaults again now.