### PR TITLE
fix(repl): Evaluate IO expressions automatically in the repl

### DIFF
--- a/base/src/resolve.rs
+++ b/base/src/resolve.rs
@@ -93,6 +93,11 @@ pub fn type_of_alias(
     let alias_args = &alias.args;
     let mut typ = alias.unresolved_type().clone();
 
+    // Opaque types should only exist as the alias itself
+    if **alias.unresolved_type() == Type::Opaque {
+        return None;
+    }
+
     // It is ok to take the aliased type only if the alias is fully applied or if it
     // the missing argument only appear in order at the end of the alias
     // i.e

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -22,7 +22,7 @@ use vm::internal::ValuePrinter;
 use vm::thread::{RootStr, RootedValue, Thread, ThreadInternal};
 
 use gluon::{new_vm, Compiler, Result as GluonResult, RootedThread};
-use gluon::compiler_pipeline::Executable;
+use gluon::compiler_pipeline::{run_io, Executable};
 
 fn type_of_expr(args: WithVM<RootStr>) -> IO<Result<String, String>> {
     let WithVM { vm, value: args } = args;
@@ -191,11 +191,12 @@ fn eval_line_(vm: &Thread, line: &str) -> GluonResult<String> {
         }
     };
     let mut eval_expr;
-    let value = match let_or_expr {
+    let (value, typ) = match let_or_expr {
         Ok(expr) => {
             eval_expr = expr;
             eval_expr
                 .run_expr(&mut compiler, vm, "<line>", line, None)
+                .and_then(|v| run_io(vm, v))
                 .wait()?
         }
         Err(let_binding) => {
@@ -214,16 +215,12 @@ fn eval_line_(vm: &Thread, line: &str) -> GluonResult<String> {
                 .run_expr(&mut compiler, vm, "<line>", line, None)
                 .wait()?;
             set_globals(vm, &unpack_pattern, &value.typ, &value.value)?;
-            value
+            (value.value, value.typ)
         }
     };
 
     let env = vm.global_env().get_env();
-    Ok(
-        ValuePrinter::new(&*env, &value.typ, *value.value)
-            .width(80)
-            .to_string(),
-    )
+    Ok(ValuePrinter::new(&*env, &typ, *value).width(80).to_string())
 }
 
 fn set_globals(

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -15,9 +15,10 @@ use either::Either;
 use base::ast::SpannedExpr;
 use base::error::InFile;
 use base::metadata::Metadata;
-use base::types::ArcType;
+use base::types::{ArcType, Type};
 use base::source::Source;
 use base::symbol::{Name, NameBuf, Symbol, SymbolModule};
+use base::resolve;
 
 use vm::compiler::CompiledFunction;
 use vm::future::{BoxFutureValue, FutureValue};
@@ -521,7 +522,15 @@ pub fn run_io<'vm, E>(
     } = v;
     if check_signature(&*vm.get_env(), &actual, &IO::<A>::make_type(vm)) {
         vm.execute_io(*value)
-            .map(move |(_, value)| (vm.root_value(value), actual))
+            .map(move |(_, value)| {
+                // The type of the new value will be `a` instead of `IO a`
+                let actual = resolve::remove_aliases_cow(&*vm.get_env(), &actual);
+                let actual = match **actual {
+                    Type::App(_, ref arg) => arg[0].clone(),
+                    _ => panic!("ICE: Expected IO type found: `{}`", actual),
+                };
+                (vm.root_value(value), actual)
+            })
             .map_err(Error::from)
             .boxed()
     } else {


### PR DESCRIPTION
Broken accidentally when let bindings without a body expression (`let x = 3`) were accepted in the repl

Fixes #334