### PR TITLE
fix(check): generalize_type must not return unified variables ...

### DIFF
--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -1742,7 +1742,8 @@ impl<'a> Typecheck<'a> {
                         self.subs.resolve_constraints(|| state.clone(), var, typ)
                     };
                     let resolved_type = match resolved_result {
-                        Ok(x) => x.unwrap_or_else(|| typ.clone()),
+                        Ok(x) => x.map(|x| self.subs.real(&x).clone())
+                            .unwrap_or_else(|| typ.clone()),
                         Err(err) => self.error(
                             Span::new(0.into(), 0.into()),
                             TypeError::Unification(

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -507,3 +507,18 @@ make
 
     assert!(result.is_err(), "{}", result.unwrap_err());
 }
+
+
+#[test]
+fn double_type_variable_unification_bug() {
+    let _ = ::env_logger::init();
+
+    let text = r#"
+\k ->
+    let { k } = k
+    insert k
+"#;
+    let result = support::typecheck(text);
+
+    assert_err!(result, UndefinedVariable(..));
+}


### PR DESCRIPTION
after having resolved a constraint

The match below this fix assumes that if `Type::Variable` matches then that variable has not been unified with a concrete type.