### PR TITLE
feat(check): Let type aliases be referred via projection

### DIFF
--- a/base/src/types/mod.rs
+++ b/base/src/types/mod.rs
@@ -2010,18 +2010,16 @@ where
     }
 }
 
-pub fn translate_alias<Id, T, U>(
-    cache: &TypeCache<Id, U>,
-    alias: &AliasData<Id, T>,
-) -> AliasData<Id, U>
+pub fn translate_alias<Id, T, U, F>(alias: &AliasData<Id, T>, mut translate: F) -> AliasData<Id, U>
 where
     T: Deref<Target = Type<Id, T>>,
     U: From<Type<Id, U>> + Clone,
     Id: Clone,
+    F: FnMut(&T) -> U,
 {
     AliasData {
         name: alias.name.clone(),
-        typ: translate_type(cache, &alias.typ),
+        typ: translate(&alias.typ),
     }
 }
 
@@ -2031,19 +2029,33 @@ where
     U: From<Type<Id, U>> + Clone,
     Id: Clone,
 {
+    translate_type_with(cache, typ, |t| translate_type(cache, t))
+}
+
+pub fn translate_type_with<Id, T, U, F>(
+    cache: &TypeCache<Id, U>,
+    typ: &Type<Id, T>,
+    mut translate: F,
+) -> U
+where
+    T: Deref<Target = Type<Id, T>>,
+    U: From<Type<Id, U>> + Clone,
+    Id: Clone,
+    F: FnMut(&T) -> U,
+{
     match *typ {
         Type::App(ref f, ref args) => Type::app(
-            translate_type(cache, f),
-            args.iter().map(|typ| translate_type(cache, typ)).collect(),
+            translate(f),
+            args.iter().map(|typ| translate(typ)).collect(),
         ),
-        Type::Record(ref row) => U::from(Type::Record(translate_type(cache, row))),
-        Type::Variant(ref row) => U::from(Type::Variant(translate_type(cache, row))),
+        Type::Record(ref row) => U::from(Type::Record(translate(row))),
+        Type::Variant(ref row) => U::from(Type::Variant(translate(row))),
         Type::Forall(ref params, ref typ, ref skolem) => U::from(Type::Forall(
             params.clone(),
-            translate_type(cache, typ),
+            translate(typ),
             skolem
                 .as_ref()
-                .map(|ts| ts.iter().map(|t| translate_type(cache, t)).collect()),
+                .map(|ts| ts.iter().map(|t| translate(t)).collect()),
         )),
         Type::Skolem(ref skolem) => U::from(Type::Skolem(Skolem {
             name: skolem.name.clone(),
@@ -2060,7 +2072,7 @@ where
                 .map(|field| {
                     Field {
                         name: field.name.clone(),
-                        typ: Alias::from(translate_alias(cache, &field.typ)),
+                        typ: Alias::from(translate_alias(&field.typ, &mut translate)),
                     }
                 })
                 .collect(),
@@ -2069,7 +2081,7 @@ where
                 .map(|field| {
                     Field {
                         name: field.name.clone(),
-                        typ: translate_type(cache, &field.typ),
+                        typ: translate(&field.typ),
                     }
                 })
                 .collect(),
@@ -2085,7 +2097,7 @@ where
         // so this will not be used
         Type::Alias(ref alias) => U::from(Type::Alias(AliasRef {
             index: 0,
-            group: Arc::new(vec![translate_alias(cache, alias)]),
+            group: Arc::new(vec![translate_alias(alias, translate)]),
         })),
         Type::EmptyRow => cache.empty_row(),
     }

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -15,6 +15,7 @@ use base::types::{Alias, AliasData, ArcType, Field, Generic, Type};
 use support::{alias, intern, typ, MockEnv};
 
 #[macro_use]
+#[allow(unused_macros)]
 mod support;
 
 macro_rules! assert_pass {

--- a/check/tests/type_projection.rs
+++ b/check/tests/type_projection.rs
@@ -1,0 +1,96 @@
+#[macro_use]
+extern crate collect_mac;
+extern crate env_logger;
+
+extern crate gluon_base as base;
+extern crate gluon_check as check;
+extern crate gluon_parser as parser;
+
+#[macro_use]
+mod support;
+
+test_check! {
+    project_type,
+    r#"
+    type Test = Int
+    let module = { Test }
+    let x : module.Test = 1
+    x
+    "#,
+    "test.Test"
+}
+
+test_check! {
+    project_type_with_params,
+    r#"
+    type Test a = | Test a
+    let module = { Test }
+    let x : module.Test Int = Test 1
+    x
+    "#,
+    "test.Test Int"
+}
+
+test_check! {
+    project_type_in_alias,
+    r#"
+    type Test = Int
+    let module = { Test }
+    type Test2 = {
+        test : module.Test
+    }
+    let x : Test2 = { test = 1 }
+    x
+    "#,
+    "test.Test2"
+}
+
+#[test]
+fn undefined_field_in_type_projection() {
+    let _ = ::env_logger::init();
+    let text = r#"
+let module = { }
+let x : module.Test = 1
+x
+"#;
+    let result = support::typecheck(text);
+    assert_err!(result, UndefinedField(..));
+}
+
+#[test]
+fn undefined_variable_in_type_projection() {
+    let _ = ::env_logger::init();
+    let text = r#"
+let x : module.Test = 1
+x
+"#;
+    let result = support::typecheck(text);
+    assert_err!(result, UndefinedVariable(..));
+}
+
+
+#[test]
+fn type_mismatch_in_type_projection() {
+    let _ = ::env_logger::init();
+    let text = r#"
+type Test = String
+let module = { Test }
+let x : module.Test = 1
+x
+"#;
+    let result = support::typecheck(text);
+    assert_unify_err!(result, TypeMismatch(..));
+}
+
+#[test]
+fn type_mismatch_in_type_projection_with_params() {
+    let _ = ::env_logger::init();
+    let text = r#"
+type Test a = | Test a
+let module = { Test }
+let x : module.Test String = Test 1
+x
+"#;
+    let result = support::typecheck(text);
+    assert_unify_err!(result, TypeMismatch(..));
+}


### PR DESCRIPTION
Since we want to provide the correct spans in the errors I had to hook into the ast type translation which was slightly awkward (need to clone `type_cache` to make lifetimes work).

## Example

```f#
type Test = Int
let module = { Test }
let x : module.Test = 1
x
```

Closes #192

Fixes #370