### PR TITLE
fix(check): Require that an record alias matches exactly on record construction

### DIFF
--- a/base/src/error.rs
+++ b/base/src/error.rs
@@ -107,7 +107,7 @@ impl<T: fmt::Display + fmt::Debug + Any> StdError for Errors<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct SourceContext<E> {
     line: String,
     error: Spanned<E, Location>,
@@ -127,7 +127,7 @@ impl<E> SourceContext<E> {
 }
 
 /// Error type which contains information of which file and where in the file the error occured
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct InFile<E> {
     pub source_name: String,
     error: Errors<SourceContext<E>>,

--- a/base/src/pos.rs
+++ b/base/src/pos.rs
@@ -214,6 +214,16 @@ impl<Pos: Ord> Span<Pos> {
             None
         }
     }
+
+    pub fn map<Pos2, F>(self, mut f: F) -> Span<Pos2>
+        where F: FnMut(Pos) -> Pos2
+    {
+        Span {
+            start: f(self.start),
+            end: f(self.end),
+            expansion_id: self.expansion_id,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/base/src/symbol.rs
+++ b/base/src/symbol.rs
@@ -132,7 +132,11 @@ impl AsRef<str> for SymbolRef {
 impl SymbolRef {
     /// Checks whether the names of two symbols are equal
     pub fn name_eq(&self, other: &SymbolRef) -> bool {
-        self == other || self.0 == other.0
+        self.name() == other.name()
+    }
+
+    pub fn name(&self) -> &Name {
+        Name::new(self)
     }
 
     /// Returns the name of this symbol as it was originally declared (strips location information)
@@ -149,8 +153,14 @@ impl SymbolRef {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct NameBuf(String);
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, Hash)]
 pub struct Name(str);
+
+impl PartialEq for Name {
+    fn eq(&self, other: &Name) -> bool {
+        self.0.as_ptr() == other.0.as_ptr() || self.0 == other.0
+    }
+}
 
 pub struct Components<'a>(::std::str::Split<'a, char>);
 

--- a/base/src/types.rs
+++ b/base/src/types.rs
@@ -23,7 +23,36 @@ pub trait TypeEnv: KindEnv {
 
     /// Returns a record which contains all `fields`. The first element is the record type and the
     /// second is the alias type.
-    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)>;
+    fn find_record(&self,
+                   fields: &[Symbol],
+                   selector: RecordSelector)
+                   -> Option<(ArcType, ArcType)>;
+}
+
+pub enum RecordSelector {
+    // Selects a record which exactly has the fields
+    Exact,
+    // Selects a record which has all the passed fields (in any order)
+    Subset,
+}
+
+impl RecordSelector {
+    /// Returns `true` if the iterators matches according to the selector
+    pub fn matches<F, I, J>(&self, mut record: F, needle: J) -> bool
+        where F: FnMut() -> I,
+              I: IntoIterator,
+              J: IntoIterator<Item = I::Item>,
+              I::Item: PartialEq
+    {
+        match *self {
+            RecordSelector::Exact => record().into_iter().eq(needle),
+            RecordSelector::Subset => {
+                needle
+                    .into_iter()
+                    .all(|name| record().into_iter().any(|other| other == name))
+            }
+        }
+    }
 }
 
 impl<'a, T: ?Sized + TypeEnv> TypeEnv for &'a T {
@@ -35,8 +64,11 @@ impl<'a, T: ?Sized + TypeEnv> TypeEnv for &'a T {
         (**self).find_type_info(id)
     }
 
-    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
-        (**self).find_record(fields)
+    fn find_record(&self,
+                   fields: &[Symbol],
+                   selector: RecordSelector)
+                   -> Option<(ArcType, ArcType)> {
+        (**self).find_record(fields, selector)
     }
 }
 

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -20,6 +20,7 @@ gluon_parser = { path = "../parser", version = "0.4.0", optional = true } # GLUO
 
 [dev-dependencies]
 collect-mac = "0.1.0"
+pretty_assertions = "0.2.0"
 
 [features]
 test = ["gluon_parser", "env_logger"]

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -45,7 +45,7 @@ mod tests {
 
     use base::kind::{ArcKind, KindEnv};
     use base::symbol::{Symbol, Symbols, SymbolModule, SymbolRef};
-    use base::types::{Alias, ArcType, TypeEnv};
+    use base::types::{Alias, ArcType, RecordSelector, TypeEnv};
 
     pub struct MockEnv;
 
@@ -62,7 +62,10 @@ mod tests {
         fn find_type_info(&self, _id: &SymbolRef) -> Option<&Alias<Symbol, ArcType>> {
             None
         }
-        fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
+        fn find_record(&self,
+                       _fields: &[Symbol],
+                       _selector: RecordSelector)
+                       -> Option<(ArcType, ArcType)> {
             None
         }
     }

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -7,7 +7,7 @@ use base::kind::{ArcKind, Kind, KindEnv};
 use base::pos::{self, BytePos, Span, Spanned};
 use base::scoped_map::ScopedMap;
 use base::symbol::{Symbol, SymbolRef, SymbolModule};
-use base::types::{self, Alias, ArcType, Type, TypeEnv};
+use base::types::{self, Alias, ArcType, RecordSelector, Type, TypeEnv};
 use unify_type::{TypeError, State};
 use unify::{Error as UnifyError, Unifier, Unifiable, UnifierState};
 
@@ -73,7 +73,10 @@ impl<'a> TypeEnv for Environment<'a> {
             .or_else(|| self.env.find_type_info(id))
     }
 
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
+    fn find_record(&self,
+                   _fields: &[Symbol],
+                   _selector: RecordSelector)
+                   -> Option<(ArcType, ArcType)> {
         None
     }
 }

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -23,7 +23,8 @@ macro_rules! assert_err {
         match $e {
             Ok(x) => assert!(false, "Expected error, got {}",
                              types::display_type(&*symbols.borrow(), &x)),
-            Err(errors) => {
+            Err(err) => {
+                let errors = err.errors();
                 let mut iter = (&errors).into_iter();
                 $(
                 match iter.next() {
@@ -51,8 +52,8 @@ macro_rules! assert_unify_err {
         match $e {
             Ok(x) => assert!(false, "Expected error, got {}",
                              types::display_type(&*symbols.borrow(), &x)),
-            Err(errors) => {
-                for error in errors {
+            Err(err) => {
+                for error in err.errors() {
                     match error {
                         Spanned { value: Unification(_, _, ref errors), .. } => {
                             let mut iter = errors.iter();
@@ -400,7 +401,8 @@ let y = 1.0
 y
 "#;
     let result = support::typecheck_expr_expected(text, Some(&Type::int())).1;
-    let errors: Vec<_> = result.unwrap_err().into();
+    let errors: Vec<_> = result.unwrap_err().errors().into();
     assert_eq!(errors.len(), 1);
-    assert_eq!(errors[0].span, Span::new(13.into(), 14.into()));
+    assert_eq!(errors[0].span.map(|loc| loc.absolute),
+               Span::new(13.into(), 14.into()));
 }

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate collect_mac;
 extern crate env_logger;
+#[macro_use]
+extern crate pretty_assertions;
 
 extern crate gluon_base as base;
 extern crate gluon_parser as parser;
@@ -1008,4 +1010,23 @@ type Test2 = {
                                name: intern("x"),
                                typ: Type::int()
                            }]))));
+}
+
+#[test]
+fn alias_selection_on_pattern_match() {
+    let _ = ::env_logger::init();
+    let text = r#"
+type Test = {
+    x : Float,
+    y : Float
+}
+type Test2 = {
+    x : Int
+}
+let { x } = { x = 1 }
+x
+"#;
+    let result = support::typecheck(text);
+
+    assert_eq!(result, Ok(Type::int()));
 }

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -1,7 +1,8 @@
 use base::ast::{DisplayEnv, IdentEnv, SpannedExpr};
+use base::error::InFile;
 use base::kind::{ArcKind, Kind, KindEnv};
 use base::symbol::{Symbols, SymbolModule, Symbol, SymbolRef};
-use base::types::{self, Alias, ArcType, Generic, PrimitiveEnv, Type, TypeEnv};
+use base::types::{self, Alias, ArcType, Generic, PrimitiveEnv, RecordSelector, Type, TypeEnv};
 use check::typecheck::{self, Typecheck};
 use parser::{parse_partial_expr, ParseErrors};
 
@@ -45,7 +46,7 @@ pub fn parse_new(s: &str)
 }
 
 #[allow(dead_code)]
-pub fn typecheck(text: &str) -> Result<ArcType, typecheck::Error> {
+pub fn typecheck(text: &str) -> Result<ArcType, InFile<typecheck::TypeError<Symbol>>> {
     let (_, t) = typecheck_expr(text);
     t
 }
@@ -90,7 +91,10 @@ impl TypeEnv for MockEnv {
         }
     }
 
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
+    fn find_record(&self,
+                   _fields: &[Symbol],
+                   _selector: RecordSelector)
+                   -> Option<(ArcType, ArcType)> {
         None
     }
 }
@@ -120,16 +124,17 @@ impl<T: AsRef<str>> DisplayEnv for MockIdentEnv<T> {
 }
 
 impl<T> IdentEnv for MockIdentEnv<T>
-    where T: AsRef<str> + for<'a> From<&'a str>,
+    where T: AsRef<str> + for<'a> From<&'a str>
 {
     fn from_str(&mut self, s: &str) -> Self::Ident {
         T::from(s)
     }
 }
 
-pub fn typecheck_expr_expected(text: &str,
-                               expected: Option<&ArcType>)
-                               -> (SpannedExpr<Symbol>, Result<ArcType, typecheck::Error>) {
+pub fn typecheck_expr_expected
+    (text: &str,
+     expected: Option<&ArcType>)
+     -> (SpannedExpr<Symbol>, Result<ArcType, InFile<typecheck::TypeError<Symbol>>>) {
     let mut expr = parse_new(text).unwrap_or_else(|(_, err)| panic!("{}", err));
 
     let env = MockEnv::new();
@@ -139,16 +144,19 @@ pub fn typecheck_expr_expected(text: &str,
 
     let result = tc.typecheck_expr_expected(&mut expr, expected);
 
-    (expr, result)
+    (expr, result.map_err(|err| InFile::new("test", text, err)))
 }
 
-pub fn typecheck_expr(text: &str) -> (SpannedExpr<Symbol>, Result<ArcType, typecheck::Error>) {
+pub fn typecheck_expr
+    (text: &str)
+     -> (SpannedExpr<Symbol>, Result<ArcType, InFile<typecheck::TypeError<Symbol>>>) {
     typecheck_expr_expected(text, None)
 }
 
 #[allow(dead_code)]
-pub fn typecheck_partial_expr(text: &str)
-                              -> (SpannedExpr<Symbol>, Result<ArcType, typecheck::Error>) {
+pub fn typecheck_partial_expr
+    (text: &str)
+     -> (SpannedExpr<Symbol>, Result<ArcType, InFile<typecheck::TypeError<Symbol>>>) {
     let mut expr = match parse_new(text) {
         Ok(e) => e,
         Err((Some(e), _)) => e,
@@ -162,7 +170,7 @@ pub fn typecheck_partial_expr(text: &str)
 
     let result = tc.typecheck_expr(&mut expr);
 
-    (expr, result)
+    (expr, result.map_err(|err| InFile::new("test", text, err)))
 }
 
 #[allow(dead_code)]
@@ -172,7 +180,7 @@ pub fn typ(s: &str) -> ArcType {
 }
 
 pub fn typ_a<T>(s: &str, args: Vec<T>) -> T
-    where T: From<Type<Symbol, T>>,
+    where T: From<Type<Symbol, T>>
 {
     assert!(s.len() != 0);
 
@@ -206,15 +214,21 @@ pub fn alias(s: &str, args: &[&str], typ: ArcType) -> ArcType {
 #[allow(dead_code)]
 pub fn close_record(typ: ArcType) -> ArcType {
     types::walk_move_type(typ,
-                          &mut |typ| {
-        match *typ {
-            Type::ExtendRow { ref types, ref fields, ref rest } => {
-                match **rest {
-                    Type::ExtendRow { .. } => None,
-                    _ => Some(Type::extend_row(types.clone(), fields.clone(), Type::empty_row())),
-                }
-            }
-            _ => None,
-        }
-    })
+                          &mut |typ| match *typ {
+                                   Type::ExtendRow {
+                                       ref types,
+                                       ref fields,
+                                       ref rest,
+                                   } => {
+                                       match **rest {
+                                           Type::ExtendRow { .. } => None,
+                                           _ => {
+                                               Some(Type::extend_row(types.clone(),
+                                                                     fields.clone(),
+                                                                     Type::empty_row()))
+                                           }
+                                       }
+                                   }
+                                   _ => None,
+                               })
 }

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -3,7 +3,7 @@ use interner::InternedStr;
 use base::ast::{Literal, TypedIdent, Typed, DisplayEnv, SpannedExpr};
 use base::resolve;
 use base::kind::{ArcKind, KindEnv};
-use base::types::{self, Alias, ArcType, BuiltinType, Type, TypeEnv};
+use base::types::{self, Alias, ArcType, BuiltinType, RecordSelector, Type, TypeEnv};
 use base::scoped_map::ScopedMap;
 use base::symbol::{Symbol, SymbolRef, SymbolModule};
 use base::pos::{Line, NO_EXPANSION};
@@ -369,7 +369,10 @@ impl<'a> TypeEnv for Compiler<'a> {
         self.stack_types.get(id)
     }
 
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
+    fn find_record(&self,
+                   _fields: &[Symbol],
+                   _selector: RecordSelector)
+                   -> Option<(ArcType, ArcType)> {
         None
     }
 }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -1,7 +1,7 @@
 use base::fnv::FnvMap;
 use base::kind::{ArcKind, Kind, KindEnv};
 use base::symbol::{Symbol, SymbolRef};
-use base::types::{Alias, ArcType, TypeEnv, Type};
+use base::types::{Alias, ArcType, RecordSelector, TypeEnv, Type};
 
 pub use self::Instruction::*;
 
@@ -189,7 +189,10 @@ impl TypeEnv for TypeInfos {
         self.id_to_type.get(id)
     }
 
-    fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
+    fn find_record(&self,
+                   _fields: &[Symbol],
+                   _selector: RecordSelector)
+                   -> Option<(ArcType, ArcType)> {
         None
     }
 }

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1150,7 +1150,7 @@ mod tests {
     use types::VmInt;
 
     use base::kind::{ArcKind, KindEnv};
-    use base::types::{Alias, ArcType, Field, Type, TypeEnv};
+    use base::types::{Alias, ArcType, Field, RecordSelector, Type, TypeEnv};
     use base::symbol::{Symbol, SymbolRef};
 
     struct MockEnv(Option<Alias<Symbol, ArcType>>);
@@ -1170,7 +1170,10 @@ mod tests {
             self.0.as_ref()
         }
 
-        fn find_record(&self, _fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
+        fn find_record(&self,
+                       _fields: &[Symbol],
+                       _selector: RecordSelector)
+                       -> Option<(ArcType, ArcType)> {
             None
         }
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -10,7 +10,8 @@ use base::fnv::FnvMap;
 use base::kind::{ArcKind, Kind, KindEnv};
 use base::metadata::{Metadata, MetadataEnv};
 use base::symbol::{Name, Symbol, SymbolRef};
-use base::types::{Alias, AliasData, AppVec, ArcType, Generic, PrimitiveEnv, Type, TypeEnv};
+use base::types::{Alias, AliasData, AppVec, ArcType, Generic, PrimitiveEnv, RecordSelector, Type,
+                  TypeEnv};
 
 use macros::MacroEnv;
 use {Error, Result};
@@ -165,11 +166,16 @@ impl TypeEnv for VmEnv {
                     .map(|ctor| ctor)
             })
     }
+
     fn find_type_info(&self, id: &SymbolRef) -> Option<&Alias<Symbol, ArcType>> {
         self.type_infos.find_type_info(id)
     }
-    fn find_record(&self, fields: &[Symbol]) -> Option<(ArcType, ArcType)> {
-        self.type_infos.find_record(fields)
+
+    fn find_record(&self,
+                   fields: &[Symbol],
+                   selector: RecordSelector)
+                   -> Option<(ArcType, ArcType)> {
+        self.type_infos.find_record(fields, selector)
     }
 }
 


### PR DESCRIPTION
When creating a record the compiler attempts to look up a matching alias to simplify typechecking later on (since an alias is a smaller type than a record, most of the time). For the alias to unify correctly though its fields need to match exactly however whereas it used to only require a subset of them to match which is the case for looking up an alias from a field access or pattern match.

Fixes https://gitter.im/gluon-lang/gluon?at=59211caffa63ba2f76634737