### PR TITLE
Prelude breakups

### DIFF
--- a/examples/http.glu
+++ b/examples/http.glu
@@ -1,5 +1,6 @@
 let prelude = import! "std/prelude.glu"
 let string = import! "std/string.glu"
+let { Bool } = import! "std/bool.glu"
 let { (==) } = string.eq
 let { Functor, Applicative, Alternative, Monad } = prelude
 let { (<<), id } = prelude.make_Category prelude.category_Function

--- a/examples/http.glu
+++ b/examples/http.glu
@@ -1,10 +1,11 @@
 let prelude = import! "std/prelude.glu"
+let io = import! "std/io.glu"
 let string = import! "std/string.glu"
 let { Bool } = import! "std/bool.glu"
 let { (==) } = string.eq
 let { Functor, Applicative, Alternative, Monad } = prelude
 let { (<<), id } = prelude.make_Category prelude.category_Function
-let { wrap } = prelude.applicative_IO
+let { wrap } = io.applicative
 
 let {
     Method,
@@ -101,8 +102,8 @@ let get_response_body : Handler ResponseBody =
 let empty_response = { status = OK }
 
 /// Converts an `IO` into a `Handler`
-let io_handler io: IO a -> Handler a =
-    make (\success _ state -> prelude.monad_IO.flat_map (\a -> success a state) io)
+let io_handler action : IO a -> Handler a =
+    make (\success _ state -> io.monad.flat_map (\a -> success a state) action)
 
 /// Write `bytes` to the http response
 let write_response bytes : Array Byte -> Handler () =

--- a/examples/http_server.glu
+++ b/examples/http_server.glu
@@ -1,8 +1,9 @@
 let prelude = import! "std/prelude.glu"
+let io = import! "std/io.glu"
 let { show } = prelude.show_Int
 let string = import! "std/string.glu"
 let { (<>) } = prelude.make_Semigroup string.semigroup
-let { (*>) } = prelude.make_Applicative prelude.applicative_IO
+let { (*>) } = prelude.make_Applicative io.applicative
 
 let {
     Request, Response, Handler, StatusCode,

--- a/examples/lisp/lisp.glu
+++ b/examples/lisp/lisp.glu
@@ -5,6 +5,9 @@ let string = import! "std/string.glu"
 let { (==) } = string.eq
 let { (<>) } = prelude.make_Semigroup string.semigroup
 
+let result = import! "std/result.glu"
+let { Result } = result
+
 let list = import! "std/list.glu"
 let { List } = list
 
@@ -196,7 +199,7 @@ and eval_lisp expr : Expr -> Lisp Expr =
 and eval_exprs exprs = fold_m (\_result expr -> eval_lisp expr) (List Nil) exprs
 
 let run_lisp expr env : Lisp a -> Map String Expr -> Result String a =
-    prelude.functor_Result.map (\r -> r.value) (lisp expr env)
+    result.functor.map (\r -> r.value) (lisp expr env)
 
 let eval expr : Expr -> Result String Expr = run_lisp (eval_lisp expr) primitives
 let eval_seq exprs =

--- a/examples/lisp/lisp.glu
+++ b/examples/lisp/lisp.glu
@@ -7,6 +7,7 @@ let { (<>) } = prelude.make_Semigroup string.semigroup
 
 let result = import! "std/result.glu"
 let { Result } = result
+let { Option } = import! "std/option.glu"
 
 let list = import! "std/list.glu"
 let { List } = list

--- a/examples/lisp/lisp.glu
+++ b/examples/lisp/lisp.glu
@@ -5,6 +5,7 @@ let string = import! "std/string.glu"
 let { (==) } = string.eq
 let { (<>) } = prelude.make_Semigroup string.semigroup
 
+let { Bool } = import! "std/bool.glu"
 let result = import! "std/result.glu"
 let { Result } = result
 let { Option } = import! "std/option.glu"

--- a/examples/lisp/parser.glu
+++ b/examples/lisp/parser.glu
@@ -1,5 +1,6 @@
 let prelude = import! "std/prelude.glu"
 let { Expr } = import! "examples/lisp/types.glu"
+let char = import! "std/char.glu"
 let { List } = import! "std/list.glu"
 let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"

--- a/examples/lisp/parser.glu
+++ b/examples/lisp/parser.glu
@@ -1,6 +1,7 @@
 let prelude = import! "std/prelude.glu"
 let { Expr } = import! "examples/lisp/types.glu"
 let { List } = import! "std/list.glu"
+let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
 
 let {

--- a/examples/lisp/types.glu
+++ b/examples/lisp/types.glu
@@ -1,5 +1,6 @@
 let { List } = import! "std/list.glu"
 let { Map } = import! "std/map.glu"
+let { Result } = import! "std/result.glu"
 
 type Expr =
     | Atom String

--- a/examples/lisp/types.glu
+++ b/examples/lisp/types.glu
@@ -1,5 +1,6 @@
 let { List } = import! "std/list.glu"
 let { Map } = import! "std/map.glu"
+let { Option } = import! "std/option.glu"
 let { Result } = import! "std/result.glu"
 
 type Expr =

--- a/parser/tests/pretty_print.rs
+++ b/parser/tests/pretty_print.rs
@@ -44,6 +44,11 @@ fn bool() {
 }
 
 #[test]
+fn char() {
+    test_format("std/char.glu");
+}
+
+#[test]
 fn map() {
     test_format("std/map.glu");
 }

--- a/parser/tests/pretty_print.rs
+++ b/parser/tests/pretty_print.rs
@@ -89,6 +89,11 @@ fn types() {
 }
 
 #[test]
+fn unit() {
+    test_format("std/unit.glu");
+}
+
+#[test]
 fn writer() {
     test_format("std/writer.glu");
 }

--- a/parser/tests/pretty_print.rs
+++ b/parser/tests/pretty_print.rs
@@ -39,6 +39,11 @@ fn test_format(name: &str) {
 }
 
 #[test]
+fn bool() {
+    test_format("std/bool.glu");
+}
+
+#[test]
 fn map() {
     test_format("std/map.glu");
 }

--- a/parser/tests/pretty_print.rs
+++ b/parser/tests/pretty_print.rs
@@ -44,8 +44,18 @@ fn map() {
 }
 
 #[test]
+fn option() {
+    test_format("std/option.glu");
+}
+
+#[test]
 fn prelude() {
     test_format("std/prelude.glu");
+}
+
+#[test]
+fn result() {
+    test_format("std/result.glu");
 }
 
 #[test]

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -1,5 +1,6 @@
 let prelude = import! "std/prelude.glu"
 let map = import! "std/map.glu"
+let { Bool } = import! "std/bool.glu"
 let { Option } = import! "std/option.glu"
 let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -1,17 +1,18 @@
 let prelude = import! "std/prelude.glu"
+let io = import! "std/io.glu"
 let map = import! "std/map.glu"
 let { Bool } = import! "std/bool.glu"
 let { Option } = import! "std/option.glu"
 let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
 let { Map } = map
-let { wrap, (*>) } = prelude.make_Applicative prelude.applicative_IO
-let { (>>=) } = prelude.make_Monad prelude.monad_IO
+let { wrap, (*>) } = prelude.make_Applicative io.applicative
+let { (>>=) } = prelude.make_Monad io.monad
 let { Eq } = prelude
 let { append = (++) } = string.semigroup
 let ord_map = map.make string.ord
 let { singleton, find } = ord_map
-let for = (prelude.make_Traversable ord_map.traversable).for prelude.applicative_IO
+let for = (prelude.make_Traversable ord_map.traversable).for io.applicative
 let { (<>) } = prelude.make_Semigroup ord_map.semigroup
 let { empty } = ord_map.monoid
 

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -1,10 +1,11 @@
 let prelude = import! "std/prelude.glu"
 let map = import! "std/map.glu"
+let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
 let { Map } = map
 let { wrap, (*>) } = prelude.make_Applicative prelude.applicative_IO
 let { (>>=) } = prelude.make_Monad prelude.monad_IO
-let { Eq, Result } = prelude
+let { Eq } = prelude
 let { append = (++) } = string.semigroup
 let ord_map = map.make string.ord
 let { singleton, find } = ord_map

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -1,5 +1,6 @@
 let prelude = import! "std/prelude.glu"
 let map = import! "std/map.glu"
+let { Option } = import! "std/option.glu"
 let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
 let { Map } = map

--- a/src/import.rs
+++ b/src/import.rs
@@ -47,12 +47,13 @@ macro_rules! std_libs {
     }
 }
 // Include the standard library distribution in the binary
-static STD_LIBS: [(&str, &str); 15] = std_libs!(
+static STD_LIBS: [(&str, &str); 16] = std_libs!(
     "prelude",
     "types",
 
     "bool",
     "char",
+    "io",
     "list",
     "map",
     "option",

--- a/src/io.rs
+++ b/src/io.rs
@@ -209,38 +209,30 @@ pub fn load(vm: &Thread) -> Result<()> {
         PushInt(0), // [f, m_ret, ()]   Add a dummy argument ()
         TailCall(2) /* [f_ret]          Call f m_ret () */,
     ];
-    let io_flat_map_type =
-        <fn(fn(A) -> IO<B>, IO<A>) -> IO<B> as VmType>::make_type(vm);
-    vm.add_bytecode(
-        "io_flat_map",
-        io_flat_map_type,
-        3,
-        io_flat_map,
-    )?;
 
+    type FlatMap = fn(fn(A) -> IO<B>, IO<A>) -> IO<B>;
+    type Wrap = fn(A) -> IO<A>;
+    let flat_map_ty = <FlatMap as VmType>::make_type(vm);
+    let wrap_ty = <Wrap as VmType>::make_type(vm);
 
-    vm.add_bytecode(
-        "io_wrap",
-        <fn(A) -> IO<A> as VmType>::make_type(vm),
-        2,
-        vec![Pop(1)],
-    )?;
+    vm.add_bytecode("io_flat_map", flat_map_ty, 3, io_flat_map)?;
+    vm.add_bytecode("io_wrap", wrap_ty, 2, vec![Pop(1)])?;
+
     // IO functions
     vm.define_global(
-        "io",
-        record!(
-        open_file => primitive!(1 open_file),
-        read_file => primitive!(2 read_file),
-        read_file_to_string => primitive!(1 read_file_to_string),
-        read_char => primitive!(0 read_char),
-        read_line => primitive!(0 read_line),
-        print => primitive!(1 print),
-        println => primitive!(1 println),
-        catch =>
-            primitive!(2 catch),
-        run_expr => primitive!(1 run_expr),
-        load_script => primitive!(2 load_script)
-    ),
+        "io_prim",
+        record! {
+            open_file => primitive!(1 open_file),
+            read_file => primitive!(2 read_file),
+            read_file_to_string => primitive!(1 read_file_to_string),
+            read_char => primitive!(0 read_char),
+            read_line => primitive!(0 read_line),
+            print => primitive!(1 print),
+            println => primitive!(1 println),
+            catch => primitive!(2 catch),
+            run_expr => primitive!(1 run_expr),
+            load_script => primitive!(2 load_script)
+        },
     )?;
     Ok(())
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -219,19 +219,20 @@ pub fn load(vm: &Thread) -> Result<()> {
     vm.add_bytecode("io_wrap", wrap_ty, 2, vec![Pop(1)])?;
 
     // IO functions
+    use super::io as io_prim;
     vm.define_global(
         "io_prim",
         record! {
-            open_file => primitive!(1 open_file),
-            read_file => primitive!(2 read_file),
-            read_file_to_string => primitive!(1 read_file_to_string),
-            read_char => primitive!(0 read_char),
-            read_line => primitive!(0 read_line),
-            print => primitive!(1 print),
-            println => primitive!(1 println),
-            catch => primitive!(2 catch),
-            run_expr => primitive!(1 run_expr),
-            load_script => primitive!(2 load_script)
+            open_file => primitive!(1 io_prim::open_file),
+            read_file => primitive!(2 io_prim::read_file),
+            read_file_to_string => primitive!(1 io_prim::read_file_to_string),
+            read_char => primitive!(0 io_prim::read_char),
+            read_line => primitive!(0 io_prim::read_line),
+            print => primitive!(1 io_prim::print),
+            println => primitive!(1 io_prim::println),
+            catch => primitive!(2 io_prim::catch),
+            run_expr => primitive!(1 io_prim::run_expr),
+            load_script => primitive!(2 io_prim::load_script)
         },
     )?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,8 +230,13 @@ impl Compiler {
         expr_str: &str,
         expected_type: Option<&ArcType>,
     ) -> Result<(SpannedExpr<Symbol>, ArcType)> {
-        let TypecheckValue { expr, typ } =
-            expr_str.typecheck_expected(self, vm, file, expr_str, expected_type)?;
+        let TypecheckValue { expr, typ } = expr_str.typecheck_expected(
+            self,
+            vm,
+            file,
+            expr_str,
+            expected_type,
+        )?;
         Ok((expr, typ))
     }
 
@@ -334,10 +339,9 @@ impl Compiler {
             // Use the import macro's path resolution if it exists so that we mimick the import
             // macro as close as possible
             let opt_macro = vm.get_macros().get("import");
-            match opt_macro
-                .as_ref()
-                .and_then(|mac| mac.downcast_ref::<Import>())
-            {
+            match opt_macro.as_ref().and_then(
+                |mac| mac.downcast_ref::<Import>(),
+            ) {
                 Some(import) => Ok(import.read_file(filename)?),
                 None => {
                     let mut buffer = StdString::new();
@@ -428,9 +432,7 @@ impl Compiler {
         expr_str
             .run_expr(self, vm, name, expr_str, Some(&expected))
             .and_then(move |v| {
-                let ExecuteValue {
-                    typ: actual, value, ..
-                } = v;
+                let ExecuteValue { typ: actual, value, .. } = v;
                 unsafe {
                     FutureValue::sync(match T::from_value(vm, Variants::new(&value)) {
                         Some(value) => Ok((value, actual)),
@@ -538,9 +540,6 @@ and { (<), (<=), (>=), (>) } = __implicit_prelude.make_Ord __implicit_prelude.or
 let { (+), (-), (*), (/) } = __implicit_prelude.num_Float
 and { (==) } = __implicit_prelude.eq_Float
 and { (<), (<=), (>=), (>) } = __implicit_prelude.make_Ord __implicit_prelude.ord_Float
-
-let { (==) } = __implicit_prelude.eq_Char
-and { (<), (<=), (>=), (>) } = __implicit_prelude.make_Ord __implicit_prelude.ord_Char
 
 in 0
 "#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,7 @@ impl Compiler {
 
 pub const PRELUDE: &'static str = r#"
 let __implicit_prelude = import! "std/prelude.glu"
-and { Num, Eq, Ord, Show, Functor, Monad, Bool, not } = __implicit_prelude
+and { Num, Eq, Ord, Show, Functor, Monad } = __implicit_prelude
 
 let { (+), (-), (*), (/) } = __implicit_prelude.num_Int
 and { (==) } = __implicit_prelude.eq_Int

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,7 @@ impl Compiler {
 
 pub const PRELUDE: &'static str = r#"
 let __implicit_prelude = import! "std/prelude.glu"
-and { Num, Eq, Ord, Show, Functor, Monad, Bool, Option, Result, not } = __implicit_prelude
+and { Num, Eq, Ord, Show, Functor, Monad, Bool, Option, not } = __implicit_prelude
 
 let { (+), (-), (*), (/) } = __implicit_prelude.num_Int
 and { (==) } = __implicit_prelude.eq_Int

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,7 @@ impl Compiler {
 
 pub const PRELUDE: &'static str = r#"
 let __implicit_prelude = import! "std/prelude.glu"
-and { Num, Eq, Ord, Show, Functor, Monad, Bool, Option, not } = __implicit_prelude
+and { Num, Eq, Ord, Show, Functor, Monad, Bool, not } = __implicit_prelude
 
 let { (+), (-), (*), (/) } = __implicit_prelude.num_Int
 and { (==) } = __implicit_prelude.eq_Int

--- a/std/bool.glu
+++ b/std/bool.glu
@@ -7,49 +7,64 @@ let not x : Bool -> Bool = if x then False else True
 /// Boolean 'exclusive or'
 let xor x y : Bool -> Bool -> Bool = if x then not y else y
 
-let semigroup_And : Semigroup Bool = { append = \x y -> x && y }
+let conjunctive =
+    let semigroup : Semigroup Bool = {
+        append = \x y -> x && y
+    }
 
-let semigroup_Or : Semigroup Bool = { append = \x y -> x || y }
+    let monoid : Monoid Bool = {
+        semigroup = semigroup,
+        empty = True
+    }
 
-let semigroup_Xor : Semigroup Bool = { append = xor }
+    { semigroup, monoid }
 
-let monoid_And : Monoid Bool = {
-    semigroup = semigroup_And,
-    empty = True
+let disjunctive =
+    let semigroup : Semigroup Bool = {
+        append = \x y -> x || y
+    }
+
+    let monoid : Monoid Bool = {
+        semigroup = semigroup,
+        empty = False
+    }
+
+    { semigroup, monoid }
+
+let exclusive =
+    let semigroup : Semigroup Bool = { append = xor }
+
+    let monoid : Monoid Bool = {
+        semigroup = semigroup,
+        empty = False
+    }
+
+    let group : Group Bool = {
+        monoid = monoid,
+        inverse = id
+    }
+
+    { semigroup, monoid, group }
+
+let eq : Eq Bool = {
+    (==) = \l r -> if l then r else not r
 }
 
-let monoid_Or : Monoid Bool = {
-    semigroup = semigroup_Or,
-    empty = False
+let ord : Ord Bool = {
+    eq = eq, compare = \l r -> if l then if r then EQ else GT else LT
 }
 
-let monoid_Xor : Monoid Bool = {
-    semigroup = semigroup_Xor,
-    empty = False
+let show : Show Bool = {
+    show = \x -> if x then "True" else "False"
 }
-
-let group_Xor : Group Bool = {
-    monoid = monoid_Xor,
-    inverse = id
-}
-
-let eq : Eq Bool = { (==) = \l r -> if l then r else not r }
-
-let ord : Ord Bool = { eq = eq, compare = \l r -> if l then if r then EQ else GT else LT }
-
-let show : Show Bool = { show = \x -> if x then "True" else "False" }
 
 {
     Bool,
     not,
     xor,
-    semigroup_And,
-    semigroup_Or,
-    semigroup_Xor,
-    monoid_And,
-    monoid_Or,
-    monoid_Xor,
-    group_Xor,
+    conjunctive,
+    disjunctive,
+    exclusive,
     eq,
     ord,
     show

--- a/std/bool.glu
+++ b/std/bool.glu
@@ -1,0 +1,56 @@
+let { Bool, Ordering } = import! "std/types.glu"
+let { Semigroup, Monoid, Group, Eq, Show, id } = import! "std/prelude.glu"
+
+/// Boolean 'not'
+let not x : Bool -> Bool = if x then False else True
+
+/// Boolean 'exclusive or'
+let xor x y : Bool -> Bool -> Bool = if x then not y else y
+
+let semigroup_And : Semigroup Bool = { append = \x y -> x && y }
+
+let semigroup_Or : Semigroup Bool = { append = \x y -> x || y }
+
+let semigroup_Xor : Semigroup Bool = { append = xor }
+
+let monoid_And : Monoid Bool = {
+    semigroup = semigroup_And,
+    empty = True
+}
+
+let monoid_Or : Monoid Bool = {
+    semigroup = semigroup_Or,
+    empty = False
+}
+
+let monoid_Xor : Monoid Bool = {
+    semigroup = semigroup_Xor,
+    empty = False
+}
+
+let group_Xor : Group Bool = {
+    monoid = monoid_Xor,
+    inverse = id
+}
+
+let eq : Eq Bool = { (==) = \l r -> if l then r else not r }
+
+let ord : Ord Bool = { eq = eq, compare = \l r -> if l then if r then EQ else GT else LT }
+
+let show : Show Bool = { show = \x -> if x then "True" else "False" }
+
+{
+    Bool,
+    not,
+    xor,
+    semigroup_And,
+    semigroup_Or,
+    semigroup_Xor,
+    monoid_And,
+    monoid_Or,
+    monoid_Xor,
+    group_Xor,
+    eq,
+    ord,
+    show
+}

--- a/std/char.glu
+++ b/std/char.glu
@@ -1,0 +1,27 @@
+let { Eq, Ord, Ordering, Show } = import! "std/prelude.glu"
+
+let eq : Eq Char = { (==) = \l r -> l #Char== r }
+
+let ord : Ord Char = {
+    eq = eq,
+    compare = \l r -> if l #Char< r then LT else if l #Char== r then EQ else GT
+}
+
+let show : Show Char = { show = prim.show_char }
+
+{
+    eq,
+    ord,
+    show,
+    is_digit = char_prim.is_digit,
+    to_digit = char_prim.to_digit,
+    len_utf8 = char_prim.len_utf8,
+    len_utf16 = char_prim.len_utf16,
+    is_alphabetic = char_prim.is_alphabetic,
+    is_lowercase = char_prim.is_lowercase,
+    is_uppercase = char_prim.is_uppercase,
+    is_whitespace = char_prim.is_whitespace,
+    is_alphanumeric = char_prim.is_alphanumeric,
+    is_control = char_prim.is_control,
+    is_numeric = char_prim.is_numeric
+}

--- a/std/io.glu
+++ b/std/io.glu
@@ -1,0 +1,33 @@
+let { Functor, Applicative, Monad } = import! "std/prelude.glu"
+
+let functor : Functor IO = {
+    map = \f -> io_flat_map (\x -> io_wrap (f x))
+}
+
+let applicative : Applicative IO =
+    let wrap = io_wrap
+    let apply f x = io_flat_map (\g -> io_flat_map (\y -> wrap (g y)) x) f
+
+    { functor, apply, wrap }
+
+let monad : Monad IO = {
+    applicative = applicative,
+    flat_map = io_flat_map
+}
+
+{
+    functor,
+    applicative,
+    monad,
+
+    open_file = io_prim.open_file,
+    read_file = io_prim.read_file,
+    read_file_to_string = io_prim.read_file_to_string,
+    read_char = io_prim.read_char,
+    read_line = io_prim.read_line,
+    print = io_prim.print,
+    println = io_prim.println,
+    catch = io_prim.catch,
+    run_expr = io_prim.run_expr,
+    load_script = io_prim.load_script,
+}

--- a/std/list.glu
+++ b/std/list.glu
@@ -1,6 +1,7 @@
 let prelude = import! "std/prelude.glu"
 let { Semigroup, Monoid, Eq, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
+let { Bool } = import! "std/bool.glu"
 let string = import! "std/string.glu"
 
 /// A linked list type

--- a/std/map.glu
+++ b/std/map.glu
@@ -1,9 +1,10 @@
 let prelude = import! "std/prelude.glu"
-and { Ordering, Ord, Option, Semigroup, Monoid } = prelude
-and { Functor, Applicative, Foldable, Traversable } = prelude
+let { Ordering, Ord, Semigroup, Monoid } = prelude
+let { Functor, Applicative, Foldable, Traversable } = prelude
 
 let list = import! "std/list.glu"
-and { List } = list
+let { List } = list
+let { Option } = import! "std/option.glu"
 
 type Map k a = | Bin k a (Map k a) (Map k a) | Tip
 

--- a/std/option.glu
+++ b/std/option.glu
@@ -1,6 +1,7 @@
 let prelude = import! "std/prelude.glu"
 let { Semigroup, Monoid, Eq, Ord, Ordering, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
+let { Bool } = import! "std/bool.glu"
 let { Option } = import! "std/types.glu"
 
 let unwrap opt : Option a -> a =

--- a/std/option.glu
+++ b/std/option.glu
@@ -18,34 +18,40 @@ let semigroup a : Semigroup a -> Semigroup (Option a) = {
         | (None, None) -> None
 }
 
-let semigroup_First : Semigroup (Option a) = {
-    append = \l r ->
-        match l with
-        | Some x -> Some x
-        | None -> r
-}
-
-let semigroup_Last : Semigroup (Option a) = {
-    append = \l r ->
-        match r with
-        | Some x -> Some x
-        | None -> l
-}
-
 let monoid a : Semigroup a -> Monoid (Option a) = {
     semigroup = semigroup a,
     empty = None
 }
 
-let monoid_First : Monoid (Option a) = {
-    semigroup = semigroup_First,
-    empty = None
-}
+let former =
+    let semigroup : Semigroup (Option a) = {
+        append = \l r ->
+            match l with
+            | Some x -> Some x
+            | None -> r
+    }
 
-let monoid_Last : Monoid (Option a) = {
-    semigroup = semigroup_Last,
-    empty = None
-}
+    let monoid : Monoid (Option a) = {
+        semigroup = semigroup,
+        empty = None
+    }
+
+    { semigroup, monoid }
+
+let latter =
+    let semigroup : Semigroup (Option a) = {
+        append = \l r ->
+            match r with
+            | Some x -> Some x
+            | None -> l
+    }
+
+    let monoid : Monoid (Option a) = {
+        semigroup = semigroup,
+        empty = None
+    }
+
+    { semigroup, monoid }
 
 let eq a : Eq a -> Eq (Option a) = {
     (==) = \l r ->
@@ -132,11 +138,9 @@ let traversable : Traversable Option = {
     Option,
     unwrap,
     semigroup,
-    semigroup_First,
-    semigroup_Last,
     monoid,
-    monoid_First,
-    monoid_Last,
+    former,
+    latter,
     eq,
     ord,
     functor,

--- a/std/option.glu
+++ b/std/option.glu
@@ -1,0 +1,148 @@
+let prelude = import! "std/prelude.glu"
+let { Semigroup, Monoid, Eq, Ord, Ordering, Show } = prelude
+let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
+let { Option } = import! "std/types.glu"
+
+let unwrap opt : Option a -> a =
+    match opt with
+    | Some x -> x
+    | None -> error "Option was None"
+
+let semigroup a : Semigroup a -> Semigroup (Option a) = {
+    append = \l r ->
+        match (l, r) with
+        | (Some x, Some y) -> Some (a.append x y)
+        | (Some _, None) -> l
+        | (None, Some _) -> r
+        | (None, None) -> None
+}
+
+let semigroup_First : Semigroup (Option a) = {
+    append = \l r ->
+        match l with
+        | Some x -> Some x
+        | None -> r
+}
+
+let semigroup_Last : Semigroup (Option a) = {
+    append = \l r ->
+        match r with
+        | Some x -> Some x
+        | None -> l
+}
+
+let monoid a : Semigroup a -> Monoid (Option a) = {
+    semigroup = semigroup a,
+    empty = None
+}
+
+let monoid_First : Monoid (Option a) = {
+    semigroup = semigroup_First,
+    empty = None
+}
+
+let monoid_Last : Monoid (Option a) = {
+    semigroup = semigroup_Last,
+    empty = None
+}
+
+let eq a : Eq a -> Eq (Option a) = {
+    (==) = \l r ->
+        match (l, r) with
+        | (Some l_val, Some r_val) -> a.(==) l_val r_val
+        | (None, None) -> True
+        | _ -> False
+}
+
+let ord a : Ord a -> Ord (Option a) = {
+    eq = eq a.eq,
+    compare = \l r ->
+        match (l, r) with
+        | (Some l_val, Some r_val) -> a.compare l_val r_val
+        | (None, Some _) -> LT
+        | (Some _, None) -> GT
+        | (None, None) -> EQ
+}
+
+let functor : Functor Option = {
+    map = \f x ->
+        match x with
+        | Some y -> Some (f y)
+        | None -> None
+}
+
+let applicative : Applicative Option = {
+    functor = functor,
+    apply = \f x ->
+        match (f, x) with
+        | (Some g, Some y) -> Some (g y)
+        | _ -> None,
+    wrap = \x -> Some x
+}
+
+let alternative : Alternative Option = {
+    applicative = applicative,
+    or = \x y ->
+        match x with
+        | Some _ -> x
+        | None -> y,
+    empty = None
+}
+
+let monad : Monad Option = {
+    applicative = applicative,
+    flat_map = \f m ->
+        match m with
+        | Some x -> f x
+        | None -> None
+}
+
+let show : Show a -> Show (Option a) = \d ->
+    let (++) = string_prim.append
+
+    let show o =
+        match o with
+        | Some x -> "Some (" ++ d.show x ++ ")"
+        | None -> "None"
+
+    { show }
+
+let foldable : Foldable Option = {
+    foldr = \f z o ->
+        match o with
+        | None -> z
+        | Some x -> f x z,
+    foldl = \f z o ->
+        match o with
+        | None -> z
+        | Some x -> f z x
+}
+
+let traversable : Traversable Option = {
+    functor = functor,
+    foldable = foldable,
+    traverse = \app f o ->
+        match o with
+        | None -> app.wrap None
+        | Some x -> app.functor.map Some (f x)
+}
+
+{
+    Option,
+    unwrap,
+    semigroup,
+    semigroup_First,
+    semigroup_Last,
+    monoid,
+    monoid_First,
+    monoid_Last,
+    eq,
+    ord,
+    functor,
+    applicative,
+    alternative,
+    monad,
+    show,
+    foldable,
+    traversable
+}

--- a/std/option.glu
+++ b/std/option.glu
@@ -9,20 +9,6 @@ let unwrap opt : Option a -> a =
     | Some x -> x
     | None -> error "Option was None"
 
-let semigroup a : Semigroup a -> Semigroup (Option a) = {
-    append = \l r ->
-        match (l, r) with
-        | (Some x, Some y) -> Some (a.append x y)
-        | (Some _, None) -> l
-        | (None, Some _) -> r
-        | (None, None) -> None
-}
-
-let monoid a : Semigroup a -> Monoid (Option a) = {
-    semigroup = semigroup a,
-    empty = None
-}
-
 let former =
     let semigroup : Semigroup (Option a) = {
         append = \l r ->
@@ -52,6 +38,20 @@ let latter =
     }
 
     { semigroup, monoid }
+
+let semigroup a : Semigroup a -> Semigroup (Option a) = {
+    append = \l r ->
+        match (l, r) with
+        | (Some x, Some y) -> Some (a.append x y)
+        | (Some _, None) -> l
+        | (None, Some _) -> r
+        | (None, None) -> None
+}
+
+let monoid a : Semigroup a -> Monoid (Option a) = {
+    semigroup = semigroup a,
+    empty = None
+}
 
 let eq a : Eq a -> Eq (Option a) = {
     (==) = \l r ->

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -1,6 +1,8 @@
 let prelude = import! "std/prelude.glu"
-let { Functor, Applicative, Alternative, Monad, id, show_Char = show } = prelude
+let { Functor, Applicative, Alternative, Monad, id } = prelude
 let { Bool } = import! "std/bool.glu"
+let char = import! "std/char.glu"
+let { (==) } = char.eq
 let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
 let { (<>) } = prelude.make_Semigroup string.semigroup
@@ -102,7 +104,7 @@ let satisfy predicate: (Char -> Bool) -> Parser Char =
         if predicate c then
             wrap c
         else
-            fail ("Unexpected character " <> show.show c)
+            fail ("Unexpected character " <> char.show.show c)
     flat_map f any
 
 let token expected: Char -> Parser Char =

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -1,5 +1,6 @@
 let prelude = import! "std/prelude.glu"
 let { Functor, Applicative, Alternative, Monad, id, show_Char = show } = prelude
+let { Bool } = import! "std/bool.glu"
 let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
 let { (<>) } = prelude.make_Semigroup string.semigroup

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -1,5 +1,6 @@
 let prelude = import! "std/prelude.glu"
 let { Functor, Applicative, Alternative, Monad, id, show_Char = show } = prelude
+let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
 let { (<>) } = prelude.make_Semigroup string.semigroup
 let list = import! "std/list.glu"

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -5,6 +5,7 @@ let string = import! "std/string.glu"
 let { (<>) } = prelude.make_Semigroup string.semigroup
 let list = import! "std/list.glu"
 let { List } = list
+let { Option } = import! "std/option.glu"
 
 type OffsetString = { start: Int, end: Int, buffer: String }
 type Position = Int

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -108,8 +108,6 @@ let group_Float_Mul : Group Float = {
 /// `Eq a` defines equality (==) on `a`
 type Eq a = { (==) : a -> a -> Bool }
 
-let eq_Unit : Eq () = { (==) = \l r -> True }
-
 let eq_Int = { (==) = \l r -> l #Int== r }
 
 let eq_Float = { (==) = \l r -> l #Float== r }
@@ -149,7 +147,6 @@ let make_Ord ord : Ord a -> _ =
 
     { eq, compare, (<=), (<), (>), (>=) }
 
-let ord_Unit = { eq = eq_Unit, compare = \l r -> EQ }
 
 let ord_Int = {
     eq = eq_Int,
@@ -377,7 +374,6 @@ let monad_IO : Monad IO = {
 /// `Show a` represents a conversion function from `a` to a readable string.
 type Show a = { show : a -> String }
 
-let show_Unit : Show () = { show = const "()" }
 
 let show_Int : Show Int = { show = prim.show_int }
 
@@ -486,14 +482,12 @@ let make_Traversable traversable : Traversable t -> _ =
     group_Float_Mul,
 
     Eq,
-    eq_Unit,
     eq_Float,
     eq_Int,
     eq_Char,
 
     Ord,
     make_Ord,
-    ord_Unit,
     ord_Float,
     ord_Int,
     ord_Char,
@@ -535,7 +529,6 @@ let make_Traversable traversable : Traversable t -> _ =
     (>>),
 
     Show,
-    show_Unit,
     show_Int,
     show_Float,
     show_Char

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -1,19 +1,9 @@
-let { Bool, Option, Result, Ordering } = import! "std/types.glu"
+let { Bool, Option, Ordering } = import! "std/types.glu"
 
 let unwrap opt : Option a -> a =
     match opt with
     | Some x -> x
     | None -> error "Option was None"
-
-let unwrap_ok res : Result e a -> a =
-    match res with
-    | Ok x -> x
-    | Err _ -> error "Result was an Err"
-
-let unwrap_err res : Result e a -> e =
-    match res with
-    | Ok _ -> error "Result was an Ok"
-    | Err x -> x
 
 /// Boolean 'not'
 let not x : Bool -> Bool = if x then False else True
@@ -211,14 +201,6 @@ let eq_Option a : Eq a -> Eq (Option a) = {
         | _ -> False
 }
 
-let eq_Result e a : Eq e -> Eq a -> Eq (Result e a) = {
-    (==) = \l r ->
-        match (l, r) with
-        | (Ok l_val, Ok r_val) -> a.(==) l_val r_val
-        | (Err l_val, Err r_val) -> e.(==) l_val r_val
-        | _ -> False
-}
-
 /// `Ord a` defines an ordering on `a`
 type Ord a = { eq : Eq a, compare : a -> a -> Ordering }
 
@@ -279,16 +261,6 @@ let ord_Option a : Ord a -> Ord (Option a) = {
         | (None, Some _) -> LT
         | (Some _, None) -> GT
         | (None, None) -> EQ
-}
-
-let ord_Result e a : Ord e -> Ord a -> Ord (Result e a) = {
-    eq = eq_Result e.eq a.eq,
-    compare = \l r ->
-        match (l, r) with
-        | (Ok l_val, Ok r_val) -> a.compare l_val r_val
-        | (Err l_val, Err r_val) -> e.compare l_val r_val
-        | (Ok _, Err _) -> LT
-        | (Err _, Ok _) -> GT
 }
 
 /**
@@ -374,7 +346,7 @@ type Functor f = {
     /// # Examples
     ///
     /// * `applicative_Option.map show_Int.show (Some 1) == Some "1"`
-    /// * `applicative_Result.map show_Int.show (Some 1) == Ok "1"`
+    /// * `result.applicative.map show_Int.show (Some 1) == Ok "1"`
     /// * `list.functor.map show_Int.show (list.of [1, 2]) == list.of ["1", "2"]`
     ///
     /// # Note
@@ -392,13 +364,6 @@ let functor_Option : Functor Option = {
         | None -> None
 }
 
-let functor_Result : Functor (Result e) = {
-    map = \f x ->
-        match x with
-        | Ok y -> Ok (f y)
-        | Err _ -> x
-}
-
 let functor_IO : Functor IO = { map = \f -> io_flat_map (\x -> io_wrap (f x)) }
 
 type Applicative (f : Type -> Type) = {
@@ -414,7 +379,7 @@ type Applicative (f : Type -> Type) = {
     /// # Examples
     ///
     /// * `applicative_Option.wrap 1 == Some 1`
-    /// * `applicative_Result.wrap 1 == Ok 1`
+    /// * `result.applicative.wrap 1 == Ok 1`
     /// * `list.applicative.wrap 1 == list.of [1]`
     ///
     /// # Note
@@ -451,16 +416,6 @@ let applicative_Option : Applicative Option = {
         | (Some g, Some y) -> Some (g y)
         | _ -> None,
     wrap = \x -> Some x
-}
-
-let applicative_Result : Applicative (Result e) = {
-    functor = functor_Result,
-    apply = \f x ->
-        match (f, x) with
-        | (Ok g, Ok y) -> Ok (g y)
-        | (Ok _, Err _) -> x
-        | (Err x, _) -> Err x,
-    wrap = \x -> Ok x
 }
 
 let applicative_IO : Applicative IO =
@@ -501,13 +456,13 @@ type Monad (m : Type -> Type) = {
     /// In gluon this would look like:
     ///
     /// ```gluon
-    /// monad_Result.flat_map (\x -> do_something x) (call_fallible "hello")
+    /// result.monad.flat_map (\x -> do_something x) (call_fallible "hello")
     /// ```
     ///
     /// Note that it is sometimes more ergonomic to use the `(>>=)` operator:
     ///
     /// ```gluon
-    /// let { (>>=) } = make_Monad monad_Result
+    /// let { (>>=) } = make_Monad result.monad
     ///
     /// call_fallible "hello" >>= (\x -> do_something x)
     /// ```
@@ -544,14 +499,6 @@ let monad_Option : Monad Option = {
         | None -> None
 }
 
-let monad_Result : Monad (Result e) = {
-    applicative = applicative_Result,
-    flat_map = \f m ->
-        match m with
-        | Ok x -> f x
-        | Err err -> Err err
-}
-
 let monad_IO : Monad IO = {
     applicative = applicative_IO,
     flat_map = io_flat_map
@@ -577,16 +524,6 @@ let show_Option : Show a -> Show (Option a) = \d ->
         match o with
         | Some x -> "Some (" ++ d.show x ++ ")"
         | None -> "None"
-
-    { show }
-
-let show_Result : Show e -> Show t -> Show (Result e t) = \e t ->
-    let (++) = string_prim.append
-
-    let show o =
-        match o with
-        | Ok x -> "Ok (" ++ t.show x ++ ")"
-        | Err x -> "Err (" ++ e.show x ++ ")"
 
     { show }
 
@@ -665,17 +602,6 @@ let foldable_Option : Foldable Option = {
         | Some x -> f z x
 }
 
-let foldable_Result : Foldable (Result e) = {
-    foldr = \f z r ->
-        match r with
-        | Err _ -> z
-        | Ok x -> f x z,
-    foldl = \f z r ->
-        match r with
-        | Err _ -> z
-        | Ok x -> f z x
-}
-
 type Traversable t = {
     functor : Functor t,
     foldable : Foldable t,
@@ -700,24 +626,12 @@ let traversable_Option : Traversable Option = {
         | Some x -> app.functor.map Some (f x)
 }
 
-let traversable_Result : Traversable (Result e) = {
-    functor = functor_Result,
-    foldable = foldable_Result,
-    traverse = \app f r ->
-        match r with
-        | Err e -> app.wrap (Err e)
-        | Ok x -> app.functor.map Ok (f x)
-}
-
 {
     Bool,
     Ordering,
     Option,
-    Result,
 
     unwrap,
-    unwrap_ok,
-    unwrap_err,
 
     not,
     xor,
@@ -761,7 +675,6 @@ let traversable_Result : Traversable (Result e) = {
     eq_Unit,
     eq_Bool,
     eq_Option,
-    eq_Result,
     eq_Float,
     eq_Int,
     eq_Char,
@@ -771,7 +684,6 @@ let traversable_Result : Traversable (Result e) = {
     ord_Unit,
     ord_Bool,
     ord_Option,
-    ord_Result,
     ord_Float,
     ord_Int,
     ord_Char,
@@ -782,13 +694,11 @@ let traversable_Result : Traversable (Result e) = {
 
     Functor,
     functor_Option,
-    functor_Result,
     functor_IO,
 
     Applicative,
     make_Applicative,
     applicative_Option,
-    applicative_Result,
     applicative_IO,
 
     Alternative,
@@ -798,18 +708,15 @@ let traversable_Result : Traversable (Result e) = {
     Monad,
     make_Monad,
     monad_Option,
-    monad_Result,
     monad_IO,
 
     Foldable,
     make_Foldable,
     foldable_Option,
-    foldable_Result,
 
     Traversable,
     make_Traversable,
     traversable_Option,
-    traversable_Result,
 
     Num,
     num_Int,
@@ -829,6 +736,5 @@ let traversable_Result : Traversable (Result e) = {
     show_Int,
     show_Float,
     show_Char,
-    show_Option,
-    show_Result
+    show_Option
 }

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -112,8 +112,6 @@ let eq_Int = { (==) = \l r -> l #Int== r }
 
 let eq_Float = { (==) = \l r -> l #Float== r }
 
-let eq_Char = { (==) = \l r -> l #Char== r }
-
 /// `Ord a` defines an ordering on `a`
 type Ord a = { eq : Eq a, compare : a -> a -> Ordering }
 
@@ -156,11 +154,6 @@ let ord_Int = {
 let ord_Float = {
     eq = eq_Float,
     compare = \l r -> if l #Float< r then LT else if l #Float== r then EQ else GT
-}
-
-let ord_Char = {
-    eq = eq_Char,
-    compare = \l r -> if l #Char< r then LT else if l #Char== r then EQ else GT
 }
 
 /**
@@ -379,7 +372,6 @@ let show_Int : Show Int = { show = prim.show_int }
 
 let show_Float : Show Float = { show = prim.show_float }
 
-let show_Char : Show Char = { show = prim.show_char }
 
 type Foldable (f : Type -> Type) = {
     foldr : (a -> b -> b) -> b -> f a -> b,
@@ -484,13 +476,11 @@ let make_Traversable traversable : Traversable t -> _ =
     Eq,
     eq_Float,
     eq_Int,
-    eq_Char,
 
     Ord,
     make_Ord,
     ord_Float,
     ord_Int,
-    ord_Char,
 
     Category,
     make_Category,
@@ -530,6 +520,5 @@ let make_Traversable traversable : Traversable t -> _ =
 
     Show,
     show_Int,
-    show_Float,
-    show_Char
+    show_Float
 }

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -1,11 +1,5 @@
 let { Bool, Option, Ordering } = import! "std/types.glu"
 
-/// Boolean 'not'
-let not x : Bool -> Bool = if x then False else True
-
-/// Boolean 'exclusive or'
-let xor x y : Bool -> Bool -> Bool = if x then not y else y
-
 /// `Semigroup a` represents an associative operation on `a`.
 /// This means the following laws must hold:
 ///
@@ -35,12 +29,6 @@ let semigroup_Int_Mul : Semigroup Int = { append = \x y -> x #Int* y }
 let semigroup_Float_Add : Semigroup Float = { append = \x y -> x #Float+ y }
 
 let semigroup_Float_Mul : Semigroup Float = { append = \x y -> x #Float* y }
-
-let semigroup_Bool_And : Semigroup Bool = { append = \x y -> x && y }
-
-let semigroup_Bool_Or : Semigroup Bool = { append = \x y -> x || y }
-
-let semigroup_Bool_Xor : Semigroup Bool = { append = xor }
 
 let semigroup_Ordering : Semigroup Ordering = {
     append = \x y ->
@@ -87,21 +75,6 @@ let monoid_Float_Mul : Monoid Float = {
     empty = 1.0
 }
 
-let monoid_Bool_And : Monoid Bool = {
-    semigroup = semigroup_Bool_And,
-    empty = True
-}
-
-let monoid_Bool_Or : Monoid Bool = {
-    semigroup = semigroup_Bool_Or,
-    empty = False
-}
-
-let monoid_Bool_Xor : Monoid Bool = {
-    semigroup = semigroup_Bool_Xor,
-    empty = False
-}
-
 let monoid_Ordering : Monoid Ordering = {
     semigroup = semigroup_Ordering,
     empty = EQ
@@ -132,17 +105,10 @@ let group_Float_Mul : Group Float = {
     inverse = \x -> 1.0 #Float/ x
 }
 
-let group_Bool_Xor : Group Bool = {
-    monoid = monoid_Bool_Xor,
-    inverse = \x -> x
-}
-
 /// `Eq a` defines equality (==) on `a`
 type Eq a = { (==) : a -> a -> Bool }
 
 let eq_Unit : Eq () = { (==) = \l r -> True }
-
-let eq_Bool : Eq Bool = { (==) = \l r -> if l then r else not r }
 
 let eq_Int = { (==) = \l r -> l #Int== r }
 
@@ -184,8 +150,6 @@ let make_Ord ord : Ord a -> _ =
     { eq, compare, (<=), (<), (>), (>=) }
 
 let ord_Unit = { eq = eq_Unit, compare = \l r -> EQ }
-
-let ord_Bool = { eq = eq_Bool, compare = \l r -> if l then if r then EQ else GT else LT }
 
 let ord_Int = {
     eq = eq_Int,
@@ -415,8 +379,6 @@ type Show a = { show : a -> String }
 
 let show_Unit : Show () = { show = const "()" }
 
-let show_Bool : Show Bool = { show = \x -> if x then "True" else "False" }
-
 let show_Int : Show Int = { show = prim.show_int }
 
 let show_Float : Show Float = { show = prim.show_float }
@@ -466,9 +428,6 @@ let make_Foldable foldable : Foldable t -> _ =
     let elem eq : Eq a -> a -> t a -> Bool =
         any << eq.(==)
 
-    let notElem eq x : Eq a -> a -> t a -> Bool =
-        not << elem eq x
-
     let count : t a -> Int =
         foldl (\acc _ -> acc + 1) 0
 
@@ -483,7 +442,6 @@ let make_Foldable foldable : Foldable t -> _ =
         all,
         any,
         elem,
-        notElem,
         count
     }
 
@@ -503,11 +461,7 @@ let make_Traversable traversable : Traversable t -> _ =
     { functor, foldable, traverse, sequence, for }
 
 {
-    Bool,
     Ordering,
-
-    not,
-    xor,
 
     Semigroup,
     make_Semigroup,
@@ -516,9 +470,6 @@ let make_Traversable traversable : Traversable t -> _ =
     semigroup_Int_Mul,
     semigroup_Float_Add,
     semigroup_Float_Mul,
-    semigroup_Bool_And,
-    semigroup_Bool_Or,
-    semigroup_Bool_Xor,
     semigroup_Ordering,
 
     Monoid,
@@ -527,20 +478,15 @@ let make_Traversable traversable : Traversable t -> _ =
     monoid_Int_Mul,
     monoid_Float_Add,
     monoid_Float_Mul,
-    monoid_Bool_And,
-    monoid_Bool_Or,
-    monoid_Bool_Xor,
     monoid_Ordering,
 
     Group,
     group_Int_Add,
     group_Float_Add,
     group_Float_Mul,
-    group_Bool_Xor,
 
     Eq,
     eq_Unit,
-    eq_Bool,
     eq_Float,
     eq_Int,
     eq_Char,
@@ -548,7 +494,6 @@ let make_Traversable traversable : Traversable t -> _ =
     Ord,
     make_Ord,
     ord_Unit,
-    ord_Bool,
     ord_Float,
     ord_Int,
     ord_Char,
@@ -591,7 +536,6 @@ let make_Traversable traversable : Traversable t -> _ =
 
     Show,
     show_Unit,
-    show_Bool,
     show_Int,
     show_Float,
     show_Char

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -1,10 +1,5 @@
 let { Bool, Option, Ordering } = import! "std/types.glu"
 
-let unwrap opt : Option a -> a =
-    match opt with
-    | Some x -> x
-    | None -> error "Option was None"
-
 /// Boolean 'not'
 let not x : Bool -> Bool = if x then False else True
 
@@ -31,29 +26,6 @@ let make_Semigroup semigroup : Semigroup a -> _ =
 
 let semigroup_Function semigroup : Semigroup b -> Semigroup (a -> b) = {
     append = \f g x -> semigroup.append (f x) (g x)
-}
-
-let semigroup_Option semigroup : Semigroup a -> Semigroup (Option a) = {
-    append = \l r ->
-        match (l, r) with
-        | (Some x, Some y) -> Some (semigroup.append x y)
-        | (Some _, None) -> l
-        | (None, Some _) -> r
-        | (None, None) -> None
-}
-
-let semigroup_Option_First : Semigroup (Option a) = {
-    append = \l r ->
-        match l with
-        | Some x -> Some x
-        | None -> r
-}
-
-let semigroup_Option_Last : Semigroup (Option a) = {
-    append = \l r ->
-        match r with
-        | Some x -> Some x
-        | None -> l
 }
 
 let semigroup_Int_Add : Semigroup Int = { append = \x y -> x #Int+ y }
@@ -93,21 +65,6 @@ type Monoid a = {
 let monoid_Function monoid : Monoid b -> Monoid (a -> b) = {
     semigroup = semigroup_Function monoid.semigroup,
     empty = \_ -> monoid.empty
-}
-
-let monoid_Option semigroup : Semigroup a -> Monoid (Option a) = {
-    semigroup = semigroup_Option semigroup,
-    empty = None
-}
-
-let monoid_Option_First : Monoid (Option a) = {
-    semigroup = semigroup_Option_First,
-    empty = None
-}
-
-let monoid_Option_Last : Monoid (Option a) = {
-    semigroup = semigroup_Option_Last,
-    empty = None
 }
 
 let monoid_Int_Add : Monoid Int = {
@@ -193,14 +150,6 @@ let eq_Float = { (==) = \l r -> l #Float== r }
 
 let eq_Char = { (==) = \l r -> l #Char== r }
 
-let eq_Option a : Eq a -> Eq (Option a) = {
-    (==) = \l r ->
-        match (l, r) with
-        | (Some l_val, Some r_val) -> a.(==) l_val r_val
-        | (None, None) -> True
-        | _ -> False
-}
-
 /// `Ord a` defines an ordering on `a`
 type Ord a = { eq : Eq a, compare : a -> a -> Ordering }
 
@@ -251,16 +200,6 @@ let ord_Float = {
 let ord_Char = {
     eq = eq_Char,
     compare = \l r -> if l #Char< r then LT else if l #Char== r then EQ else GT
-}
-
-let ord_Option a : Ord a -> Ord (Option a) = {
-    eq = eq_Option a.eq,
-    compare = \l r ->
-        match (l, r) with
-        | (Some l_val, Some r_val) -> a.compare l_val r_val
-        | (None, Some _) -> LT
-        | (Some _, None) -> GT
-        | (None, None) -> EQ
 }
 
 /**
@@ -345,8 +284,8 @@ type Functor f = {
     ///
     /// # Examples
     ///
-    /// * `applicative_Option.map show_Int.show (Some 1) == Some "1"`
-    /// * `result.applicative.map show_Int.show (Some 1) == Ok "1"`
+    /// * `option.functor.map show_Int.show (Some 1) == Some "1"`
+    /// * `result.functor.map show_Int.show (Some 1) == Ok "1"`
     /// * `list.functor.map show_Int.show (list.of [1, 2]) == list.of ["1", "2"]`
     ///
     /// # Note
@@ -356,13 +295,6 @@ type Functor f = {
 }
 
 let functor_Function : Functor ((->) a) = { map = category_Function.compose }
-
-let functor_Option : Functor Option = {
-    map = \f x ->
-        match x with
-        | Some y -> Some (f y)
-        | None -> None
-}
 
 let functor_IO : Functor IO = { map = \f -> io_flat_map (\x -> io_wrap (f x)) }
 
@@ -378,7 +310,7 @@ type Applicative (f : Type -> Type) = {
     ///
     /// # Examples
     ///
-    /// * `applicative_Option.wrap 1 == Some 1`
+    /// * `option.applicative.wrap 1 == Some 1`
     /// * `result.applicative.wrap 1 == Ok 1`
     /// * `list.applicative.wrap 1 == list.of [1]`
     ///
@@ -409,15 +341,6 @@ let applicative_Function : Applicative ((->) a) = {
     wrap = const
 }
 
-let applicative_Option : Applicative Option = {
-    functor = functor_Option,
-    apply = \f x ->
-        match (f, x) with
-        | (Some g, Some y) -> Some (g y)
-        | _ -> None,
-    wrap = \x -> Some x
-}
-
 let applicative_IO : Applicative IO =
     let wrap = io_wrap
     let apply f x = io_flat_map (\g -> io_flat_map (\y -> wrap (g y)) x) f
@@ -425,15 +348,6 @@ let applicative_IO : Applicative IO =
     { functor = functor_IO, apply, wrap }
 
 type Alternative f = { applicative : Applicative f, or : f a -> f a -> f a, empty : f a }
-
-let alternative_Option : Alternative Option = {
-    applicative = applicative_Option,
-    or = \x y ->
-        match x with
-        | Some _ -> x
-        | None -> y,
-    empty = None
-}
 
 let make_Alternative alternative : Alternative f -> _ =
     let { applicative, or, empty } = alternative
@@ -491,14 +405,6 @@ let monad_Function : Monad ((->) a) = {
     flat_map = \f m x -> f (m x) x
 }
 
-let monad_Option : Monad Option = {
-    applicative = applicative_Option,
-    flat_map = \f m ->
-        match m with
-        | Some x -> f x
-        | None -> None
-}
-
 let monad_IO : Monad IO = {
     applicative = applicative_IO,
     flat_map = io_flat_map
@@ -516,16 +422,6 @@ let show_Int : Show Int = { show = prim.show_int }
 let show_Float : Show Float = { show = prim.show_float }
 
 let show_Char : Show Char = { show = prim.show_char }
-
-let show_Option : Show a -> Show (Option a) = \d ->
-    let (++) = string_prim.append
-
-    let show o =
-        match o with
-        | Some x -> "Some (" ++ d.show x ++ ")"
-        | None -> "None"
-
-    { show }
 
 type Foldable (f : Type -> Type) = {
     foldr : (a -> b -> b) -> b -> f a -> b,
@@ -591,17 +487,6 @@ let make_Foldable foldable : Foldable t -> _ =
         count
     }
 
-let foldable_Option : Foldable Option = {
-    foldr = \f z o ->
-        match o with
-        | None -> z
-        | Some x -> f x z,
-    foldl = \f z o ->
-        match o with
-        | None -> z
-        | Some x -> f z x
-}
-
 type Traversable t = {
     functor : Functor t,
     foldable : Foldable t,
@@ -617,21 +502,9 @@ let make_Traversable traversable : Traversable t -> _ =
 
     { functor, foldable, traverse, sequence, for }
 
-let traversable_Option : Traversable Option = {
-    functor = functor_Option,
-    foldable = foldable_Option,
-    traverse = \app f o ->
-        match o with
-        | None -> app.wrap None
-        | Some x -> app.functor.map Some (f x)
-}
-
 {
     Bool,
     Ordering,
-    Option,
-
-    unwrap,
 
     not,
     xor,
@@ -639,9 +512,6 @@ let traversable_Option : Traversable Option = {
     Semigroup,
     make_Semigroup,
     semigroup_Function,
-    semigroup_Option,
-    semigroup_Option_First,
-    semigroup_Option_Last,
     semigroup_Int_Add,
     semigroup_Int_Mul,
     semigroup_Float_Add,
@@ -653,9 +523,6 @@ let traversable_Option : Traversable Option = {
 
     Monoid,
     monoid_Function,
-    monoid_Option,
-    monoid_Option_First,
-    monoid_Option_Last,
     monoid_Int_Add,
     monoid_Int_Mul,
     monoid_Float_Add,
@@ -674,7 +541,6 @@ let traversable_Option : Traversable Option = {
     Eq,
     eq_Unit,
     eq_Bool,
-    eq_Option,
     eq_Float,
     eq_Int,
     eq_Char,
@@ -683,7 +549,6 @@ let traversable_Option : Traversable Option = {
     make_Ord,
     ord_Unit,
     ord_Bool,
-    ord_Option,
     ord_Float,
     ord_Int,
     ord_Char,
@@ -693,30 +558,24 @@ let traversable_Option : Traversable Option = {
     category_Function,
 
     Functor,
-    functor_Option,
     functor_IO,
 
     Applicative,
     make_Applicative,
-    applicative_Option,
     applicative_IO,
 
     Alternative,
     make_Alternative,
-    alternative_Option,
 
     Monad,
     make_Monad,
-    monad_Option,
     monad_IO,
 
     Foldable,
     make_Foldable,
-    foldable_Option,
 
     Traversable,
     make_Traversable,
-    traversable_Option,
 
     Num,
     num_Int,
@@ -735,6 +594,5 @@ let traversable_Option : Traversable Option = {
     show_Bool,
     show_Int,
     show_Float,
-    show_Char,
-    show_Option
+    show_Char
 }

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -250,8 +250,6 @@ type Functor f = {
 
 let functor_Function : Functor ((->) a) = { map = category_Function.compose }
 
-let functor_IO : Functor IO = { map = \f -> io_flat_map (\x -> io_wrap (f x)) }
-
 type Applicative (f : Type -> Type) = {
     functor : Functor f,
     /// Like `functor.map`, but this time the supplied function is embedded in `f`
@@ -294,12 +292,6 @@ let applicative_Function : Applicative ((->) a) = {
     apply = \f g x -> f x (g x),
     wrap = const
 }
-
-let applicative_IO : Applicative IO =
-    let wrap = io_wrap
-    let apply f x = io_flat_map (\g -> io_flat_map (\y -> wrap (g y)) x) f
-
-    { functor = functor_IO, apply, wrap }
 
 type Alternative f = { applicative : Applicative f, or : f a -> f a -> f a, empty : f a }
 
@@ -357,11 +349,6 @@ let make_Monad monad : Monad m -> _ =
 let monad_Function : Monad ((->) a) = {
     applicative = applicative_Function,
     flat_map = \f m x -> f (m x) x
-}
-
-let monad_IO : Monad IO = {
-    applicative = applicative_IO,
-    flat_map = io_flat_map
 }
 
 /// `Show a` represents a conversion function from `a` to a readable string.
@@ -487,18 +474,15 @@ let make_Traversable traversable : Traversable t -> _ =
     category_Function,
 
     Functor,
-    functor_IO,
 
     Applicative,
     make_Applicative,
-    applicative_IO,
 
     Alternative,
     make_Alternative,
 
     Monad,
     make_Monad,
-    monad_IO,
 
     Foldable,
     make_Foldable,

--- a/std/result.glu
+++ b/std/result.glu
@@ -1,0 +1,101 @@
+let prelude = import! "std/prelude.glu"
+let { Eq, Ord, Ordering, Show } = prelude
+let { Functor, Applicative, Monad, Foldable, Traversable } = prelude
+let { Result } = import! "std/types.glu"
+
+let unwrap_ok res : Result e a -> a =
+    match res with
+    | Ok x -> x
+    | Err _ -> error "Result was an Err"
+
+let unwrap_err res : Result e a -> e =
+    match res with
+    | Ok _ -> error "Result was an Ok"
+    | Err x -> x
+
+let eq e a : Eq e -> Eq a -> Eq (Result e a) = {
+    (==) = \l r ->
+        match (l, r) with
+        | (Ok l_val, Ok r_val) -> a.(==) l_val r_val
+        | (Err l_val, Err r_val) -> e.(==) l_val r_val
+        | _ -> False
+}
+
+let ord e a : Ord e -> Ord a -> Ord (Result e a) = {
+    eq = eq e.eq a.eq,
+    compare = \l r ->
+        match (l, r) with
+        | (Ok l_val, Ok r_val) -> a.compare l_val r_val
+        | (Err l_val, Err r_val) -> e.compare l_val r_val
+        | (Ok _, Err _) -> LT
+        | (Err _, Ok _) -> GT
+}
+
+let functor : Functor (Result e) = {
+    map = \f x ->
+        match x with
+        | Ok y -> Ok (f y)
+        | Err _ -> x
+}
+
+let applicative : Applicative (Result e) = {
+    functor = functor,
+    apply = \f x ->
+        match (f, x) with
+        | (Ok g, Ok y) -> Ok (g y)
+        | (Ok _, Err _) -> x
+        | (Err x, _) -> Err x,
+    wrap = \x -> Ok x
+}
+
+let monad : Monad (Result e) = {
+    applicative = applicative,
+    flat_map = \f m ->
+        match m with
+        | Ok x -> f x
+        | Err err -> Err err
+}
+
+let foldable : Foldable (Result e) = {
+    foldr = \f z r ->
+        match r with
+        | Err _ -> z
+        | Ok x -> f x z,
+    foldl = \f z r ->
+        match r with
+        | Err _ -> z
+        | Ok x -> f z x
+}
+
+let traversable : Traversable (Result e) = {
+    functor = functor,
+    foldable = foldable,
+    traverse = \app f r ->
+        match r with
+        | Err e -> app.wrap (Err e)
+        | Ok x -> app.functor.map Ok (f x)
+}
+
+let show : Show e -> Show t -> Show (Result e t) = \e t ->
+    let (++) = string_prim.append
+
+    let show o =
+        match o with
+        | Ok x -> "Ok (" ++ t.show x ++ ")"
+        | Err x -> "Err (" ++ e.show x ++ ")"
+
+    { show }
+
+{
+    Result,
+    unwrap_ok,
+    unwrap_err,
+    eq,
+    ord,
+    functor,
+    applicative,
+    monad,
+    foldable,
+    traversable,
+    show
+}

--- a/std/result.glu
+++ b/std/result.glu
@@ -2,6 +2,7 @@ let prelude = import! "std/prelude.glu"
 let { Eq, Ord, Ordering, Show } = prelude
 let { Functor, Applicative, Monad, Foldable, Traversable } = prelude
 let { Result } = import! "std/types.glu"
+let { Bool } = import! "std/bool.glu"
 
 let unwrap_ok res : Result e a -> a =
     match res with

--- a/std/stream.glu
+++ b/std/stream.glu
@@ -1,8 +1,9 @@
 let prelude = import! "std/prelude.glu"
-and { Option, Num, Functor, Applicative } = prelude
+and { Num, Functor, Applicative } = prelude
 and { (+) } = prelude.num_Int
 let list = import! "std/list.glu"
 let { List } = list
+let { Option } = import! "std/option.glu"
 
 type Stream_ a = | Value a (Stream a) | Empty
 and Stream a = Lazy (Stream_ a)

--- a/std/stream.glu
+++ b/std/stream.glu
@@ -2,6 +2,7 @@ let prelude = import! "std/prelude.glu"
 and { Num, Functor, Applicative } = prelude
 and { (+) } = prelude.num_Int
 let list = import! "std/list.glu"
+let { Bool } = import! "std/bool.glu"
 let { List } = list
 let { Option } = import! "std/option.glu"
 

--- a/std/string.glu
+++ b/std/string.glu
@@ -1,5 +1,5 @@
 let prelude = import! "std/prelude.glu"
-let { Num, Option, Eq, Ord, Ordering, Semigroup, Monoid, Show } = prelude
+let { Num, Eq, Ord, Ordering, Semigroup, Monoid, Show } = prelude
 
 let semigroup : Semigroup String = { append = string_prim.append }
 

--- a/std/test.glu
+++ b/std/test.glu
@@ -1,13 +1,14 @@
 let string = import! "std/string.glu"
 and { Writer, make = make_Writer, tell } = import! "std/writer.glu"
 and prelude = import! "std/prelude.glu"
-and { Show, Num, Eq, Option, Applicative, Monad, Monoid } = prelude
+and { Show, Num, Eq, Applicative, Monad, Monoid } = prelude
 and { (+) } = prelude.num_Int
 and { (==) } = prelude.eq_Int
 and { (<) } = prelude.make_Ord prelude.ord_Int
 let list = import! "std/list.glu"
 let { List } = list
 and { foldl } = list.foldable
+let { Option } = import! "std/option.glu"
 
 let (++) = string.semigroup.append
 

--- a/std/unit.glu
+++ b/std/unit.glu
@@ -1,0 +1,14 @@
+let { Eq, Ord, Ordering, Show, const } = import! "std/prelude.glu"
+let { Bool } = import! "std/bool.glu"
+
+let eq : Eq () = { (==) = const (const True) }
+
+let ord : Ord () = { eq = eq, compare = const (const EQ) }
+
+let show : Show () = { show = const "()" }
+
+{
+    eq,
+    ord,
+    show
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -207,8 +207,8 @@ fn io_future() {
     }
 
     let expr = r#"
-    let { applicative_IO, monad_IO }  = import! "std/prelude.glu"
-    monad_IO.flat_map (\x -> applicative_IO.wrap (x + 1)) (test ())
+    let { applicative, monad }  = import! "std/io.glu"
+    monad.flat_map (\x -> applicative.wrap (x + 1)) (test ())
 "#;
 
     let vm = make_vm();

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -18,7 +18,11 @@ fn bool() {
 
     let thread = new_vm();
     let (De(b), _) = Compiler::new()
-        .run_expr::<De<bool>>(&thread, "test", "True")
+        .run_expr::<De<bool>>(
+            &thread,
+            "test",
+            r#"let { Bool } = import! "std/bool.glu" in True"#,
+        )
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(b, true);
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -56,7 +56,11 @@ fn option() {
 
     let thread = new_vm();
     let (De(opt), _) = Compiler::new()
-        .run_expr::<De<Option<f64>>>(&thread, "test", r#" Some 1.0 "#)
+        .run_expr::<De<Option<f64>>>(
+            &thread,
+            "test",
+            r#"let { Option } = import! "std/option.glu" in Some 1.0 "#,
+        )
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(opt, Some(1.0));
 }
@@ -120,7 +124,11 @@ fn optional_field() {
     );
 
     let (value, _) = Compiler::new()
-        .run_expr::<OpaqueValue<&Thread, Hole>>(&thread, "test", r#" { test = Some 2 } "#)
+        .run_expr::<OpaqueValue<&Thread, Hole>>(
+            &thread,
+            "test",
+            r#"let { Option } = import! "std/option.glu" in { test = Some 2 } "#,
+        )
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(
         De::<OptionalFieldRecord>::from_value(&thread, value.get_variants()).map(|x| x.0),

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -178,13 +178,15 @@ fn implicit_prelude_lines_not_counted() {
     let thread = new_vm();
     {
         let mut context = thread.context();
-        context.set_hook(Some(Box::new(move |_, debug_info| {
-            if debug_info.stack_info(0).unwrap().source_name() == "test" {
+        context.set_hook(Some(Box::new(
+            move |_, debug_info| if debug_info.stack_info(0).unwrap().source_name() ==
+                "test"
+            {
                 Ok(Async::NotReady)
             } else {
                 Ok(Async::Ready(()))
-            }
-        })));
+            },
+        )));
         context.set_hook_mask(LINE_FLAG);
     }
     let mut execute = Compiler::new()
@@ -336,7 +338,7 @@ fn argument_types() {
                 vec![
                     ("int_function".to_string(), int_function.clone()),
                     ("g".to_string(), int_function.clone()),
-                ],
+                ]
             ),
             (
                 4,
@@ -344,7 +346,7 @@ fn argument_types() {
                     ("int_function".to_string(), int_function.clone()),
                     ("g".to_string(), int_function.clone()),
                     ("f".to_string(), int_function.clone()),
-                ],
+                ]
             ),
             (3, vec![("z".to_string(), Type::int())]),
             (2, vec![("y".to_string(), Type::int())]),
@@ -474,14 +476,9 @@ fn implicit_prelude_variable_names() {
     let f = functions.lock().unwrap();
     match *f[0] {
         Type::Record(ref row) => {
-            assert!(
-                row.row_iter()
-                    .any(|field| field.name.declared_name() == "id")
-            );
-            assert!(
-                row.row_iter()
-                    .any(|field| field.name.declared_name() == "not")
-            );
+            assert!(row.row_iter().any(
+                |field| field.name.declared_name() == "id",
+            ));
         }
         _ => panic!(),
     }

--- a/tests/fail/unwrap.glu
+++ b/tests/fail/unwrap.glu
@@ -1,3 +1,3 @@
-let { Option, unwrap }  = import! "std/prelude.glu"
+let { Option, unwrap }  = import! "std/option.glu"
 
 unwrap None

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -13,8 +13,9 @@ fn read_file() {
     let text = r#"
         let prelude  = import! "std/prelude.glu"
         let { assert }  = import! "std/test.glu"
-        let { wrap } = prelude.applicative_IO
-        let { (>>=) } = prelude.make_Monad prelude.monad_IO
+        let io = import! "std/io.glu"
+        let { wrap } = io.applicative
+        let { (>>=) } = prelude.make_Monad io.monad
 
         io.open_file "Cargo.toml" >>= \file ->
             io.read_file file 9 >>= \bytes ->

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -50,6 +50,8 @@ fn parallel_() -> Result<(), Error> {
     let handle2 = spawn(move || -> Result<(), Error> {
         let expr = r#"
         let { assert }  = import! "std/test.glu"
+        let { Result }  = import! "std/result.glu"
+
         let f receiver =
             match recv receiver with
             | Ok x -> assert (x == 1)
@@ -57,6 +59,7 @@ fn parallel_() -> Result<(), Error> {
             match recv receiver with
             | Ok x -> assert (x == 2)
             | Err _ -> assert False
+
         f
         "#;
         let mut compiler = Compiler::new();

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -50,6 +50,7 @@ fn parallel_() -> Result<(), Error> {
     let handle2 = spawn(move || -> Result<(), Error> {
         let expr = r#"
         let { assert }  = import! "std/test.glu"
+        let { Bool } = import! "std/bool.glu"
         let { Result }  = import! "std/result.glu"
 
         let f receiver =

--- a/tests/pass/alternative.glu
+++ b/tests/pass/alternative.glu
@@ -1,7 +1,8 @@
 let { run, writer, assert_eq }  = import! "std/test.glu"
 let prelude  = import! "std/prelude.glu"
 let { (*>) } = prelude.make_Applicative writer.applicative
-let list  = import! "std/list.glu"
+let list = import! "std/list.glu"
+let option = import! "std/option.glu"
 
 let test_alt show eq alt =
     let { (<|>), or, empty } = prelude.make_Alternative alt
@@ -15,5 +16,5 @@ let test_alt show eq alt =
         *> assert (empty <|> empty) empty
         *> assert (empty <|> empty <|> wrap 10) (wrap 10)
 
-test_alt prelude.show_Option prelude.eq_Option prelude.alternative_Option
+test_alt option.show option.eq option.alternative
     *> test_alt list.show list.eq list.alternative

--- a/tests/pass/channel.glu
+++ b/tests/pass/channel.glu
@@ -3,10 +3,11 @@ let prelude  = import! "std/prelude.glu"
 let { (*>) } = prelude.make_Applicative writer.applicative
 let result = import! "std/result.glu"
 let { Result } = result
+let unit = import! "std/unit.glu"
 
 let assert =
-    assert_eq (result.show prelude.show_Unit prelude.show_Int )
-              (result.eq prelude.eq_Unit prelude.eq_Int)
+    assert_eq (result.show unit.show prelude.show_Int )
+              (result.eq unit.eq prelude.eq_Int)
 
 let { sender, receiver } = channel 0
 

--- a/tests/pass/channel.glu
+++ b/tests/pass/channel.glu
@@ -1,10 +1,12 @@
 let { run, writer, assert_eq }  = import! "std/test.glu"
 let prelude  = import! "std/prelude.glu"
 let { (*>) } = prelude.make_Applicative writer.applicative
+let result = import! "std/result.glu"
+let { Result } = result
 
 let assert =
-    assert_eq (prelude.show_Result prelude.show_Unit prelude.show_Int )
-              (prelude.eq_Result prelude.eq_Unit prelude.eq_Int)
+    assert_eq (result.show prelude.show_Unit prelude.show_Int )
+              (result.eq prelude.eq_Unit prelude.eq_Int)
 
 let { sender, receiver } = channel 0
 

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -1,6 +1,7 @@
 let { run, writer, assert, assert_ieq, assert_feq }  = import! "std/test.glu"
 let prelude  = import! "std/prelude.glu"
 let { (*>) } = prelude.make_Applicative writer.applicative
+let { Result } = import! "std/result.glu"
 
 
 let _ =
@@ -12,7 +13,7 @@ let _ =
         force l
         send sender l
         ())
-    
+
     resume thread
 
     match recv receiver with
@@ -29,7 +30,7 @@ let _ =
     let thread = spawn (\_ ->
         send sender (ref 3)
         ())
-        
+
     resume thread
 
     match recv receiver with

--- a/tests/pass/lisp.glu
+++ b/tests/pass/lisp.glu
@@ -5,6 +5,8 @@ let { (*>) } = prelude.make_Applicative writer.applicative
 let list = import! "std/list.glu"
 let { List } = list
 
+let result = import! "std/result.glu"
+let { Result } = result
 let string = import! "std/string.glu"
 let parser = import! "std/parser.glu"
 
@@ -12,7 +14,7 @@ let lisp = import! "examples/lisp/lisp.glu"
 let { Expr } = lisp
 
 let assert_leq =
-    assert_eq (prelude.show_Result string.show lisp.show) (prelude.eq_Result string.eq lisp.eq)
+    assert_eq (result.show string.show lisp.show) (result.eq string.eq lisp.eq)
 
 let parser_tests =
     assert_leq (parser.parse lisp.expr "test") (Ok (Atom "test"))
@@ -35,7 +37,7 @@ let parser_tests =
             (Ok (List (Cons (Atom "test") (Cons (Int 123) Nil))))
         *> assert_leq (parser.parse lisp.expr "123.45") (Ok (Float 123.45))
 
-let { (>>=) } = prelude.make_Monad prelude.monad_Result
+let { (>>=) } = prelude.make_Monad result.monad
 let eval_string s = parser.parse lisp.expr s >>= lisp.eval
 let eval_string_seq s = parser.parse (parser.many lisp.expr) s >>= lisp.eval_seq
 

--- a/tests/pass/lisp.glu
+++ b/tests/pass/lisp.glu
@@ -1,6 +1,5 @@
 let prelude = import! "std/prelude.glu"
 let { Test, run, writer, assert_eq, assert_seq, assert_ieq } = import! "std/test.glu"
-let { Option } = prelude
 let { (*>) } = prelude.make_Applicative writer.applicative
 let list = import! "std/list.glu"
 let { List } = list

--- a/tests/pass/map.glu
+++ b/tests/pass/map.glu
@@ -1,5 +1,7 @@
 let prelude  = import! "std/prelude.glu"
-let { Option, Eq, Show } = prelude
+let { Eq, Show } = prelude
+let option = import! "std/option.glu"
+let { Option } = option
 let string  = import! "std/string.glu"
 let { (==) } = string.eq
 let { (<>) } = prelude.make_Semigroup string.semigroup
@@ -30,8 +32,8 @@ let assert_values =
               (list.eq prelude.eq_Int)
 
 let assert_opt =
-    assert_eq (prelude.show_Option prelude.show_Int)
-              (prelude.eq_Option prelude.eq_Int)
+    assert_eq (option.show prelude.show_Int)
+              (option.eq prelude.eq_Int)
 
 let ord_map = map.make string.ord
 let { singleton, find, insert, to_list, keys, values } = ord_map

--- a/tests/pass/parser.glu
+++ b/tests/pass/parser.glu
@@ -1,4 +1,5 @@
 let prelude = import! "std/prelude.glu"
+let char = import! "std/char.glu"
 let string = import! "std/string.glu"
 let result = import! "std/result.glu"
 let { Result } = result
@@ -15,6 +16,6 @@ let assert_parse show eq =
         (result.eq string.eq eq)
 
 let tests =
-    assert_parse prelude.show_Char prelude.eq_Char (parse any "abc") (Ok 'a')
+    assert_parse char.show char.eq (parse any "abc") (Ok 'a')
 
 run tests

--- a/tests/pass/parser.glu
+++ b/tests/pass/parser.glu
@@ -1,5 +1,7 @@
 let prelude = import! "std/prelude.glu"
-let { show = show_String, eq = eq_String } = import! "std/string.glu"
+let string = import! "std/string.glu"
+let result = import! "std/result.glu"
+let { Result } = result
 let { Test, run, writer, assert, assert_eq } = import! "std/test.glu"
 let { Writer } = import! "std/writer.glu"
 
@@ -9,8 +11,8 @@ let { (<|>) } = prelude.make_Alternative alternative
 
 let assert_parse show eq =
     assert_eq
-        (prelude.show_Result show_String show)
-        (prelude.eq_Result eq_String eq)
+        (result.show string.show show)
+        (result.eq string.eq eq)
 
 let tests =
     assert_parse prelude.show_Char prelude.eq_Char (parse any "abc") (Ok 'a')

--- a/tests/pass/reference.glu
+++ b/tests/pass/reference.glu
@@ -1,6 +1,7 @@
 let { assert }  = import! "std/test.glu"
 let prelude  = import! "std/prelude.glu"
 let { (==) } = prelude.eq_Int
+let { Bool } = import! "std/bool.glu"
 
 let ri = ref 0
 assert (0 == load ri)

--- a/tests/pass/stream.glu
+++ b/tests/pass/stream.glu
@@ -1,12 +1,13 @@
 let prelude  = import! "std/prelude.glu"
 let { run, writer, assert_eq, assert_ieq }  = import! "std/test.glu"
 let stream  = import! "std/stream.glu"
-let { Ord, Num, Option } = prelude
+let { Ord, Num } = prelude
 let { (<) } = prelude.make_Ord prelude.ord_Int
 let { (+) } = prelude.num_Int
 let { (*>) } = prelude.make_Applicative writer.applicative
 let list = import! "std/list.glu"
 let { List } = list
+let { Option } = import! "std/option.glu"
 
 let s = stream.from (\i -> if i < 5 then Some i else None)
 

--- a/tests/pass/string.glu
+++ b/tests/pass/string.glu
@@ -11,12 +11,11 @@ let { Option } = option
 let string = import! "std/string.glu"
 let result = import! "std/result.glu"
 let { Result } = result
+let unit = import! "std/unit.glu"
 
 let assert_oieq = assert_eq (option.show prelude.show_Int) (option.eq prelude.eq_Int)
 let assert_beq = assert_eq bool.show bool.eq
-let assert_req =
-    assert_eq (result.show prelude.show_Unit string.show)
-              (result.eq prelude.eq_Unit string.eq)
+let assert_req = assert_eq (result.show unit.show string.show) (result.eq unit.eq string.eq)
 
 let slice_tests =
     assert_seq (string.slice "ab" 0 1) "a"

--- a/tests/pass/string.glu
+++ b/tests/pass/string.glu
@@ -4,6 +4,8 @@ let { (<) } = prelude.make_Ord prelude.ord_Int
 let { (+) } = prelude.num_Int
 let { (*>) } = prelude.make_Applicative writer.applicative
 
+let bool = import! "std/bool.glu"
+let { Bool } = bool
 let option = import! "std/option.glu"
 let { Option } = option
 let string = import! "std/string.glu"
@@ -11,7 +13,7 @@ let result = import! "std/result.glu"
 let { Result } = result
 
 let assert_oieq = assert_eq (option.show prelude.show_Int) (option.eq prelude.eq_Int)
-let assert_beq = assert_eq prelude.show_Bool prelude.eq_Bool
+let assert_beq = assert_eq bool.show bool.eq
 let assert_req =
     assert_eq (result.show prelude.show_Unit string.show)
               (result.eq prelude.eq_Unit string.eq)

--- a/tests/pass/string.glu
+++ b/tests/pass/string.glu
@@ -1,15 +1,16 @@
 let prelude  = import! "std/prelude.glu"
 let { run, writer, assert_eq, assert_seq, assert_ieq }  = import! "std/test.glu"
-let { Option } = prelude
 let { (<) } = prelude.make_Ord prelude.ord_Int
 let { (+) } = prelude.num_Int
 let { (*>) } = prelude.make_Applicative writer.applicative
 
+let option = import! "std/option.glu"
+let { Option } = option
 let string = import! "std/string.glu"
 let result = import! "std/result.glu"
 let { Result } = result
 
-let assert_oieq = assert_eq (prelude.show_Option prelude.show_Int) (prelude.eq_Option prelude.eq_Int)
+let assert_oieq = assert_eq (option.show prelude.show_Int) (option.eq prelude.eq_Int)
 let assert_beq = assert_eq prelude.show_Bool prelude.eq_Bool
 let assert_req =
     assert_eq (result.show prelude.show_Unit string.show)

--- a/tests/pass/string.glu
+++ b/tests/pass/string.glu
@@ -5,13 +5,15 @@ let { (<) } = prelude.make_Ord prelude.ord_Int
 let { (+) } = prelude.num_Int
 let { (*>) } = prelude.make_Applicative writer.applicative
 
-let string  = import! "std/string.glu"
+let string = import! "std/string.glu"
+let result = import! "std/result.glu"
+let { Result } = result
 
 let assert_oieq = assert_eq (prelude.show_Option prelude.show_Int) (prelude.eq_Option prelude.eq_Int)
 let assert_beq = assert_eq prelude.show_Bool prelude.eq_Bool
 let assert_req =
-    assert_eq (prelude.show_Result prelude.show_Unit string.show)
-              (prelude.eq_Result prelude.eq_Unit string.eq)
+    assert_eq (result.show prelude.show_Unit string.show)
+              (result.eq prelude.eq_Unit string.eq)
 
 let slice_tests =
     assert_seq (string.slice "ab" 0 1) "a"

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -3,16 +3,17 @@ let prelude  = import! "std/prelude.glu"
 let { Bool } = import! "std/bool.glu"
 let result = import! "std/result.glu"
 let { Result } = result
-let string  = import! "std/string.glu"
+let string = import! "std/string.glu"
+let unit = import! "std/unit.glu"
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { (>>=) } = prelude.make_Monad writer.monad
 
 let assert =
-    assert_eq (result.show prelude.show_Unit prelude.show_Int)
-              (result.eq prelude.eq_Unit prelude.eq_Int)
+    assert_eq (result.show unit.show prelude.show_Int)
+              (result.eq unit.eq prelude.eq_Int)
 let assert_any_err =
-    assert_eq (result.show string.show prelude.show_Unit)
-              (result.eq { (==) = \x y -> True } prelude.eq_Unit)
+    assert_eq (result.show string.show unit.show)
+              (result.eq { (==) = \x y -> True } unit.eq)
 
 let { sender, receiver } = channel 0
 

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -1,15 +1,17 @@
 let { run, writer, assert_eq }  = import! "std/test.glu"
 let prelude  = import! "std/prelude.glu"
+let result = import! "std/result.glu"
+let { Result } = result
 let string  = import! "std/string.glu"
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { (>>=) } = prelude.make_Monad writer.monad
 
 let assert =
-    assert_eq (prelude.show_Result prelude.show_Unit prelude.show_Int)
-              (prelude.eq_Result prelude.eq_Unit prelude.eq_Int)
+    assert_eq (result.show prelude.show_Unit prelude.show_Int)
+              (result.eq prelude.eq_Unit prelude.eq_Int)
 let assert_any_err =
-    assert_eq (prelude.show_Result string.show prelude.show_Unit)
-              (prelude.eq_Result { (==) = \x y -> True } prelude.eq_Unit)
+    assert_eq (result.show string.show prelude.show_Unit)
+              (result.eq { (==) = \x y -> True } prelude.eq_Unit)
 
 let { sender, receiver } = channel 0
 

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -1,5 +1,6 @@
 let { run, writer, assert_eq }  = import! "std/test.glu"
 let prelude  = import! "std/prelude.glu"
+let { Bool } = import! "std/bool.glu"
 let result = import! "std/result.glu"
 let { Result } = result
 let string  = import! "std/string.glu"

--- a/tests/pass/unwrap.glu
+++ b/tests/pass/unwrap.glu
@@ -1,6 +1,5 @@
-let {
-    Option, Result, unwrap, unwrap_ok, unwrap_err, (|>)
-}  = import! "std/prelude.glu"
+let { Option, unwrap, (|>) } = import! "std/prelude.glu"
+let { Result, unwrap_ok, unwrap_err } = import! "std/result.glu"
 let { assert_ieq }  = import! "std/test.glu"
 
 let one = Some 1 |> unwrap

--- a/tests/pass/unwrap.glu
+++ b/tests/pass/unwrap.glu
@@ -1,4 +1,5 @@
-let { Option, unwrap, (|>) } = import! "std/prelude.glu"
+let { (|>) } = import! "std/prelude.glu"
+let { Option, unwrap } = import! "std/option.glu"
 let { Result, unwrap_ok, unwrap_err } = import! "std/result.glu"
 let { assert_ieq }  = import! "std/test.glu"
 

--- a/tests/regex_bind.rs
+++ b/tests/regex_bind.rs
@@ -11,6 +11,7 @@ fn regex_match() {
     let thread = new_vm();
     let text = r#"
         let { (|>) } = import! "std/prelude.glu"
+        let { not } = import! "std/bool.glu"
         let { unwrap_ok } = import! "std/result.glu"
         let { assert }  = import! "std/test.glu"
 

--- a/tests/regex_bind.rs
+++ b/tests/regex_bind.rs
@@ -10,7 +10,8 @@ fn regex_match() {
 
     let thread = new_vm();
     let text = r#"
-        let { unwrap_ok, (|>) }  = import! "std/prelude.glu"
+        let { (|>) } = import! "std/prelude.glu"
+        let { unwrap_ok } = import! "std/result.glu"
         let { assert }  = import! "std/test.glu"
 
         let match_a = regex.new "a" |> unwrap_ok
@@ -32,7 +33,8 @@ fn regex_error() {
 
     let thread = new_vm();
     let text = r#"
-        let { unwrap_err, (|>) }  = import! "std/prelude.glu"
+        let { (|>) } = import! "std/prelude.glu"
+        let { unwrap_err } = import! "std/result.glu"
 
         regex.new ")" |> unwrap_err |> regex.error_to_string
         "#;

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -309,6 +309,7 @@ Value::Tag(0)
 
 test_expr!{ prelude match_on_bool,
 r#"
+let { Bool } = import! "std/bool.glu"
 match True with
 | False -> 10
 | True -> 11
@@ -474,6 +475,7 @@ true
 
 test_expr!{ prelude true_branch_not_affected_by_false_branch,
 r#"
+let { Bool } = import! "std/bool.glu"
 if True then
     let x = 1
     x
@@ -509,6 +511,7 @@ id (match Test 0 with
 
 test_expr!{ prelude and_operator_stack,
 r#"
+let { Bool } = import! "std/bool.glu"
 let b = True && True
 let b2 = False
 b
@@ -518,6 +521,7 @@ true
 
 test_expr!{ prelude or_operator_stack,
 r#"
+let { Bool } = import! "std/bool.glu"
 let b = False || True
 let b2 = False
 b

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -687,7 +687,7 @@ in Cons 1 Nil == Nil
 #[test]
 fn test_implicit_prelude() {
     let _ = ::env_logger::init();
-    let text = r#"Ok (Some (1.0 + 3.0 - 2.0)) "#;
+    let text = r#"Some (1.0 + 3.0 - 2.0)"#;
     let mut vm = make_vm();
     Compiler::new()
         .run_expr_async::<OpaqueValue<&Thread, Hole>>(&mut vm, "<top>", text)
@@ -762,9 +762,10 @@ fn access_types_by_path() {
 
     let vm = make_vm();
     run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! "std/prelude.glu" "#);
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! "std/result.glu" "#);
 
     assert!(vm.find_type_info("std.prelude.Option").is_ok());
-    assert!(vm.find_type_info("std.prelude.Result").is_ok());
+    assert!(vm.find_type_info("std.result.Result").is_ok());
 
     let text = r#" type T a = | T a in { x = 0, inner = { T, y = 1.0 } } "#;
     load_script(&vm, "test", text).unwrap_or_else(|err| panic!("{}", err));

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -263,6 +263,7 @@ let f a b c = c
 
 test_expr!{ no_io_eval,
 r#"
+let io = import! "std/io.glu"
 let x = io_flat_map (\x -> error "NOOOOOOOO") (io.println "1")
 in { x }
 "#
@@ -414,7 +415,10 @@ r#"let x = string_prim.len "test" in x"#,
 }
 
 test_expr!{ io_print,
-r#"io.print "123" "#
+r#"
+let io = import! "std/io.glu"
+io.print "123"
+"#
 }
 
 test_expr!{ array,
@@ -647,7 +651,10 @@ in id 1
 fn run_expr_int() {
     let _ = ::env_logger::init();
 
-    let text = r#"io.run_expr "123" "#;
+    let text = r#"
+        let io = import! "std/io.glu"
+        io.run_expr "123"
+    "#;
     let mut vm = make_vm();
     let (result, _) = Compiler::new()
         .run_io_expr_async::<IO<String>>(&mut vm, "<top>", text)
@@ -663,7 +670,14 @@ fn run_expr_int() {
 }
 
 test_expr!{ io run_expr_io,
-r#"io_flat_map (\x -> io_wrap 100) (io.run_expr "io.print \"123\" ") "#,
+r#"
+let io = import! "std/io.glu"
+io_flat_map (\x -> io_wrap 100)
+            (io.run_expr "
+                let io = import! \"std/io.glu\"
+                io.print \"123\"
+            ")
+"#,
 100i32
 }
 
@@ -822,7 +836,8 @@ fn dont_execute_io_in_run_expr_async() {
     let vm = make_vm();
     let expr = r#"
 let prelude  = import! "std/prelude.glu"
-let { wrap } = prelude.applicative_IO
+let io = import! "std/io.glu"
+let { wrap } = io.applicative
 wrap 123
 "#;
     let value = Compiler::new()

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -244,7 +244,6 @@ extern "C" fn error(_: &Thread) -> Status {
 #[allow(non_camel_case_types)]
 pub fn load(vm: &Thread) -> Result<()> {
     use std::f64;
-    use std::char;
     type float = f64;
     vm.define_global(
         "float",
@@ -335,20 +334,18 @@ pub fn load(vm: &Thread) -> Result<()> {
         },
     )?;
 
-    {
-        use self::array;
-        vm.define_global(
-            "array",
-            record! {
-                len => primitive!(1 array::len),
-                index => primitive!(2 array::index),
-                append => primitive!(2 array::append)
-            },
-        )?;
-    }
+    use self::array;
+    vm.define_global(
+        "array",
+        record! {
+            len => primitive!(1 array::len),
+            index => primitive!(2 array::index),
+            append => primitive!(2 array::append)
+        },
+    )?;
 
-    type string_prim = str;
     use self::string;
+    type string_prim = str;
     vm.define_global(
         "string_prim",
         record! {
@@ -371,22 +368,26 @@ pub fn load(vm: &Thread) -> Result<()> {
             as_bytes => primitive!(1 string_prim::as_bytes)
         },
     )?;
+
+    use std::char;
+    type char_prim = char;
     vm.define_global(
         "char_prim",
         record! {
-            is_digit => primitive!(2 char::is_digit),
-            to_digit => primitive!(2 char::to_digit),
-            len_utf8 => primitive!(1 char::len_utf8),
-            len_utf16 => primitive!(1 char::len_utf16),
-            is_alphabetic => primitive!(1 char::is_alphabetic),
-            is_lowercase => primitive!(1 char::is_lowercase),
-            is_uppercase => primitive!(1 char::is_uppercase),
-            is_whitespace => primitive!(1 char::is_whitespace),
-            is_alphanumeric => primitive!(1 char::is_alphanumeric),
-            is_control => primitive!(1 char::is_control),
-            is_numeric => primitive!(1 char::is_numeric)
+            is_digit => primitive!(2 char_prim::is_digit),
+            to_digit => primitive!(2 char_prim::to_digit),
+            len_utf8 => primitive!(1 char_prim::len_utf8),
+            len_utf16 => primitive!(1 char_prim::len_utf16),
+            is_alphabetic => primitive!(1 char_prim::is_alphabetic),
+            is_lowercase => primitive!(1 char_prim::is_lowercase),
+            is_uppercase => primitive!(1 char_prim::is_uppercase),
+            is_whitespace => primitive!(1 char_prim::is_whitespace),
+            is_alphanumeric => primitive!(1 char_prim::is_alphanumeric),
+            is_control => primitive!(1 char_prim::is_control),
+            is_numeric => primitive!(1 char_prim::is_numeric)
         },
     )?;
+
     vm.define_global(
         "prim",
         record! {
@@ -403,6 +404,7 @@ pub fn load(vm: &Thread) -> Result<()> {
             prim::error,
         ),
     )?;
+
     vm.define_global(
         "error",
         primitive::<fn(StdString) -> Generic<A>>(

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -168,32 +168,34 @@ mod string {
         let mut context = thread.context();
         let value = StackFrame::current(&mut context.stack)[0];
         match value {
-            Value::Array(array) => match GcStr::from_utf8(array) {
-                Ok(string) => {
-                    let value = Value::String(string);
-                    let result = context.alloc_with(
-                        thread,
-                        Def {
-                            tag: 1,
-                            elems: &[value],
-                        },
-                    );
-                    match result {
-                        Ok(data) => {
-                            context.stack.push(Value::Data(data));
-                            Status::Ok
-                        }
-                        Err(err) => {
-                            let result: RuntimeResult<(), _> = RuntimeResult::Panic(err);
-                            result.status_push(thread, &mut context)
+            Value::Array(array) => {
+                match GcStr::from_utf8(array) {
+                    Ok(string) => {
+                        let value = Value::String(string);
+                        let result = context.alloc_with(
+                            thread,
+                            Def {
+                                tag: 1,
+                                elems: &[value],
+                            },
+                        );
+                        match result {
+                            Ok(data) => {
+                                context.stack.push(Value::Data(data));
+                                Status::Ok
+                            }
+                            Err(err) => {
+                                let result: RuntimeResult<(), _> = RuntimeResult::Panic(err);
+                                result.status_push(thread, &mut context)
+                            }
                         }
                     }
-                }
-                Err(()) => {
+                    Err(()) => {
                     let err: StdResult<&str, ()> = Err(());
                     err.status_push(thread, &mut context)
                 }
-            },
+                }
+            }
             _ => unreachable!(),
         }
     }
@@ -246,102 +248,102 @@ pub fn load(vm: &Thread) -> Result<()> {
     type float = f64;
     vm.define_global(
         "float",
-        record!(
-        digits => f64::DIGITS,
-        epsilon => f64::EPSILON,
-        infinity => f64::INFINITY,
-        mantissa_digits => f64::MANTISSA_DIGITS,
-        max_ => f64::MAX,
-        max_10_exp => f64::MAX_10_EXP,
-        max_exp => f64::MAX_EXP,
-        min_ => f64::MIN,
-        min_10_exp => f64::MIN_10_EXP,
-        min_exp => f64::MIN_EXP,
-        min_positive => f64::MIN_POSITIVE,
-        nan => f64::NAN,
-        neg_infinity => f64::NEG_INFINITY,
-        e => f64::consts::E,
-        pi => f64::consts::PI,
-        radix => f64::RADIX,
-        is_nan => primitive!(1 float::is_nan),
-        is_infinite => primitive!(1 float::is_infinite),
-        is_finite => primitive!(1 float::is_finite),
-        is_normal => primitive!(1 float::is_normal),
-        floor => primitive!(1 float::floor),
-        ceil => primitive!(1 float::ceil),
-        round => primitive!(1 float::round),
-        trunc => primitive!(1 float::trunc),
-        fract => primitive!(1 float::fract),
-        abs => primitive!(1 float::abs),
-        signum => primitive!(1 float::signum),
-        is_sign_positive => primitive!(1 float::is_sign_positive),
-        is_sign_negative => primitive!(1 float::is_sign_negative),
-        mul_add => primitive!(3 float::mul_add),
-        recip => primitive!(1 float::recip),
-        powi => primitive!(2 float::powi),
-        powf => primitive!(2 float::powf),
-        sqrt => primitive!(1 float::sqrt),
-        exp => primitive!(1 float::exp),
-        exp2 => primitive!(1 float::exp2),
-        ln => primitive!(1 float::ln),
-        log2 => primitive!(1 float::log2),
-        log10 => primitive!(1 float::log10),
-        to_degrees => primitive!(1 float::to_degrees),
-        to_radians => primitive!(1 float::to_radians),
-        max => primitive!(2 float::max),
-        min => primitive!(2 float::min),
-        cbrt => primitive!(1 float::cbrt),
-        hypot => primitive!(2 float::hypot),
-        sin => primitive!(1 float::sin),
-        cos => primitive!(1 float::cos),
-        tan => primitive!(1 float::tan),
-        acos => primitive!(1 float::acos),
-        atan => primitive!(1 float::atan),
-        atan2 => primitive!(2 float::atan2),
-        sin_cos => primitive!(1 float::sin_cos),
-        exp_m1 => primitive!(1 float::exp_m1),
-        ln_1p => primitive!(1 float::ln_1p),
-        sinh => primitive!(1 float::sinh),
-        cosh => primitive!(1 float::cosh),
-        tanh => primitive!(1 float::tanh),
-        acosh => primitive!(1 float::acosh),
-        atanh => primitive!(1 float::atanh),
-        parse => named_primitive!(1, "float.parse", parse::<f64>)
-    ),
+        record! {
+            digits => f64::DIGITS,
+            epsilon => f64::EPSILON,
+            infinity => f64::INFINITY,
+            mantissa_digits => f64::MANTISSA_DIGITS,
+            max_ => f64::MAX,
+            max_10_exp => f64::MAX_10_EXP,
+            max_exp => f64::MAX_EXP,
+            min_ => f64::MIN,
+            min_10_exp => f64::MIN_10_EXP,
+            min_exp => f64::MIN_EXP,
+            min_positive => f64::MIN_POSITIVE,
+            nan => f64::NAN,
+            neg_infinity => f64::NEG_INFINITY,
+            e => f64::consts::E,
+            pi => f64::consts::PI,
+            radix => f64::RADIX,
+            is_nan => primitive!(1 float::is_nan),
+            is_infinite => primitive!(1 float::is_infinite),
+            is_finite => primitive!(1 float::is_finite),
+            is_normal => primitive!(1 float::is_normal),
+            floor => primitive!(1 float::floor),
+            ceil => primitive!(1 float::ceil),
+            round => primitive!(1 float::round),
+            trunc => primitive!(1 float::trunc),
+            fract => primitive!(1 float::fract),
+            abs => primitive!(1 float::abs),
+            signum => primitive!(1 float::signum),
+            is_sign_positive => primitive!(1 float::is_sign_positive),
+            is_sign_negative => primitive!(1 float::is_sign_negative),
+            mul_add => primitive!(3 float::mul_add),
+            recip => primitive!(1 float::recip),
+            powi => primitive!(2 float::powi),
+            powf => primitive!(2 float::powf),
+            sqrt => primitive!(1 float::sqrt),
+            exp => primitive!(1 float::exp),
+            exp2 => primitive!(1 float::exp2),
+            ln => primitive!(1 float::ln),
+            log2 => primitive!(1 float::log2),
+            log10 => primitive!(1 float::log10),
+            to_degrees => primitive!(1 float::to_degrees),
+            to_radians => primitive!(1 float::to_radians),
+            max => primitive!(2 float::max),
+            min => primitive!(2 float::min),
+            cbrt => primitive!(1 float::cbrt),
+            hypot => primitive!(2 float::hypot),
+            sin => primitive!(1 float::sin),
+            cos => primitive!(1 float::cos),
+            tan => primitive!(1 float::tan),
+            acos => primitive!(1 float::acos),
+            atan => primitive!(1 float::atan),
+            atan2 => primitive!(2 float::atan2),
+            sin_cos => primitive!(1 float::sin_cos),
+            exp_m1 => primitive!(1 float::exp_m1),
+            ln_1p => primitive!(1 float::ln_1p),
+            sinh => primitive!(1 float::sinh),
+            cosh => primitive!(1 float::cosh),
+            tanh => primitive!(1 float::tanh),
+            acosh => primitive!(1 float::acosh),
+            atanh => primitive!(1 float::atanh),
+            parse => named_primitive!(1, "float.parse", parse::<f64>)
+        },
     )?;
 
     use types::VmInt as int;
     vm.define_global(
         "int",
-        record!(
-        min_value => int::min_value(),
-        max_value => int::max_value(),
-        count_ones => primitive!(1 int::count_ones),
-        rotate_left => primitive!(2 int::rotate_left),
-        rotate_right => primitive!(2 int::rotate_right),
-        swap_bytes => primitive!(1 int::swap_bytes),
-        from_be => primitive!(1 int::from_be),
-        from_le => primitive!(1 int::from_le),
-        to_be => primitive!(1 int::to_be),
-        to_le => primitive!(1 int::to_le),
-        pow => primitive!(2 int::pow),
-        abs => primitive!(1 int::abs),
-        signum => primitive!(1 int::signum),
-        is_positive => primitive!(1 int::is_positive),
-        is_negative => primitive!(1 int::is_negative),
-        parse => named_primitive!(1, "int.parse", parse::<VmInt>)
-    ),
+        record! {
+            min_value => int::min_value(),
+            max_value => int::max_value(),
+            count_ones => primitive!(1 int::count_ones),
+            rotate_left => primitive!(2 int::rotate_left),
+            rotate_right => primitive!(2 int::rotate_right),
+            swap_bytes => primitive!(1 int::swap_bytes),
+            from_be => primitive!(1 int::from_be),
+            from_le => primitive!(1 int::from_le),
+            to_be => primitive!(1 int::to_be),
+            to_le => primitive!(1 int::to_le),
+            pow => primitive!(2 int::pow),
+            abs => primitive!(1 int::abs),
+            signum => primitive!(1 int::signum),
+            is_positive => primitive!(1 int::is_positive),
+            is_negative => primitive!(1 int::is_negative),
+            parse => named_primitive!(1, "int.parse", parse::<VmInt>)
+        },
     )?;
 
     {
         use self::array;
         vm.define_global(
             "array",
-            record!(
-            len => primitive!(1 array::len),
-            index => primitive!(2 array::index),
-            append => primitive!(2 array::append)
-        ),
+            record! {
+                len => primitive!(1 array::len),
+                index => primitive!(2 array::index),
+                append => primitive!(2 array::append)
+            },
         )?;
     }
 
@@ -349,61 +351,64 @@ pub fn load(vm: &Thread) -> Result<()> {
     use self::string;
     vm.define_global(
         "string_prim",
-        record!(
-        len => primitive!(1 string_prim::len),
-        is_empty => primitive!(1 string_prim::is_empty),
-        split_at => primitive!(2 string_prim::split_at),
-        find => named_primitive!(2, "string_prim.find", string_prim::find::<&str>),
-        rfind => named_primitive!(2, "string_prim.rfind", string_prim::rfind::<&str>),
-        starts_with =>
-            named_primitive!(2, "string_prim.starts_with", string_prim::starts_with::<&str>),
-        ends_with => named_primitive!(2, "string_prim.ends_with", string_prim::ends_with::<&str>),
-        trim => primitive!(1 string_prim::trim),
-        trim_left => primitive!(1 string_prim::trim_left),
-        trim_right => primitive!(1 string_prim::trim_right),
-        compare => named_primitive!(2, "string_prim.compare", string_prim::cmp),
-        append => named_primitive!(2, "string_prim.append", string::append),
-        eq => named_primitive!(2, "string_prim.eq", <str as PartialEq>::eq),
-        slice => named_primitive!(3, "string_prim.slice", string::slice),
-        from_utf8 =>
-            primitive::<fn(Vec<u8>) -> StdResult<String, ()>>("string_prim.from_utf8",
-                                                              string::from_utf8),
-        char_at => named_primitive!(2, "string_prim.char_at", string::char_at),
-        as_bytes => primitive!(1 string_prim::as_bytes)
-    ),
+        record! {
+            len => primitive!(1 string_prim::len),
+            is_empty => primitive!(1 string_prim::is_empty),
+            split_at => primitive!(2 string_prim::split_at),
+            find => named_primitive!(2, "string_prim.find", string_prim::find::<&str>),
+            rfind => named_primitive!(2, "string_prim.rfind", string_prim::rfind::<&str>),
+            starts_with => named_primitive!(2, "string_prim.starts_with", string_prim::starts_with::<&str>),
+            ends_with => named_primitive!(2, "string_prim.ends_with", string_prim::ends_with::<&str>),
+            trim => primitive!(1 string_prim::trim),
+            trim_left => primitive!(1 string_prim::trim_left),
+            trim_right => primitive!(1 string_prim::trim_right),
+            compare => named_primitive!(2, "string_prim.compare", string_prim::cmp),
+            append => named_primitive!(2, "string_prim.append", string::append),
+            eq => named_primitive!(2, "string_prim.eq", <str as PartialEq>::eq),
+            slice => named_primitive!(3, "string_prim.slice", string::slice),
+            from_utf8 => primitive::<fn(Vec<u8>) -> StdResult<String, ()>>("string_prim.from_utf8", string::from_utf8),
+            char_at => named_primitive!(2, "string_prim.char_at", string::char_at),
+            as_bytes => primitive!(1 string_prim::as_bytes)
+        },
     )?;
     vm.define_global(
-        "char",
-        record!(
-        is_digit => primitive!(2 char::is_digit),
-        to_digit => primitive!(2 char::to_digit),
-        len_utf8 => primitive!(1 char::len_utf8),
-        len_utf16 => primitive!(1 char::len_utf16),
-        is_alphabetic => primitive!(1 char::is_alphabetic),
-        is_lowercase => primitive!(1 char::is_lowercase),
-        is_uppercase => primitive!(1 char::is_uppercase),
-        is_whitespace => primitive!(1 char::is_whitespace),
-        is_alphanumeric => primitive!(1 char::is_alphanumeric),
-        is_control => primitive!(1 char::is_control),
-        is_numeric => primitive!(1 char::is_numeric)
-    ),
+        "char_prim",
+        record! {
+            is_digit => primitive!(2 char::is_digit),
+            to_digit => primitive!(2 char::to_digit),
+            len_utf8 => primitive!(1 char::len_utf8),
+            len_utf16 => primitive!(1 char::len_utf16),
+            is_alphabetic => primitive!(1 char::is_alphabetic),
+            is_lowercase => primitive!(1 char::is_lowercase),
+            is_uppercase => primitive!(1 char::is_uppercase),
+            is_whitespace => primitive!(1 char::is_whitespace),
+            is_alphanumeric => primitive!(1 char::is_alphanumeric),
+            is_control => primitive!(1 char::is_control),
+            is_numeric => primitive!(1 char::is_numeric)
+        },
     )?;
     vm.define_global(
         "prim",
-        record!(
-        show_int => primitive!(1 prim::show_int),
-        show_float => primitive!(1 prim::show_float),
-        show_char => primitive!(1 prim::show_char)
-    ),
+        record! {
+            show_int => primitive!(1 prim::show_int),
+            show_float => primitive!(1 prim::show_float),
+            show_char => primitive!(1 prim::show_char)
+        },
     )?;
 
     vm.define_global(
         "#error",
-        primitive::<fn(StdString) -> Generic<A>>("#error", prim::error),
+        primitive::<fn(StdString) -> Generic<A>>(
+            "#error",
+            prim::error,
+        ),
     )?;
     vm.define_global(
         "error",
-        primitive::<fn(StdString) -> Generic<A>>("error", prim::error),
+        primitive::<fn(StdString) -> Generic<A>>(
+            "error",
+            prim::error,
+        ),
     )?;
 
     ::lazy::load(vm)?;


### PR DESCRIPTION
As mentioned in #335 at https://github.com/gluon-lang/gluon/pull/335#discussion_r138100396, this pulls more functionality out of the prelude and puts them into separate modules. Some ergonomics suffers as a result, but at the same time using some of the imported instances is starting to look prettier. Also the prelude looks much less intimidating. #337 should help on the ergonomics front too.