### PR TITLE
fix(check): Don't diverge when typechecking a pattern with an undefin…

### DIFF
--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -1167,9 +1167,13 @@ impl<'a> Typecheck<'a> {
                 debug!("{}: {}",
                        self.symbols.string(&id.name),
                        types::display_type(&self.symbols, typ));
-                for (arg, arg_type) in
-                    args.iter_mut()
-                        .zip(function_arg_iter(self, typ.clone()).collect::<Vec<_>>()) {
+
+                let len = args.len();
+                let iter = args.iter_mut()
+                    .zip(function_arg_iter(self, typ.clone())
+                             .take(len)
+                             .collect::<Vec<_>>());
+                for (arg, arg_type) in iter {
                     self.finish_pattern(level, arg, &arg_type);
                 }
             }

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -378,7 +378,6 @@ type Bar = Test Int
     assert_err!(result, KindError(TypeMismatch(..)));
 }
 
-
 #[test]
 fn type_alias_with_explicit_function_kind() {
     let _ = ::env_logger::init();
@@ -405,4 +404,15 @@ y
     assert_eq!(errors.len(), 1);
     assert_eq!(errors[0].span.map(|loc| loc.absolute),
                Span::new(13.into(), 14.into()));
+}
+
+#[test]
+fn issue_286() {
+    let _ = ::env_logger::init();
+    let text = r#"
+let Test = 1
+1
+"#;
+    let result = support::typecheck(text);
+    assert_err!(result, UndefinedVariable(..));
 }


### PR DESCRIPTION
…ed type

`FunctionArgIter` would just keep returning new type variables on every call to `next` causing the call to `collect` to never return. However we just need `args.len()` arguments so a `take` call resolves this easily

Fixes #286