### PR TITLE
Fix warnings raised when 'serialization' feature is not specified.

### DIFF
--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -8,8 +8,10 @@
 //! difficult to forget a stage.
 
 use std::borrow::{Borrow, BorrowMut};
+#[cfg(feature = "serde")]
 use std::result::Result as StdResult;
 
+#[cfg(feature = "serde")]
 use either::Either;
 
 use base::ast::SpannedExpr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub use vm::thread::{RootedThread, Thread};
 
 pub use futures::Future;
 
+#[cfg(feature = "serialization")]
 use either::Either;
 
 use std::result::Result as StdResult;


### PR DESCRIPTION
When compiled without 'serialization' feature, some 'unused import' warnings occur
(I used rustc 1.20.0).
This PR fixes them by adding `cfg` attributes.