### PR TITLE
feat(check): Allow retrieval of documentation through the completion interface

### DIFF
--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use base::ast::{self, Expr, Pattern, SpannedExpr, SpannedPattern, ValueBinding};
-use base::ast::MutVisitor;
+use base::ast::Visitor;
 use base::fnv::FnvMap;
 use base::metadata::{Metadata, MetadataEnv};
 use base::symbol::{Name, Symbol};
@@ -13,16 +13,16 @@ struct Environment<'b> {
 
 /// Queries `expr` for the metadata which it contains.
 pub fn metadata(env: &MetadataEnv,
-                expr: &mut SpannedExpr<Symbol>)
+                expr: &SpannedExpr<Symbol>)
                 -> (Metadata, FnvMap<Symbol, Metadata>) {
     struct MetadataVisitor<'b> {
         env: Environment<'b>,
     }
 
     impl<'b> MetadataVisitor<'b> {
-        fn new_binding(&mut self, metadata: Metadata, bind: &mut ValueBinding<Symbol>) {
+        fn new_binding(&mut self, metadata: Metadata, bind: &ValueBinding<Symbol>) {
             match bind.name.value {
-                Pattern::Ident(ref mut id) => {
+                Pattern::Ident(ref id) => {
                     let metadata = bind.comment
                         .as_ref()
                         .map_or(metadata, |comment| {
@@ -33,21 +33,21 @@ pub fn metadata(env: &MetadataEnv,
                         });
                     self.stack_var(id.name.clone(), metadata);
                 }
-                _ => self.new_pattern(metadata, &mut bind.name),
+                _ => self.new_pattern(metadata, &bind.name),
             }
         }
 
-        fn new_pattern(&mut self, mut metadata: Metadata, pattern: &mut SpannedPattern<Symbol>) {
+        fn new_pattern(&mut self, mut metadata: Metadata, pattern: &SpannedPattern<Symbol>) {
             match pattern.value {
                 Pattern::Record {
-                    ref mut fields,
-                    ref mut types,
+                    ref fields,
+                    ref types,
                     ..
                 } => {
                     for field in fields {
                         if let Some(m) = metadata.module.remove(field.0.as_ref()) {
                             let id = match field.1 {
-                                Some(ref mut pat) => {
+                                Some(ref pat) => {
                                     match pat.value {
                                         Pattern::Ident(ref id) => &id.name,
                                         _ => return self.new_pattern(m, pat),
@@ -65,7 +65,7 @@ pub fn metadata(env: &MetadataEnv,
                         }
                     }
                 }
-                Pattern::Ident(ref mut id) => {
+                Pattern::Ident(ref id) => {
                     self.stack_var(id.name.clone(), metadata);
                 }
                 Pattern::Tuple { .. } |
@@ -92,22 +92,22 @@ pub fn metadata(env: &MetadataEnv,
                 .or_else(|| self.env.env.get_metadata(id))
         }
 
-        fn metadata_expr(&mut self, expr: &mut SpannedExpr<Symbol>) -> Metadata {
+        fn metadata_expr(&mut self, expr: &SpannedExpr<Symbol>) -> Metadata {
             match expr.value {
-                Expr::Ident(ref mut id) => {
+                Expr::Ident(ref id) => {
                     self.metadata(&id.name)
                         .cloned()
                         .unwrap_or_else(Metadata::default)
                 }
                 Expr::Record {
-                    ref mut exprs,
-                    ref mut types,
+                    ref exprs,
+                    ref types,
                     ..
                 } => {
                     let mut module = BTreeMap::new();
                     for field in exprs {
                         let maybe_metadata = match field.value {
-                            Some(ref mut expr) => {
+                            Some(ref expr) => {
                                 let m = self.metadata_expr(expr);
                                 if m.has_data() { Some(m) } else { None }
                             }
@@ -143,26 +143,26 @@ pub fn metadata(env: &MetadataEnv,
                         module: module,
                     }
                 }
-                Expr::LetBindings(ref mut bindings, ref mut expr) => {
+                Expr::LetBindings(ref bindings, ref expr) => {
                     let is_recursive = bindings.iter().all(|bind| !bind.args.is_empty());
                     if is_recursive {
-                        for bind in bindings.iter_mut() {
+                        for bind in bindings {
                             self.new_binding(Metadata::default(), bind);
                         }
                         for bind in bindings {
-                            self.metadata_expr(&mut bind.expr);
+                            self.metadata_expr(&bind.expr);
                         }
                     } else {
                         for bind in bindings {
-                            let metadata = self.metadata_expr(&mut bind.expr);
+                            let metadata = self.metadata_expr(&bind.expr);
                             self.new_binding(metadata, bind);
                         }
                     }
                     let result = self.metadata_expr(expr);
                     result
                 }
-                Expr::TypeBindings(ref mut bindings, ref mut expr) => {
-                    for bind in bindings.iter_mut() {
+                Expr::TypeBindings(ref bindings, ref expr) => {
+                    for bind in bindings {
                         let maybe_metadata = bind.comment
                             .as_ref()
                             .map(|comment| {
@@ -179,17 +179,17 @@ pub fn metadata(env: &MetadataEnv,
                     result
                 }
                 _ => {
-                    ast::walk_mut_expr(self, expr);
+                    ast::walk_expr(self, expr);
                     Metadata::default()
                 }
             }
         }
     }
 
-    impl<'b> MutVisitor for MetadataVisitor<'b> {
+    impl<'b> Visitor for MetadataVisitor<'b> {
         type Ident = Symbol;
 
-        fn visit_expr(&mut self, expr: &mut SpannedExpr<Symbol>) {
+        fn visit_expr(&mut self, expr: &SpannedExpr<Symbol>) {
             self.metadata_expr(expr);
         }
     }

--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -76,10 +76,6 @@ pub fn metadata(env: &MetadataEnv,
         fn stack_var(&mut self, id: Symbol, metadata: Metadata) {
             if metadata.has_data() {
                 debug!("Insert {}", id);
-                // All symbols should have been renamed to unique ones
-                debug_assert!(!self.env.stack.contains_key(&id),
-                              "Symbol {:?}, appears twice in the source",
-                              id);
                 self.env.stack.insert(id, metadata);
             }
         }
@@ -177,6 +173,14 @@ pub fn metadata(env: &MetadataEnv,
                     }
                     let result = self.metadata_expr(expr);
                     result
+                }
+                Expr::Projection(ref expr, ref field, _) => {
+                    let metadata = self.metadata_expr(expr);
+                    metadata
+                        .module
+                        .get(field.as_ref())
+                        .cloned()
+                        .unwrap_or_default()
                 }
                 _ => {
                     ast::walk_expr(self, expr);

--- a/check/tests/completion.rs
+++ b/check/tests/completion.rs
@@ -6,6 +6,7 @@ extern crate gluon_base as base;
 extern crate gluon_parser as parser;
 extern crate gluon_check as check;
 
+use base::metadata::Metadata;
 use base::pos::BytePos;
 use base::types::{Field, Type, ArcType};
 use check::completion::{self, Suggestion};
@@ -32,7 +33,21 @@ fn suggest_types(s: &str, pos: BytePos) -> Result<Vec<Suggestion>, ()> {
 }
 
 fn suggest(s: &str, pos: BytePos) -> Result<Vec<String>, ()> {
-    suggest_types(s, pos).map(|vec| vec.into_iter().map(|suggestion| suggestion.name).collect())
+    suggest_types(s, pos).map(|vec| {
+                                  vec.into_iter()
+                                      .map(|suggestion| suggestion.name)
+                                      .collect()
+                              })
+}
+
+fn get_metadata(s: &str, pos: BytePos) -> Option<Metadata> {
+    let env = MockEnv::new();
+
+    let (mut expr, result) = support::typecheck_expr(s);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+
+    let (_, metadata_map) = check::metadata::metadata(&env, &mut expr);
+    completion::get_metadata(&metadata_map, &mut expr, pos).cloned()
 }
 
 #[test]
@@ -343,5 +358,70 @@ test  test1
     let result = suggest(text, BytePos::from(40));
     let expected = Ok(vec!["abb".into(), "abc".into()]);
 
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn metadata_at_variable() {
+    let _ = env_logger::init();
+
+    let text = r#"
+/// test
+let abc = 1
+let abb = 2
+abb
+abc
+"#;
+    let result = get_metadata(text, BytePos::from(37));
+
+    let expected = None;
+    assert_eq!(result, expected);
+
+    let result = get_metadata(text, BytePos::from(41));
+
+    let expected = Some(Metadata {
+                            comment: Some("test".to_string()),
+                            ..Metadata::default()
+                        });
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn metadata_at_binop() {
+    let _ = env_logger::init();
+
+    let text = r#"
+/// test
+let (+++) x y = 1
+1 +++ 3
+"#;
+    let result = get_metadata(text, BytePos::from(32));
+
+    let expected = Some(Metadata {
+                            comment: Some("test".to_string()),
+                            ..Metadata::default()
+                        });
+    assert_eq!(result, expected);
+}
+
+
+#[test]
+fn metadata_at_field_access() {
+    let _ = env_logger::init();
+
+    let text = r#"
+let module = {
+        /// test
+        abc = 1,
+        abb = 2
+    }
+module.abc
+"#;
+    let result = get_metadata(text, BytePos::from(81));
+
+    let expected = Some(Metadata {
+                            comment: Some("test".to_string()),
+                            ..Metadata::default()
+                        });
     assert_eq!(result, expected);
 }

--- a/check/tests/metadata.rs
+++ b/check/tests/metadata.rs
@@ -6,9 +6,13 @@ extern crate gluon_base as base;
 extern crate gluon_parser as parser;
 extern crate gluon_check as check;
 
+use base::ast::SpannedExpr;
 use base::metadata::{Metadata, MetadataEnv};
 use base::symbol::Symbol;
-use check::metadata::metadata;
+
+fn metadata(env: &MetadataEnv, expr: &mut SpannedExpr<Symbol>) -> Metadata {
+    check::metadata::metadata(env, expr).0
+}
 
 mod support;
 
@@ -57,9 +61,9 @@ let id x = x
     let metadata = metadata(&MockEnv, &mut expr);
     assert_eq!(metadata.module.get("id"),
                Some(&Metadata {
-                   comment: Some("The identity function".into()),
-                   module: Default::default(),
-               }));
+                         comment: Some("The identity function".into()),
+                         module: Default::default(),
+                     }));
 }
 
 #[test]
@@ -78,9 +82,9 @@ type Test = Int
     let metadata = metadata(&MockEnv, &mut expr);
     assert_eq!(metadata.module.get("Test"),
                Some(&Metadata {
-                   comment: Some("A test type".into()),
-                   module: Default::default(),
-               }));
+                         comment: Some("A test type".into()),
+                         module: Default::default(),
+                     }));
 }
 
 #[test]
@@ -100,7 +104,7 @@ fn propagate_metadata_record_field_comment() {
     let metadata = metadata(&MockEnv, &mut expr);
     assert_eq!(metadata.module.get("id"),
                Some(&Metadata {
-                   comment: Some("The identity function".into()),
-                   module: Default::default(),
-               }));
+                         comment: Some("The identity function".into()),
+                         module: Default::default(),
+                     }));
 }

--- a/check/tests/metadata.rs
+++ b/check/tests/metadata.rs
@@ -108,3 +108,27 @@ fn propagate_metadata_record_field_comment() {
                          module: Default::default(),
                      }));
 }
+
+#[test]
+fn projection_has_metadata() {
+    let _ = env_logger::init();
+
+    let text = r#"
+let x = {
+    /// The identity function
+    id = \x -> x
+}
+x.id
+"#;
+    let (mut expr, result) = support::typecheck_expr(text);
+
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+
+    let metadata = metadata(&MockEnv, &mut expr);
+    assert_eq!(metadata,
+               Metadata {
+                   comment: Some("The identity function".into()),
+                   module: Default::default(),
+               });
+
+}

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -1,6 +1,7 @@
 use base::ast::{DisplayEnv, IdentEnv, SpannedExpr};
 use base::error::InFile;
 use base::kind::{ArcKind, Kind, KindEnv};
+use base::metadata::{Metadata, MetadataEnv};
 use base::symbol::{Symbols, SymbolModule, Symbol, SymbolRef};
 use base::types::{self, Alias, ArcType, Generic, PrimitiveEnv, RecordSelector, Type, TypeEnv};
 use check::typecheck::{self, Typecheck};
@@ -104,6 +105,13 @@ impl PrimitiveEnv for MockEnv {
         &self.bool.as_type()
     }
 }
+
+impl MetadataEnv for MockEnv {
+    fn get_metadata(&self, _id: &Symbol) -> Option<&Metadata> {
+        None
+    }
+}
+
 
 #[allow(dead_code)]
 pub struct MockIdentEnv<T>(PhantomData<T>);

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -335,7 +335,7 @@ impl<'vm, E> Executable<'vm, ()> for CompileValue<E>
             typ,
             function,
         } = self;
-        let metadata = metadata::metadata(&*vm.get_env(), expr.borrow_mut());
+        let (metadata, _) = metadata::metadata(&*vm.get_env(), expr.borrow_mut());
         let closure = try_future!(vm.global_env().new_global_thunk(function));
         let filename = filename.to_string();
         vm.call_thunk(closure)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ impl Compiler {
         use check::metadata;
         let (mut expr, typ) = self.typecheck_str(vm, file, expr_str, None)?;
 
-        let metadata = metadata::metadata(&*vm.get_env(), &mut expr);
+        let (metadata, _) = metadata::metadata(&*vm.get_env(), &mut expr);
         Ok((expr, typ, metadata))
     }
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -785,7 +785,7 @@ sender
 fn invalid_string_slice_dont_panic() {
     let _ = ::env_logger::init();
     let text = r#"
-let string  = import! "std/string.glu"
+let string = import! "std/string.glu"
 let s = "åäö"
 string.slice s 1 (string.length s)
 "#;


### PR DESCRIPTION
Currently only works when completing on identifiers though in the future it should be possible to annotate types as well which would let

```
(f x).field
     // ^ Should return documentation if `f x` returns a type that has documented `field`
```