### PR TITLE
test: Try enabling skeptic again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ regex = { version = "0.2.1", optional = true }
 
 # Crates used in testing Testing
 compiletest_rs = { version = "0.3", optional = true }
-skeptic = { version = "0.6", optional = true }
+skeptic = { version = "0.13", optional = true }
 
 [build-dependencies]
-skeptic = { version = "0.6", optional = true }
+skeptic = { version = "0.13", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.2"

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ mod gen_skeptic {
     /// ```f#,rust
     /// ```
     /// gives f# syntax highlight while still running the tests through the template
-    const TEMPLATE: &'static str = r##"
+    const TEMPLATE: &'static str = r#####"
 ```rust,skeptic-template
 extern crate env_logger;
 extern crate gluon;
@@ -21,19 +21,19 @@ use gluon::{{new_vm, Compiler, Thread}};
 
 fn main() {{
     let _ = ::env_logger::init();
-    let text = r#\"{}\"#;
+    let text = r##"{}"##;
     let vm = new_vm();
-    match Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, \"example\", text) .sync_or_error() {{
+    match Compiler::new().run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", text) {{
         Ok(_value) => (),
         Err(err) => {{
-            panic!(\"{{}}\", err);
+            panic!("{{}}", err);
         }}
     }}
     return;
 }}
 ```
 
-"##;
+"#####;
 
     fn generate_skeptic_tests(file: &str) -> String {
         // Preprocess the readme to inject the skeptic template needed to to run the examples

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -9,7 +9,7 @@
   cargo test --features test --package gluon_completion &&
   cargo test --features test --package gluon_vm &&
   cargo test --features test --package gluon_format &&
-  cargo test --features test --package gluon &&
+  cargo test --features "test skeptic" --package gluon &&
   cargo test --features test --package gluon_repl &&
   cargo test --features test --package gluon_c-api &&
   travis-cargo --only nightly test -- --features "test nightly" -p gluon compile_test &&


### PR DESCRIPTION
Skeptic has been updated a bit (as have rustc) so lets see if we can run skeptic tests again