### PR TITLE
chore: Update lalrpop to 0.13.1 (with LALRPOP_LANE_TABLE=disabled)

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 [dependencies]
 env_logger = { version = "0.3.4", optional = true }
 quick-error = "1.0.0"
-lalrpop-util = "0.12.5"
+lalrpop-util = "0.13.1"
 log = "0.3.6"
 gluon_base = { path = "../base", version = "0.4.2" } # GLUON
 
@@ -23,7 +23,7 @@ gluon_base = { path = "../base", version = "0.4.2" } # GLUON
 collect-mac = "0.1.0"
 
 [build-dependencies]
-lalrpop = "0.12.5"
+lalrpop = "0.13.1"
 
 [features]
 test = ["env_logger"]

--- a/parser/build.rs
+++ b/parser/build.rs
@@ -1,6 +1,8 @@
 extern crate lalrpop;
 
 fn main() {
+    ::std::env::set_var("LALRPOP_LANE_TABLE", "disabled");
+
     lalrpop::Configuration::new()
         .process_current_dir()
         .unwrap();

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -30,10 +30,10 @@ gluon_check = { path = "../check", version = "0.4.2" } # GLUON
 gluon_parser = { path = "../parser", version = "0.4.2", optional = true } # GLUON
 
 [build-dependencies]
-lalrpop = { version = "0.12.5", optional = true }
+lalrpop = { version = "0.13.1", optional = true }
 
 [dev-dependencies]
-lalrpop-util = "0.12.5"
+lalrpop-util = "0.13.1"
 
 [features]
 test = ["env_logger", "lalrpop", "gluon_parser"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -34,6 +34,7 @@ lalrpop = { version = "0.13.1", optional = true }
 
 [dev-dependencies]
 lalrpop-util = "0.13.1"
+regex = "0.2.0"
 
 [features]
 test = ["env_logger", "lalrpop", "gluon_parser"]


### PR DESCRIPTION
Fixes the petgrapth regression causing nightly to fail on travis