### PR TITLE
perf: Share type and kind instances instead of allocating new objects

### DIFF
--- a/base/src/kind.rs
+++ b/base/src/kind.rs
@@ -129,6 +129,8 @@ impl fmt::Display for ArcKind {
     }
 }
 
+type_cache! { KindCache() { ArcKind, Kind } row hole typ }
+
 impl<F: ?Sized> Walker<ArcKind> for F
     where F: FnMut(&ArcKind)
 {

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -9,6 +9,39 @@ extern crate smallvec;
 #[macro_use]
 extern crate collect_mac;
 
+macro_rules! type_cache {
+    ($name: ident ($($args: ident),*) { $typ: ty, $inner_type: ident } $( $id: ident )+) => {
+
+        #[derive(Debug, Clone)]
+        pub struct $name<$($args),*> {
+            $(pub $id : $typ),+
+        }
+
+        impl<$($args),*> Default for $name<$($args),*> {
+            fn default() -> Self {
+                $name::new()
+            }
+        }
+
+        impl<$($args),*> $name<$($args),*> {
+            pub fn new() -> Self {
+                $name {
+                    $(
+                        $id : $inner_type::$id(),
+                    )+
+                }
+            }
+
+            $(
+                pub fn $id(&self) -> $typ {
+                    self.$id.clone()
+                }
+            )+
+        }
+    }
+}
+
+
 pub mod ast;
 pub mod error;
 pub mod fixed;

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -52,6 +52,69 @@ impl<'a, T: ?Sized + PrimitiveEnv> PrimitiveEnv for &'a T {
     }
 }
 
+macro_rules! type_cache {
+    ($( $id: ident )+) => {
+        pub struct TypeCache<Id> {
+            $(pub $id : ArcType<Id>),+
+        }
+
+        impl<Id> Default for TypeCache<Id> {
+            fn default() -> TypeCache<Id> {
+                TypeCache::new()
+            }
+        }
+
+        impl<Id> TypeCache<Id> {
+            pub fn new() -> TypeCache<Id> {
+                TypeCache {
+                    $(
+                        $id : Type::$id(),
+                    )+
+                }
+            }
+
+            $(
+                pub fn $id(&self) -> ArcType<Id> {
+                    self.$id.clone()
+                }
+            )+
+
+            pub fn function<I>(&self, args: I, ret: ArcType<Id>) -> ArcType<Id>
+                where I: IntoIterator<Item = ArcType<Id>>,
+                      I::IntoIter: DoubleEndedIterator<Item = ArcType<Id>>,
+            {
+                args.into_iter()
+                    .rev()
+                    .fold(ret,
+                        |body, arg| Type::app(self.function_builtin(), collect![arg, body]))
+            }
+
+            pub fn tuple<S, I>(&self, symbols: &mut S, elems: I) -> ArcType<Id>
+                where S: ?Sized + IdentEnv<Ident = Id>,
+                    I: IntoIterator<Item = ArcType<Id>>
+            {
+                let fields: Vec<_> = elems
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, typ)| {
+                                Field {
+                                    name: symbols.from_str(&format!("_{}", i)),
+                                    typ: typ,
+                                }
+                            })
+                        .collect();
+                if fields.is_empty() {
+                    self.unit.clone()
+                } else {
+                    Type::record(vec![], fields)
+                }
+            }
+        }
+    }
+}
+
+type_cache! { hole int byte float string char function_builtin unit }
+
 /// All the builtin types of gluon
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum BuiltinType {
@@ -485,6 +548,10 @@ impl<Id, T> Type<Id, T>
         T::from(Type::Ident(id))
     }
 
+    pub fn function_builtin() -> T {
+        Type::builtin(BuiltinType::Function)
+    }
+
     pub fn string() -> T {
         Type::builtin(BuiltinType::String)
     }
@@ -567,9 +634,15 @@ impl<T> Type<Symbol, T>
 }
 
 /// A shared type which is atomically reference counted
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Eq, PartialEq, Hash)]
 pub struct ArcType<Id = Symbol> {
     typ: Arc<Type<Id, ArcType<Id>>>,
+}
+
+impl<Id> Clone for ArcType<Id> {
+    fn clone(&self) -> ArcType<Id> {
+        ArcType { typ: self.typ.clone() }
+    }
 }
 
 impl<Id: fmt::Debug> fmt::Debug for ArcType<Id> {

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::result::Result as StdResult;
 
 use base::ast;
-use base::kind::{self, ArcKind, Kind, KindEnv};
+use base::kind::{self, ArcKind, Kind, KindEnv, KindCache};
 use base::merge;
 use base::symbol::Symbol;
 use base::types::{self, AppVec, ArcType, BuiltinType, Field, Generic, Type, Walker};
@@ -23,14 +23,11 @@ pub struct KindCheck<'a> {
     info: &'a (KindEnv + 'a),
     idents: &'a (ast::IdentEnv<Ident = Symbol> + 'a),
     pub subs: Substitution<ArcKind>,
-    /// A cached type kind, `Type`
-    type_kind: ArcKind,
+    kind_cache: KindCache,
     /// A cached one argument kind function, `Type -> Type`
     function1_kind: ArcKind,
     /// A cached two argument kind function, `Type -> Type -> Type`
     function2_kind: ArcKind,
-    /// A cached row kind: `Row`
-    row_kind: ArcKind,
 }
 
 fn walk_move_kind<F>(kind: ArcKind, f: &mut F) -> ArcKind
@@ -64,9 +61,10 @@ fn walk_move_kind2<F>(kind: &ArcKind, f: &mut F) -> Option<ArcKind>
 
 impl<'a> KindCheck<'a> {
     pub fn new(info: &'a (KindEnv + 'a),
-               idents: &'a (ast::IdentEnv<Ident = Symbol> + 'a))
+               idents: &'a (ast::IdentEnv<Ident = Symbol> + 'a),
+               kind_cache: KindCache)
                -> KindCheck<'a> {
-        let typ = Kind::typ();
+        let typ = kind_cache.typ();
         let function1_kind = Kind::function(typ.clone(), typ.clone());
         KindCheck {
             variables: Vec::new(),
@@ -74,10 +72,9 @@ impl<'a> KindCheck<'a> {
             info: info,
             idents: idents,
             subs: Substitution::new(),
-            type_kind: typ.clone(),
             function1_kind: function1_kind.clone(),
             function2_kind: Kind::function(typ, function1_kind),
-            row_kind: Kind::row(),
+            kind_cache: kind_cache,
         }
     }
 
@@ -91,7 +88,7 @@ impl<'a> KindCheck<'a> {
     }
 
     pub fn type_kind(&self) -> ArcKind {
-        self.type_kind.clone()
+        self.kind_cache.typ()
     }
 
     pub fn function1_kind(&self) -> ArcKind {
@@ -103,7 +100,7 @@ impl<'a> KindCheck<'a> {
     }
 
     pub fn row_kind(&self) -> ArcKind {
-        self.row_kind.clone()
+        self.kind_cache.row()
     }
 
     pub fn instantiate_kinds(&mut self, kind: &mut ArcKind) {
@@ -269,7 +266,7 @@ impl<'a> KindCheck<'a> {
     }
 
     pub fn finalize_type(&self, typ: ArcType) -> ArcType {
-        let default = Some(&self.type_kind);
+        let default = Some(&self.kind_cache.typ);
         types::walk_move_type(typ,
                               &mut |typ| match *typ {
                                        Type::Variable(ref var) => {
@@ -288,7 +285,7 @@ impl<'a> KindCheck<'a> {
     }
     pub fn finalize_generic(&self, var: &Generic<Symbol>) -> Generic<Symbol> {
         let mut kind = var.kind.clone();
-        kind = update_kind(&self.subs, kind, Some(&self.type_kind));
+        kind = update_kind(&self.subs, kind, Some(&self.kind_cache.typ));
         Generic::new(var.id.clone(), kind)
     }
 }

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -71,7 +71,7 @@ impl<'a> KindCheck<'a> {
             locals: Vec::new(),
             info: info,
             idents: idents,
-            subs: Substitution::new(),
+            subs: Substitution::new(()),
             function1_kind: function1_kind.clone(),
             function2_kind: Kind::function(typ, function1_kind),
             kind_cache: kind_cache,
@@ -327,10 +327,7 @@ pub fn fmt_kind_error<I>(error: &Error<I>, f: &mut fmt::Formatter) -> fmt::Resul
 
 impl Substitutable for ArcKind {
     type Variable = u32;
-
-    fn new(x: u32) -> ArcKind {
-        Kind::variable(x)
-    }
+    type Factory = ();
 
     fn from_variable(x: u32) -> ArcKind {
         Kind::variable(x)

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -26,12 +26,13 @@ use base::types::{ArcType, TypeEnv};
 
 /// Checks if `actual` can be assigned to a binding with the type signature `signature`
 pub fn check_signature(env: &TypeEnv, signature: &ArcType, actual: &ArcType) -> bool {
+    use base::kind::Kind;
     use base::scoped_map::ScopedMap;
     use base::fnv::FnvMap;
 
     use substitution::Substitution;
 
-    let subs = Substitution::new();
+    let subs = Substitution::new(Kind::typ());
     let state = unify_type::State::new(env, &subs);
     let actual = unify_type::instantiate_generic_variables(&mut FnvMap::default(), &subs, actual);
     unify_type::merge_signature(&subs, &mut ScopedMap::new(), 0, state, signature, &actual).is_ok()

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use base::ast::{self, DisplayEnv, Expr, Pattern, SpannedExpr, MutVisitor, Typed, TypedIdent};
 use base::error::Errors;
 use base::fnv::FnvMap;
-use base::kind::{ArcKind, KindEnv};
+use base::kind::{ArcKind, Kind, KindEnv};
 use base::pos::{self, BytePos, Span, Spanned};
 use base::scoped_map::ScopedMap;
 use base::symbol::{Symbol, SymbolRef, SymbolModule};
@@ -370,7 +370,7 @@ pub fn rename(symbols: &mut SymbolModule,
 pub fn equivalent(env: &TypeEnv, actual: &ArcType, inferred: &ArcType) -> bool {
     use substitution::Substitution;
     // FIXME This Substitution is unnecessary for equivalence unification
-    let subs = Substitution::new();
+    let subs = Substitution::new(Kind::typ());
     let mut unifier = UnifierState {
         state: State::new(env, &subs),
         unifier: Equivalent {

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -238,6 +238,7 @@ impl<'a> Typecheck<'a> {
                environment: &'a (PrimitiveEnv + 'a))
                -> Typecheck<'a> {
         let symbols = SymbolModule::new(module, symbols);
+        let kind_cache = KindCache::new();
         Typecheck {
             environment: Environment {
                 environment: environment,
@@ -246,12 +247,12 @@ impl<'a> Typecheck<'a> {
             },
             symbols: symbols,
             original_symbols: ScopedMap::new(),
-            subs: Substitution::new(),
+            subs: Substitution::new(kind_cache.typ()),
             named_variables: FnvMap::default(),
             errors: Errors::new(),
             type_variables: ScopedMap::new(),
             type_cache: TypeCache::new(),
-            kind_cache: KindCache::new(),
+            kind_cache: kind_cache,
         }
     }
 

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -2,6 +2,7 @@
 //! etc. Only checks which need to be aware of expressions are handled here the actual unifying and
 //! checking of types are done in the `unify_type` and `kindcheck` modules.
 use std::fmt;
+use std::iter::once;
 use std::mem;
 
 use base::scoped_map::ScopedMap;
@@ -15,7 +16,7 @@ use base::merge;
 use base::pos::{BytePos, Span, Spanned};
 use base::symbol::{Symbol, SymbolRef, SymbolModule, Symbols};
 use base::types::{self, Alias, AliasData, AppVec, ArcType, Field, Generic};
-use base::types::{PrimitiveEnv, Type, TypeEnv, TypeVariable};
+use base::types::{PrimitiveEnv, Type, TypeEnv, TypeVariable, TypeCache};
 
 use kindcheck::{self, Error as KindCheckError, KindCheck, KindError};
 use substitution::Substitution;
@@ -223,6 +224,7 @@ pub struct Typecheck<'a> {
     errors: Errors<SpannedTypeError<Symbol>>,
     /// Type variables `let test: a -> b` (`a` and `b`)
     type_variables: ScopedMap<Symbol, ArcType>,
+    type_cache: TypeCache<Symbol>,
 }
 
 /// Error returned when unsuccessfully typechecking an expression
@@ -247,6 +249,7 @@ impl<'a> Typecheck<'a> {
             named_variables: FnvMap::default(),
             errors: Errors::new(),
             type_variables: ScopedMap::new(),
+            type_cache: TypeCache::new(),
         }
     }
 
@@ -519,7 +522,8 @@ impl<'a> Typecheck<'a> {
             Expr::App(ref mut func, ref mut args) => {
                 let mut func_type = self.typecheck(&mut **func);
                 for arg in args.iter_mut() {
-                    let f = Type::function(vec![self.subs.new_var()], self.subs.new_var());
+                    let f = self.type_cache
+                        .function(once(self.subs.new_var()), self.subs.new_var());
                     func_type = self.unify(&f, func_type)?;
                     func_type = match func_type.as_function() {
                         Some((arg_ty, ret_ty)) => {
@@ -557,21 +561,24 @@ impl<'a> Typecheck<'a> {
                         "==" | "<" => self.bool(),
                         _ => return Err(TypeError::UndefinedVariable(op.value.name.clone())),
                     };
-                    op.value.typ = Type::function(vec![prim_type.clone(), prim_type.clone()],
-                                                  return_type.clone());
+                    op.value.typ = self.type_cache
+                        .function(vec![prim_type.clone(), prim_type.clone()],
+                                  return_type.clone());
                     return_type
                 } else {
                     match &*op_name {
                         "&&" | "||" => {
                             self.unify(&lhs_type, rhs_type.clone())?;
-                            op.value.typ = Type::function(vec![self.bool(), self.bool()],
-                                                          self.bool());
+                            op.value.typ =
+                                self.type_cache
+                                    .function(vec![self.bool(), self.bool()], self.bool());
                             self.unify(&self.bool(), lhs_type)?
                         }
                         _ => {
                             op.value.typ = self.find(&op.value.name)?;
-                            let func_type = Type::function(vec![lhs_type, rhs_type],
-                                                           self.subs.new_var());
+                            let func_type =
+                                self.type_cache
+                                    .function(vec![lhs_type, rhs_type], self.subs.new_var());
                             let ret = self.unify(&op.value.typ, func_type)?
                                 .as_function()
                                 .and_then(|(_, ret)| ret.as_function())
@@ -777,7 +784,7 @@ impl<'a> Typecheck<'a> {
         }
         let body_type = self.typecheck(body);
         self.exit_scope();
-        Type::function(arg_types, body_type)
+        self.type_cache.function(arg_types, body_type)
     }
 
     fn typecheck_pattern(&mut self,
@@ -907,7 +914,8 @@ impl<'a> Typecheck<'a> {
             } => {
                 let tuple_type = {
                     let subs = &mut self.subs;
-                    Type::tuple(&mut self.symbols, (0..elems.len()).map(|_| subs.new_var()))
+                    self.type_cache
+                        .tuple(&mut self.symbols, (0..elems.len()).map(|_| subs.new_var()))
                 };
                 *typ = self.unify_span(span, &tuple_type, match_type);
                 for (elem, field) in elems.iter_mut().zip(tuple_type.row_iter()) {

--- a/check/tests/row_polymorphism.rs
+++ b/check/tests/row_polymorphism.rs
@@ -6,7 +6,7 @@ extern crate gluon_base as base;
 extern crate gluon_parser as parser;
 extern crate gluon_check as check;
 
-use base::kind::Kind;
+use base::kind::{Kind, KindCache};
 use base::types::{Field, Type};
 use check::kindcheck::KindCheck;
 
@@ -232,7 +232,7 @@ let { Test3 } = { Test, Test2, x = 2 }
 fn row_kinds() {
     let env = MockEnv::new();
     let ident_env = MockIdentEnv::new();
-    let mut kindcheck = KindCheck::new(&env, &ident_env);
+    let mut kindcheck = KindCheck::new(&env, &ident_env, KindCache::new());
 
     let mut typ = Type::empty_row();
     let result = kindcheck.kindcheck_expected(&mut typ, &Kind::row());
@@ -250,7 +250,7 @@ fn row_kinds() {
 fn row_kinds_error() {
     let env = MockEnv::new();
     let ident_env = MockIdentEnv::new();
-    let mut kindcheck = KindCheck::new(&env, &ident_env);
+    let mut kindcheck = KindCheck::new(&env, &ident_env, KindCache::new());
 
     let mut typ = Type::extend_row(vec![],
                                    vec![Field::new(intern("x"), Type::int())],

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -184,7 +184,7 @@ AtomicType: ArcType<Id> = {
         match elems.len() {
             // Parenthesized type
             1 => elems.into_iter().next().unwrap(),
-            _ => Type::tuple(env, elems),
+            _ => type_cache.tuple(env, elems),
         },
 
     "{" <row: Comma<RecordField>> "}" =>

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -1,14 +1,17 @@
+use std::iter::once;
+use std::str::FromStr;
+
 use base::ast::{Alternative, Array, Expr, ExprField, Lambda, Literal, Pattern, SpannedExpr, TypeBinding, TypedIdent, ValueBinding};
 use base::kind::{ArcKind, Kind};
 use base::pos::{self, BytePos, Spanned};
-use base::types::{AliasData, ArcType, BuiltinType, Field, Generic, Type};
-use std::str::FromStr;
+use base::types::{AliasData, ArcType, BuiltinType, Field, Generic, Type, TypeCache};
 
+use ::new_ident;
 use token::Token;
 
 use {Error, ErrorEnv, FieldExpr, FieldPattern, MutIdentEnv};
 
-grammar<'input, 'env, Id>(src: &'input str, env: MutIdentEnv<'env, Id>, errors: ErrorEnv<'env, 'input>)
+grammar<'input, 'env, Id>(src: &'input str, type_cache: &TypeCache<Id>, env: MutIdentEnv<'env, Id>, errors: ErrorEnv<'env, 'input>)
     where Id: Clone;
 
 extern {
@@ -84,7 +87,7 @@ Ident: Id =
     IdentStr => env.from_str(<>);
 
 Operator: TypedIdent<Id> =
-    "Operator" => TypedIdent::new(env.from_str(<>));
+    "Operator" => new_ident(type_cache, env.from_str(<>));
 
 DocComment: String =
     "DocComment"+ => <>.join("\n");
@@ -137,7 +140,7 @@ TypeBinding: TypeBinding<Id> = {
         let typ: ArcType<Id> = Type::app(Type::ident(id.clone()), typ_args);
 
         let row = row.into_iter()
-            .map(|(id, params)| Field::new(id, Type::function(params, typ.clone())))
+            .map(|(id, params)| Field::new(id, type_cache.function(params, typ.clone())))
             .collect();
 
         TypeBinding {
@@ -160,11 +163,11 @@ TypeBinding: TypeBinding<Id> = {
 
 AtomicType: ArcType<Id> = {
     "(" "->" ")" =>
-        Type::builtin(BuiltinType::Function),
+        type_cache.function_builtin(),
 
     IdentStr =>
         if <> == "_" {
-            Type::hole()
+            type_cache.hole()
         } else {
             match BuiltinType::from_str(<>) {
                 Ok(ty) => Type::builtin(ty),
@@ -199,7 +202,7 @@ Type = {
     AppType,
 
     <lhs: AppType> "->" <rhs: Type> =>
-        Type::function(vec![lhs], rhs),
+        type_cache.function(once(lhs), rhs),
 };
 
 // Patterns
@@ -221,16 +224,16 @@ FieldPattern : FieldPattern<Id> = {
 AtomicPattern: Pattern<Id> = {
     <id: Ident> =>
         if env.string(&id).starts_with(char::is_uppercase) {
-            Pattern::Constructor(TypedIdent::new(id), Vec::new())
+            Pattern::Constructor(new_ident(type_cache, id), Vec::new())
         } else {
-            Pattern::Ident(TypedIdent::new(id))
+            Pattern::Ident(new_ident(type_cache, id))
         },
 
     "(" <elems: Comma<Sp<Pattern>>> ")" =>
         match elems.len() {
             // Parenthesized pattern
             1 => elems.into_iter().next().unwrap().value,
-            _ => Pattern::Tuple { typ: Type::hole(), elems: elems },
+            _ => Pattern::Tuple { typ: type_cache.hole(), elems: elems },
         },
 
     "{" <fields: Comma<FieldPattern>> "}" => {
@@ -245,7 +248,7 @@ AtomicPattern: Pattern<Id> = {
         }
 
         Pattern::Record {
-            typ: Type::hole(),
+            typ: type_cache.hole(),
             types: types,
             fields: values,
         }
@@ -256,7 +259,7 @@ Pattern = {
     AtomicPattern,
 
     <id: Ident> <args: Sp<AtomicPattern>+> => {
-        let id = TypedIdent::new(id);
+        let id = new_ident(type_cache, id);
 
         Pattern::Constructor(id, args)
     },
@@ -300,7 +303,7 @@ ValueBinding: ValueBinding<Id> = {
         ValueBinding {
             comment: comment,
             name: name,
-            typ: typ.unwrap_or_else(Type::hole),
+            typ: typ.unwrap_or_else(|| type_cache.hole()),
             args: vec![],
             expr: body,
         },
@@ -308,16 +311,16 @@ ValueBinding: ValueBinding<Id> = {
     <comment: DocComment?> <name: Sp<Ident>> <args: Ident+> <typ: (":" <Type>)?> "=" <body: SpExpr> =>
         ValueBinding {
             comment: comment,
-            name: name.map(TypedIdent::new).map(Pattern::Ident),
-            typ: typ.unwrap_or_else(Type::hole),
-            args: args.into_iter().map(TypedIdent::new).collect(),
+            name: name.map(|name| new_ident(type_cache, name)).map(Pattern::Ident),
+            typ: typ.unwrap_or_else(|| type_cache.hole()),
+            args: args.into_iter().map(|name| new_ident(type_cache, name)).collect(),
             expr: body,
         },
 };
 
 AtomicExpr: Expr<Id> = {
     <id: Ident> =>
-        Expr::Ident(TypedIdent::new(id)),
+        Expr::Ident(new_ident(type_cache, id)),
 
     <lit: Literal> =>
         Expr::Literal(lit),
@@ -327,11 +330,11 @@ AtomicExpr: Expr<Id> = {
     //     Expr::Getter(id),
 
     <expr: Sp<AtomicExpr>> "." <id: Ident> =>
-        Expr::Projection(Box::new(expr), id, Type::hole()),
+        Expr::Projection(Box::new(expr), id, type_cache.hole()),
 
     <expr: Sp<AtomicExpr>> "." <err: !> => {
         errors.push(err.error);
-        Expr::Projection(Box::new(expr), env.from_str(""), Type::hole())
+        Expr::Projection(Box::new(expr), env.from_str(""), type_cache.hole())
     },
 
     "(" <elems: Comma<SpExpr>> ")" =>
@@ -339,11 +342,11 @@ AtomicExpr: Expr<Id> = {
             // Parenthesized expression - wrap in a block to ensure
             // that it survives operator reparsing
             1 => Expr::Block(elems),
-            _ => Expr::Tuple { typ: Type::hole(), elems: elems },
+            _ => Expr::Tuple { typ: type_cache.hole(), elems: elems },
         },
 
     "[" <elems: Comma<SpExpr>> "]" => Expr::Array(Array {
-            typ: Type::hole(),
+            typ: type_cache.hole(),
             exprs: elems,
         }),
 
@@ -367,7 +370,7 @@ AtomicExpr: Expr<Id> = {
         }
 
         Expr::Record {
-            typ: Type::hole(),
+            typ: type_cache.hole(),
             types: types,
             exprs: values,
         }
@@ -386,8 +389,8 @@ InfixExpr = {
 
     "\\" <args: Ident+> "->" <body: SpExpr> =>
         Expr::Lambda(Lambda {
-            id: TypedIdent::new(env.from_str("")),
-            args: args.into_iter().map(TypedIdent::new).collect(),
+            id: new_ident(type_cache, env.from_str("")),
+            args: args.into_iter().map(|name| new_ident(type_cache, name)).collect(),
             body: Box::new(body),
         }),
 


### PR DESCRIPTION
Adds `TypeCache` and `KindCache` which are used to share a single instance of various common types and kinds which will reduce memory usage and improve performance somewhat.

Further work on this could be to add a dynamic cache which would identify duplicate instance of  function or application types as well but this would necessitate a more complex refactor.

Part of #41 