### PR TITLE
fix(check): Don't leak inference variables out to type errors

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -140,6 +140,31 @@ let id x = x
 in { id }
 ```
 
+### Array expressions
+
+Arrays can be constructed with array literals.
+
+```f#,rust
+// Results in an `Array Int`
+[1, 2, 3, 4]
+```
+
+Since gluon is statically typed all values must be of the same type. This allows the gluon interpreter to avoid tagging each value individually which makes types such as `Array Byte` be convertible into Rust's `&[u8]` type without any allocations.
+
+```f#
+// ERROR:
+// Types do not match:
+//        Expected: Int
+//        Found: String
+[1, ""]
+```
+
+Functions to operate on arrays can be found on the `array` module.
+
+```f#
+array.len [1, 2, 3]
+```
+
 ### Variants
 
 While records are great for grouping related data together, there is often a need to have data which can be one of several variants. Unlike records, variants need to be defined before they can be used.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -212,6 +212,42 @@ let Some y = Some 123
 x + y
 ```
 
+### Tuple expressions
+
+Gluon also have tuple expressions for when you don't have sensible names for your fields.
+
+```f#,rust
+(1, "", 3.14) // (Int, String, 3.14)
+```
+
+Similarily to records they can be unpacked with `match` and `let`.
+
+```f#,rust
+match (1, None) with
+| (x, Some y) -> x + y
+| (x, None) -> x
+
+let (a, b) = (1.0, 2.14)
+a + b
+```
+
+Infact, tuples are only syntax sugar over records with fields named after numbers (`_0`, `_1`, ...) which makes the above equivalent to the following code.
+
+```f#,rust
+match { _0 = 1, _1 = None } with
+| { _0 = x, _1 = Some y } -> x + y
+| { _0 = x, _1 = None } -> x
+
+let { _0 = a, _1 = b } = { _0 = 1.0, _1 = 2.14 }
+a + b
+```
+
+While that example is obviously less readable the tuple syntax, the important thing to note is that tuples equivalency with records allows one to access the fields of a tuple directly without unpacking.
+
+```f#,rust
+(0, 3.14)._1 // 3.14
+```
+
 ### Lambda expressions
 
 While we have seen that functions can be defined in let expressions it is often valuable to define a function without giving it an explicit name.

--- a/base/src/error.rs
+++ b/base/src/error.rs
@@ -92,6 +92,16 @@ impl<'a, T> IntoIterator for &'a Errors<T> {
     }
 }
 
+impl<'a, T> IntoIterator for &'a mut Errors<T> {
+    type Item = &'a mut T;
+
+    type IntoIter = slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> slice::IterMut<'a, T> {
+        self.errors.iter_mut()
+    }
+}
+
 impl<T: fmt::Display> fmt::Display for Errors<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for error in &self.errors {

--- a/check/src/unify.rs
+++ b/check/src/unify.rs
@@ -6,15 +6,14 @@ use base::fnv::FnvMap;
 use substitution::{Substitution, Substitutable, Variable};
 
 #[derive(Debug, PartialEq)]
-pub enum Error<T: Substitutable, E> {
+pub enum Error<T, E> {
     TypeMismatch(T, T),
-    Occurs(T::Variable, T),
+    Occurs(T, T),
     Other(E),
 }
 
 impl<T, E> fmt::Display for Error<T, E>
-    where T: Substitutable + fmt::Display,
-          T::Variable: fmt::Display,
+    where T: fmt::Display,
           E: fmt::Display
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -135,13 +134,13 @@ impl<'e, S, T> Unifier<S, T> for Unify<'e, T, T::Error>
             (_, Some(r)) => {
                 match subs.union(r, l) {
                     Ok(()) => Ok(None),
-                    Err(()) => Err(Error::Occurs(r.clone(), l.clone())),
+                    Err(()) => Err(Error::Occurs(T::from_variable(r.clone()), l.clone())),
                 }
             }
             (Some(l), _) => {
                 match subs.union(l, r) {
                     Ok(()) => Ok(Some(r.clone())),
-                    Err(()) => Err(Error::Occurs(l.clone(), r.clone())),
+                    Err(()) => Err(Error::Occurs(T::from_variable(l.clone()), r.clone())),
                 }
             }
             (None, None) => {
@@ -358,7 +357,7 @@ mod test {
         let fun = TType(Box::new(Type::Arrow(string.clone(), var1.clone())));
         let result = unify(&subs, &fun, &var1);
         assert_eq!(result,
-                   Err(Errors::from(vec![Error::Occurs(*var1.get_var().unwrap(), fun.clone())])));
+                   Err(Errors::from(vec![Error::Occurs(var1, fun.clone())])));
     }
 
     #[test]

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -713,20 +713,20 @@ impl<'a, 'e> Unifier<State<'a>, ArcType> for Merge<'e> {
                 };
                 match subs.union(r_var, left) {
                     Ok(()) => Ok(None),
-                    Err(()) => Err(UnifyError::Occurs(r_var.clone(), left.clone())),
+                    Err(()) => Err(UnifyError::Occurs(ArcType::from_variable(r_var.clone()), left.clone())),
                 }
 
             }
             (_, &Type::Variable(ref r)) => {
                 match subs.union(r, l) {
                     Ok(()) => Ok(None),
-                    Err(()) => Err(UnifyError::Occurs(r.clone(), l.clone())),
+                    Err(()) => Err(UnifyError::Occurs(ArcType::from_variable(r.clone()), l.clone())),
                 }
             }
             (&Type::Variable(ref l), _) => {
                 match subs.union(l, r) {
                     Ok(()) => Ok(Some(r.clone())),
-                    Err(()) => Err(UnifyError::Occurs(l.clone(), r.clone())),
+                    Err(()) => Err(UnifyError::Occurs(ArcType::from_variable(l.clone()), r.clone())),
                 }
             }
             _ => {

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate collect_mac;
 extern crate env_logger;
+#[macro_use]
+extern crate pretty_assertions;
 
 extern crate gluon_base as base;
 extern crate gluon_parser as parser;
@@ -415,4 +417,25 @@ let Test = 1
 "#;
     let result = support::typecheck(text);
     assert_err!(result, UndefinedVariable(..));
+}
+
+#[test]
+fn no_inference_variable_in_error() {
+    let _ = ::env_logger::init();
+    let text = r#"
+() 1
+"#;
+    let result = support::typecheck(text);
+
+    assert_eq!(&*format!("{}", result.unwrap_err()).replace("\t", "        "),
+               r#"test:Line: 2, Column: 1: Expected the following types to be equal
+Expected: b0 -> b1
+Found: {}
+1 errors were found during unification:
+Types do not match:
+        Expected: b0 -> b1
+        Found: {}
+() 1
+^~~~
+"#);
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -394,7 +394,7 @@ impl GlobalVmState {
             .unwrap()
             .get(&id)
             .cloned()
-            .unwrap_or_else(|| panic!("Expected type to be inserted before get_type call"))
+            .unwrap_or_else(|| panic!("Expected type to be inserted before get_type call. Did you forget to call `Thread::register_type`?"))
     }
 
     /// Checks if a global exists called `name`


### PR DESCRIPTION
I don't really have a good way to test that this fixes all cases but it should fix the majority of them.

Fixes #292