### PR TITLE
feat(vm): Rewrite global handling to be abstracted from users

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ REPL features:
 ## Hello world
 
 ```f#,rust
-let io = import! "std/io.glu"
+let io = import! std.io
 io.print "Hello world!"
 ```
 
@@ -117,7 +117,7 @@ factorial 10
 Larger example which display most if not all of the syntactical elements in the language.
 
 ```f#,rust
-let io = import! "std/io.glu"
+let io = import! std.io
 
 // `let` declares new variables.
 let id x = x
@@ -168,7 +168,7 @@ if count (Cons 20 (Cons 22 Nil)) == 41 then
     error "This branch is not executed"
 else
     // `import! <filename>` loads a module stored at `filename`
-    let io = import! "std/io.glu"
+    let io = import! std.io
     io.print "Hello world!"
 ```
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -23,7 +23,7 @@ This tutorial aims the explain the basics of gluon's syntax and semantics.
 In traditional form, we will begin with the classic hello world program.
 
 ```f#,rust
-let io = import! "std/io.glu"
+let io = import! std.io
 io.println "Hello world"
 ```
 
@@ -490,7 +490,7 @@ As is often the case, it is convenient to separate code into multiple files whic
 For example, say that we need the `assert` function from the `test` module which can be found at `std/test.glu`. We might write something like this:
 
 ```f#,rust
-let { assert }  = import! "std/test.glu"
+let { assert }  = import! std.test
 assert (1 == 1)
 ```
 
@@ -550,7 +550,7 @@ Notably, if we were to execute a script with side effects the code above will ac
 let vm = new_vm();
 
 let script = r#"
-let io = import! "std/io.glu"
+let io = import! std.io
 io.print "123"
 "#;
 // Returns an action which prints `123` when evaluated
@@ -570,7 +570,7 @@ Often, it is either inconvenient or inefficient to compile and run code directly
 let vm = new_vm();
 // Ensure that the prelude module is loaded before trying to access something from it
 Compiler::new()
-    .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", r#" import! "std/prelude.glu" "#)
+    .run_expr::<OpaqueValue<&Thread, Hole>>(&vm, "example", r#" import! std.prelude "#)
     .unwrap();
 let mut add: FunctionRef<fn (i32, i32) -> i32> = vm.get_global("std.prelude.num_Int.(+)")
     .unwrap();

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -584,18 +584,36 @@ gluon also allows native functions to be called from gluon. To do this we first 
 
 ```rust,ignore
 fn factorial(x: i32) -> i32 {
-    if x <= 1 { 1 } else { x * factorial(x - 1) }
+    if x <= 1 {
+        1
+    } else {
+        x * factorial(x - 1)
+    }
 }
+
+fn load_factorial(vm: &Thread) -> vm::Result<vm::ExternModule> {
+    vm::ExternModule::new(vm, primitive!(1 factorial))
+}
+
 let vm = new_vm();
-vm.define_global("factorial", factorial as fn (_) -> _)
-    .unwrap();
+
+// Introduce a module that can be loaded with `import! factorial`
+add_extern_module(&vm, "factorial", load_factorial);
+
+let expr = r#"
+    let factorial = import! factorial
+    factorial 5
+"#;
+
 let (result, _) = Compiler::new()
-    .run_expr::<i32>(&vm, "example", "factorial 5")
+    .run_expr_async::<i32>(&vm, "factorial", expr)
+    .sync_or_error()
     .unwrap();
+
 assert_eq!(result, 120);
 ```
 
-[define_global][] can do more than just exposing simple functions. For instance, the [primitives][] module export large parts of Rust's [string][] and [float][] modules directly as records in gluon under the `str` and `float` modules respectively.
+[add_extern_module][] can do more than just exposing simple functions. For instance, the [primitives][] module export large parts of Rust's [string][] and [float][] modules directly as records in gluon under the `str` and `float` modules respectively.
 
 ```rust,ignore
 let vm = new_vm();
@@ -611,7 +629,7 @@ assert_eq!(result, "Hello world");
 [Thread]:https://docs.rs/gluon/*/gluon/struct.Thread.html
 [run_expr]:https://docs.rs/gluon/*/gluon/struct.Compiler.html#method.run_expr
 [Compiler struct]:https://docs.rs/gluon/*/gluon/struct.Compiler.html
-[define_global]:https://docs.rs/gluon/*/vm/thread/struct.Thread.html#method.define_global
+[add_extern_module]:https://docs.rs/gluon/*/gluon/import/fn.add_extern_module.html
 [primitives]:https://github.com/gluon-lang/gluon/blob/master/vm/src/primitives.rs
 [string]:http://doc.rust-lang.org/std/primitive.str.html
 [float]:http://doc.rust-lang.org/std/primitive.f64.html

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -212,7 +212,6 @@ pub fn rename(
         /// as `id` was currently unique (#Int+, #Float*, etc)
         fn rename(&self, id: &Symbol, expected: &ArcType) -> Result<Option<Symbol>, RenameError> {
             let locals = self.env.stack.get_all(id);
-            let global = self.env.env.find_type(id).map(|typ| (id, None, typ));
             let candidates = || {
                 locals
                     .iter()
@@ -222,7 +221,6 @@ pub fn rename(
                             .rev()
                             .map(|bind| (&bind.0, Some(&bind.1), &bind.2))
                     })
-                    .chain(global)
             };
             // If there is a single binding (or no binding in case of primitives such as #Int+)
             // there is no need to check for equivalency as typechecker couldnt have infered a

--- a/examples/http.glu
+++ b/examples/http.glu
@@ -1,8 +1,8 @@
-let prelude = import! "std/prelude.glu"
-let function = import! "std/function.glu"
-let io = import! "std/io.glu"
-let string = import! "std/string.glu"
-let { Bool } = import! "std/bool.glu"
+let prelude = import! std.prelude
+let function = import! std.function
+let io = import! std.io
+let string = import! std.string
+let { Bool } = import! std.bool
 let { (==) } = string.eq
 let { Functor, Applicative, Alternative, Monad } = prelude
 let { (<<), id } = prelude.make_Category function.category

--- a/examples/http.glu
+++ b/examples/http.glu
@@ -3,6 +3,7 @@ let function = import! std.function
 let io = import! std.io
 let string = import! std.string
 let { Bool } = import! std.bool
+let http_prim = import! http.prim
 let { (==) } = string.eq
 let { Functor, Applicative, Alternative, Monad } = prelude
 let { (<<), id } = prelude.make_Category function.category
@@ -19,16 +20,16 @@ let {
 
 /// Force the value to be a Handler. Necessary to make the the type inference work for
 /// higher-kinded types
-let make: Handler a -> Handler a = id
+let make : Handler a -> Handler a = id
 
-let functor: Functor Handler = {
+let functor : Functor Handler = {
     map = \f handler ->
         // FIXME type inference fails without this
         let handler = make handler
-        make (\success failure state -> handler (success << f) failure state)
+        make (\success failure state -> handler (success << f) failure state),
 }
 
-let flat_map f handler: (a -> Handler b) -> Handler a -> Handler b =
+let flat_map f handler : (a -> Handler b) -> Handler a -> Handler b =
     // FIXME type inference fails without this
     let handler = make handler
     make (\success failure state ->
@@ -36,42 +37,41 @@ let flat_map f handler: (a -> Handler b) -> Handler a -> Handler b =
         handler success2 failure state)
 
 
-let applicative: Applicative Handler = {
+let applicative : Applicative Handler = {
     functor,
     apply = \a m ->
         let m = make m
         flat_map (\f -> functor.map f m) a,
-    wrap = \a -> make (\success _ state -> success a state)
+    wrap = \a -> make (\success _ state -> success a state),
 }
 let { (*>) } = prelude.make_Applicative applicative
 
-let alternative: Alternative Handler = {
+let alternative : Alternative Handler = {
     applicative,
     // Tries to handle the request with `l`, if it fails with `DontProcess` then `r` is tried instead
     or = \l r -> make (\success failure state ->
-        let failure2 reason state2 =
-            match reason with
-            | DontProcess -> make r success failure state2
-            | Error _ -> failure reason state2
+            let failure2 reason state2 =
+                match reason with
+                | DontProcess -> make r success failure state2
+                | Error _ -> failure reason state2
 
-        make l success failure2 state),
-    empty = make (\_ failure state -> failure DontProcess state)
+            make l success failure2 state),
+    empty = make (\_ failure state -> failure DontProcess state),
 }
 let { or, empty, (<|>) } = prelude.make_Alternative alternative
 
-let monad: Monad Handler = {
+let monad : Monad Handler = {
     applicative,
-    flat_map
+    flat_map,
 }
 let { (>>=) } = prelude.make_Monad monad
 
 /// Handles the request if `predicate` returns `True
-let test predicate: (Request -> Bool) -> Handler () =
+let test predicate : (Request -> Bool) -> Handler () =
     \success failure state ->
-        if predicate state.request then
-            success () state
-        else
-            failure DontProcess state
+    if predicate state.request
+    then success () state
+    else failure DontProcess state
 
 /// Handles `Get` requests
 let get : Handler () =
@@ -88,7 +88,7 @@ let post : Handler () =
         | _ -> False)
 
 /// Processes this handler if `uri` matches the request's uri
-let path uri: String -> Handler () =
+let path uri : String -> Handler () =
     test (\request -> request.uri == uri)
 
 /// Retrieves the HTTP request
@@ -108,7 +108,8 @@ let io_handler action : IO a -> Handler a =
 
 /// Write `bytes` to the http response
 let write_response bytes : Array Byte -> Handler () =
-    get_response_body >>= (\response -> io_handler (http_prim.write_response response bytes))
+    get_response_body
+        >>= (\response -> io_handler (http_prim.write_response response bytes))
 
 /// Throws an exception which aborts the current handler. Can be caught with `catch_error`
 let fail msg : String -> Handler a =
@@ -153,5 +154,5 @@ let handle handler state : Handler Response -> HttpState -> IO Response =
     write_response,
     io_handler,
     fail,
-    catch_error
+    catch_error,
 }

--- a/examples/http_server.glu
+++ b/examples/http_server.glu
@@ -1,7 +1,7 @@
-let prelude = import! "std/prelude.glu"
-let int = import! "std/int.glu"
-let io = import! "std/io.glu"
-let string = import! "std/string.glu"
+let prelude = import! std.prelude
+let int = import! std.int
+let io = import! std.io
+let string = import! std.string
 let { (<>) } = prelude.make_Semigroup string.semigroup
 let { (*>) } = prelude.make_Applicative io.applicative
 

--- a/examples/lisp/lisp.glu
+++ b/examples/lisp/lisp.glu
@@ -1,22 +1,22 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Functor, Applicative, Monad } = prelude
-let { id } = import! "std/function.glu"
+let { id } = import! std.function
 
-let string = import! "std/string.glu"
+let string = import! std.string
 let { (==) } = string.eq
 let { (<>) } = prelude.make_Semigroup string.semigroup
 
-let { Bool } = import! "std/bool.glu"
-let float = import! "std/float.glu"
-let int = import! "std/int.glu"
-let result = import! "std/result.glu"
+let { Bool } = import! std.bool
+let float = import! std.float
+let int = import! std.int
+let result = import! std.result
 let { Result } = result
-let { Option } = import! "std/option.glu"
+let { Option } = import! std.option
 
-let list = import! "std/list.glu"
+let list = import! std.list
 let { List } = list
 
-let map = import! "std/map.glu"
+let map = import! std.map
 let { Map } = map
 let prim_map = map.make string.ord
 

--- a/examples/lisp/parser.glu
+++ b/examples/lisp/parser.glu
@@ -1,11 +1,11 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Expr } = import! "examples/lisp/types.glu"
-let char = import! "std/char.glu"
-let { List } = import! "std/list.glu"
-let { Result } = import! "std/result.glu"
-let string = import! "std/string.glu"
-let float = import! "std/float.glu"
-let int = import! "std/int.glu"
+let char = import! std.char
+let { List } = import! std.list
+let { Result } = import! std.result
+let string = import! std.string
+let float = import! std.float
+let int = import! std.int
 
 let {
     Parser,
@@ -26,7 +26,7 @@ let {
     skip_many,
     skip_many1
 } =
-    import! "std/parser.glu"
+    import! std.parser
 
 let { (<>) } = prelude.make_Semigroup string.semigroup
 

--- a/examples/lisp/types.glu
+++ b/examples/lisp/types.glu
@@ -1,7 +1,7 @@
-let { List } = import! "std/list.glu"
-let { Map } = import! "std/map.glu"
-let { Option } = import! "std/option.glu"
-let { Result } = import! "std/result.glu"
+let { List } = import! std.list
+let { Map } = import! std.map
+let { Option } = import! std.option
+let { Result } = import! std.result
 
 type Expr =
     | Atom String

--- a/format/tests/pretty_print.rs
+++ b/format/tests/pretty_print.rs
@@ -290,3 +290,13 @@ fn preserve_comments_in_record_base() {
 "#;
     assert_diff!(&format_expr(expr).unwrap(), expr, " ", 0);
 }
+
+#[test]
+fn small_record_in_let() {
+    let expr = r#"
+let semigroup =
+    { append }
+()
+"#;
+    assert_diff!(&format_expr(expr).unwrap(), expr, " ", 0);
+}

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -1,10 +1,10 @@
-let prelude = import! "std/prelude.glu"
-let io = import! "std/io.glu"
-let map = import! "std/map.glu"
-let { Bool } = import! "std/bool.glu"
-let { Option } = import! "std/option.glu"
-let { Result } = import! "std/result.glu"
-let string = import! "std/string.glu"
+let prelude = import! std.prelude
+let io = import! std.io
+let map = import! std.map
+let { Bool } = import! std.bool
+let { Option } = import! std.option
+let { Result } = import! std.result
+let string = import! std.string
 let { ref, load, (<-) } = import! "reference"
 let { Map } = map
 let { wrap, (*>) } = prelude.make_Applicative io.applicative

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -5,7 +5,7 @@ let { Bool } = import! std.bool
 let { Option } = import! std.option
 let { Result } = import! std.result
 let string = import! std.string
-let { ref, load, (<-) } = import! "reference"
+let { ref, load, (<-) } = import! std.reference
 let { Map } = map
 let { wrap, (*>) } = prelude.make_Applicative io.applicative
 let { (>>=) } = prelude.make_Monad io.monad

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -6,6 +6,8 @@ let { Option } = import! std.option
 let { Result } = import! std.result
 let string = import! std.string
 let { ref, load, (<-) } = import! std.reference
+let rustyline = import! rustyline
+let repl_prim = import! repl.prim
 let { Map } = map
 let { wrap, (*>) } = prelude.make_Applicative io.applicative
 let { (>>=) } = prelude.make_Monad io.monad

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -5,6 +5,7 @@ let { Bool } = import! "std/bool.glu"
 let { Option } = import! "std/option.glu"
 let { Result } = import! "std/result.glu"
 let string = import! "std/string.glu"
+let { ref, load, (<-) } = import! "reference"
 let { Map } = map
 let { wrap, (*>) } = prelude.make_Applicative io.applicative
 let { (>>=) } = prelude.make_Monad io.monad

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -372,7 +372,7 @@ mod tests {
             Ok(IO::Value(Ok(_))) => (),
             x => assert!(false, "{:?}", x),
         }
-        match find_info.call("float_prim") {
+        match find_info.call("std.float.prim") {
             Ok(IO::Value(Ok(_))) => (),
             x => assert!(false, "{:?}", x),
         }

--- a/repl/tests/print.glu
+++ b/repl/tests/print.glu
@@ -1,2 +1,2 @@
-let io = import! "std/io.glu"
+let io = import! std.io
 io.println "123"

--- a/repl/tests/tests.rs
+++ b/repl/tests/tests.rs
@@ -45,6 +45,7 @@ fn issue_365_run_io_from_command_line() {
     let output = Command::new(&*gluon_path)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .arg("tests/print.glu")
         .output()
         .unwrap_or_else(|err| {

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -357,10 +357,12 @@ where
                 }
             })
             .map_err(Error::from)
-            .and_then(move |v| if run_io {
-                ::compiler_pipeline::run_io(vm, v)
-            } else {
-                FutureValue::sync(Ok(v)).boxed()
+            .and_then(move |v| {
+                if run_io {
+                    ::compiler_pipeline::run_io(vm, v)
+                } else {
+                    FutureValue::sync(Ok(v)).boxed()
+                }
             })
             .boxed()
     }
@@ -378,10 +380,12 @@ where
         let filename = filename.to_string();
 
         self.run_expr(compiler, vm, &filename, expr_str, ())
-            .and_then(move |v| if run_io {
-                ::compiler_pipeline::run_io(vm, v)
-            } else {
-                FutureValue::sync(Ok(v)).boxed()
+            .and_then(move |v| {
+                if run_io {
+                    ::compiler_pipeline::run_io(vm, v)
+                } else {
+                    FutureValue::sync(Ok(v)).boxed()
+                }
             })
             .and_then(move |mut value| {
                 let (metadata, _) = metadata::metadata(&*vm.get_env(), value.expr.borrow_mut());

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -22,7 +22,7 @@ use base::source::Source;
 use base::symbol::{Name, NameBuf, Symbol, SymbolModule};
 use base::resolve;
 
-use vm::compiler::CompiledFunction;
+use vm::compiler::CompiledModule;
 use vm::future::{BoxFutureValue, FutureValue};
 use vm::macros::MacroExpander;
 use vm::thread::{RootedValue, Thread, ThreadInternal};
@@ -182,7 +182,7 @@ where
 pub struct CompileValue<E> {
     pub expr: E,
     pub typ: ArcType,
-    pub function: CompiledFunction,
+    pub module: CompiledModule,
 }
 
 pub trait Compileable<Extra> {
@@ -233,7 +233,7 @@ where
     ) -> Result<CompileValue<Self::Expr>> {
         use vm::compiler::Compiler;
         debug!("Compile `{}`", filename);
-        let mut function = {
+        let mut module = {
             let env = thread.get_env();
             let name = Name::new(filename);
             let name = NameBuf::from(name.module());
@@ -252,11 +252,11 @@ where
             );
             compiler.compile_expr(self.expr.borrow())?
         };
-        function.id = Symbol::from(filename);
+        module.function.id = Symbol::from(filename);
         Ok(CompileValue {
             expr: self.expr,
             typ: self.typ,
-            function: function,
+            module,
         })
     }
 }
@@ -341,12 +341,12 @@ where
         let CompileValue {
             expr,
             typ,
-            mut function,
+            mut module,
         } = self;
         let run_io = compiler.run_io;
         let module_id = Symbol::from(name);
-        function.id = module_id.clone();
-        let closure = try_future!(vm.global_env().new_global_thunk(function));
+        module.function.id = module_id.clone();
+        let closure = try_future!(vm.global_env().new_global_thunk(module));
         vm.call_thunk(closure)
             .map(|(vm, value)| {
                 ExecuteValue {
@@ -408,8 +408,10 @@ pub struct Precompiled<D>(pub D);
 pub struct Module {
     #[cfg_attr(feature = "serde_derive_state", serde(state_with = "::vm::serialization::borrow"))]
     pub typ: ArcType,
+
     pub metadata: Metadata,
-    #[cfg_attr(feature = "serde_derive_state", serde(state))] pub function: CompiledFunction,
+
+    #[cfg_attr(feature = "serde_derive_state", serde(state))] pub module: CompiledModule,
 }
 
 #[cfg(feature = "serde")]
@@ -434,14 +436,14 @@ where
                 .deserialize(self.0)
                 .map_err(|err| err.to_string())
         );
-        let module_id = module.function.id.clone();
+        let module_id = module.module.function.id.clone();
         if filename != module_id.as_ref() {
             return FutureValue::sync(Err(
                 format!("filenames do not match `{}` != `{}`", filename, module_id).into(),
             )).boxed();
         }
         let typ = module.typ;
-        let closure = try_future!(vm.global_env().new_global_thunk(module.function));
+        let closure = try_future!(vm.global_env().new_global_thunk(module.module));
         vm.call_thunk(closure)
             .map(|(vm, value)| {
                 ExecuteValue {
@@ -502,7 +504,7 @@ where
     let CompileValue {
         expr: _,
         typ,
-        function,
+        module,
     } = self_
         .compile(compiler, thread, file, expr_str, arg)
         .map_err(Error::from)
@@ -510,7 +512,7 @@ where
     let module = Module {
         typ,
         metadata: Metadata::default(),
-        function,
+        module,
     };
     module
         .serialize_state(serializer, &SeSeed::new(thread))

--- a/src/import.rs
+++ b/src/import.rs
@@ -56,7 +56,7 @@ macro_rules! std_libs {
     }
 }
 // Include the standard library distribution in the binary
-static STD_LIBS: [(&str, &str); 19] = std_libs!(
+static STD_LIBS: &[(&str, &str)] = &std_libs!(
     "prelude",
     "types",
     "function",
@@ -75,7 +75,8 @@ static STD_LIBS: [(&str, &str); 19] = std_libs!(
     "string",
     "test",
     "unit",
-    "writer"
+    "writer",
+    "array"
 );
 
 pub trait Importer: Any + Clone + Sync + Send {

--- a/src/import.rs
+++ b/src/import.rs
@@ -148,7 +148,7 @@ enum UnloadedModule {
 /// already loaded and then a global access to the loaded module
 pub struct Import<I = DefaultImporter> {
     pub paths: RwLock<Vec<PathBuf>>,
-    loaders: RwLock<FnvMap<String, ExternLoader>>,
+    pub loaders: RwLock<FnvMap<String, ExternLoader>>,
     pub importer: I,
 }
 
@@ -184,6 +184,7 @@ impl<I> Import<I> {
 
         // Retrieve the source, first looking in the standard library included in the
         // binary
+
         let std_file = STD_LIBS.iter().find(|tup| tup.0 == module);
         if let Some(tup) = std_file {
             return Ok(UnloadedModule::Source(Cow::Borrowed(tup.1)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,7 +562,7 @@ pub fn new_vm() -> RootedThread {
     add_extern_module(&vm, "float_prim", ::vm::primitives::load_float);
     add_extern_module(&vm, "string_prim", ::vm::primitives::load_string);
     add_extern_module(&vm, "char_prim", ::vm::primitives::load_char);
-    add_extern_module(&vm, "array", ::vm::primitives::load_array);
+    add_extern_module(&vm, "std.array", ::vm::primitives::load_array);
 
     add_extern_module(&vm, "std.lazy", ::vm::lazy::load);
     add_extern_module(&vm, "std.reference", ::vm::reference::load);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,23 +505,23 @@ impl Compiler {
 }
 
 pub const PRELUDE: &'static str = r#"
-let __implicit_prelude = import! "std/prelude.glu"
+let __implicit_prelude = import! std.prelude
 and { Num, Eq, Ord, Show, Functor, Monad } = __implicit_prelude
-and { Bool, not } = import! "std/bool.glu"
-and { Option } = import! "std/option.glu"
+and { Bool, not } = import! std.bool
+and { Option } = import! std.option
 
-let __implicit_float = import! "std/float.glu"
+let __implicit_float = import! std.float
 let { (+), (-), (*), (/) } = __implicit_float.num
 and { (==) } = __implicit_float.eq
 
 let { (<), (<=), (>=), (>) } = __implicit_prelude.make_Ord __implicit_float.ord
 
-let __implicit_int = import! "std/int.glu"
+let __implicit_int = import! std.int
 let { (+), (-), (*), (/) } = __implicit_int.num
 and { (==) } = __implicit_int.eq
 let { (<), (<=), (>=), (>) } = __implicit_prelude.make_Ord __implicit_int.ord
 
-let __implicit_string = import! "std/string.glu"
+let __implicit_string = import! std.string
 and { eq = { (==) } } = __implicit_string
 let { (<), (<=), (>=), (>) } = __implicit_prelude.make_Ord __implicit_string.ord
 
@@ -553,7 +553,7 @@ pub fn new_vm() -> RootedThread {
 
     Compiler::new()
         .implicit_prelude(false)
-        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "", r#" import! "std/types.glu" "#)
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "", r#" import! std.types "#)
         .sync_or_error()
         .unwrap();
     ::vm::primitives::load(&vm).expect("Loaded primitives library");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use vm::Variants;
 use vm::api::{Getable, Hole, OpaqueValue, VmType};
 use vm::Error as VmError;
 use vm::future::{BoxFutureValue, FutureValue};
-use vm::compiler::CompiledFunction;
+use vm::compiler::CompiledModule;
 use vm::thread::ThreadInternal;
 use vm::macros;
 use compiler_pipeline::*;
@@ -257,12 +257,12 @@ impl Compiler {
         filename: &str,
         expr_str: &str,
         expr: &SpannedExpr<Symbol>,
-    ) -> Result<CompiledFunction> {
+    ) -> Result<CompiledModule> {
         TypecheckValue {
             expr: expr,
             typ: vm.global_env().type_cache().hole(),
         }.compile(self, vm, filename, expr_str, ())
-            .map(|result| result.function)
+            .map(|result| result.module)
     }
 
     /// Compiles the source code `expr_str` into bytecode serialized using `serializer`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,6 +525,8 @@ let __implicit_string = import! std.string
 and { eq = { (==) } } = __implicit_string
 let { (<), (<=), (>=), (>) } = __implicit_prelude.make_Ord __implicit_string.ord
 
+let { error } = import! std.prim
+
 in ()
 "#;
 
@@ -556,13 +558,13 @@ pub fn new_vm() -> RootedThread {
         .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "", r#" import! std.types "#)
         .sync_or_error()
         .unwrap();
-    ::vm::primitives::load(&vm).expect("Loaded primitives library");
 
-    add_extern_module(&vm, "int_prim", ::vm::primitives::load_int);
-    add_extern_module(&vm, "float_prim", ::vm::primitives::load_float);
-    add_extern_module(&vm, "string_prim", ::vm::primitives::load_string);
-    add_extern_module(&vm, "char_prim", ::vm::primitives::load_char);
-    add_extern_module(&vm, "std.array", ::vm::primitives::load_array);
+    add_extern_module(&vm, "std.prim", ::vm::primitives::load);
+    add_extern_module(&vm, "std.int.prim", ::vm::primitives::load_int);
+    add_extern_module(&vm, "std.float.prim", ::vm::primitives::load_float);
+    add_extern_module(&vm, "std.string.prim", ::vm::primitives::load_string);
+    add_extern_module(&vm, "std.char.prim", ::vm::primitives::load_char);
+    add_extern_module(&vm, "std.array.prim", ::vm::primitives::load_array);
 
     add_extern_module(&vm, "std.lazy", ::vm::lazy::load);
     add_extern_module(&vm, "std.reference", ::vm::reference::load);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,20 @@ impl Default for Compiler {
     }
 }
 
+macro_rules! option {
+    ($(#[$attr:meta])* $name: ident $set_name: ident : $typ: ty) => {
+        $(#[$attr])*
+        pub fn $name(mut self, $name: $typ) -> Compiler {
+            self.$name = $name;
+            self
+        }
+
+        pub fn $set_name(&mut self, $name: $typ) {
+            self.$name = $name;
+        }
+    };
+}
+
 impl Compiler {
     /// Creates a new compiler with default settings
     pub fn new() -> Compiler {
@@ -172,26 +186,23 @@ impl Compiler {
         }
     }
 
-    /// Sets whether the implicit prelude should be include when compiling a file using this
-    /// compiler (default: true)
-    pub fn implicit_prelude(mut self, implicit_prelude: bool) -> Compiler {
-        self.implicit_prelude = implicit_prelude;
-        self
+    option!{
+        /// Sets whether the implicit prelude should be include when compiling a file using this
+        /// compiler (default: true)
+        implicit_prelude set_implicit_prelude: bool
     }
 
-    /// Sets whether the compiler should emit debug information such as source maps and variable
-    /// names.
-    /// (default: true)
-    pub fn emit_debug_info(mut self, emit_debug_info: bool) -> Compiler {
-        self.emit_debug_info = emit_debug_info;
-        self
+    option!{
+        /// Sets whether the compiler should emit debug information such as source maps and variable
+        /// names.
+        /// (default: true)
+        emit_debug_info set_emit_debug_info: bool
     }
 
-    /// Sets whether `IO` expressions are evaluated.
-    /// (default: false)
-    pub fn run_io(mut self, run_io: bool) -> Compiler {
-        self.run_io = run_io;
-        self
+    option!{
+        /// Sets whether `IO` expressions are evaluated.
+        /// (default: false)
+        run_io set_run_io: bool
     }
 
     pub fn mut_symbols(&mut self) -> &mut Symbols {
@@ -360,7 +371,7 @@ impl Compiler {
         let module_name = Symbol::from(filename_to_module(filename));
         FutureValue::from(
             import
-                .load_module(vm, &mut MacroExpander::new(vm), &module_name)
+                .load_module(self, vm, &mut MacroExpander::new(vm), &module_name)
                 .map_err(Error::from),
         ).boxed()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,8 +564,8 @@ pub fn new_vm() -> RootedThread {
     add_extern_module(&vm, "char_prim", ::vm::primitives::load_char);
     add_extern_module(&vm, "array", ::vm::primitives::load_array);
 
-    add_extern_module(&vm, "lazy", ::vm::lazy::load);
-    add_extern_module(&vm, "reference", ::vm::reference::load);
+    add_extern_module(&vm, "std.lazy", ::vm::lazy::load);
+    add_extern_module(&vm, "std.reference", ::vm::reference::load);
 
     ::vm::channel::load(&vm).expect("Loaded channel library");
     ::vm::debug::load(&vm).expect("Loaded debug library");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,9 +231,7 @@ impl Compiler {
             &mut SymbolModule::new(file.into(), &mut self.symbols),
             type_cache,
             expr_str,
-        ).map_err(
-            |(expr, err)| (expr, InFile::new(file, expr_str, err)),
-        )?)
+        ).map_err(|(expr, err)| (expr, InFile::new(file, expr_str, err)))?)
     }
 
     /// Parse and typecheck `expr_str` returning the typechecked expression and type of the

--- a/src/regex_bind.rs
+++ b/src/regex_bind.rs
@@ -4,7 +4,7 @@ extern crate regex;
 
 use std::error::Error as StdError;
 
-use vm;
+use vm::{self, ExternModule};
 use vm::api::{Userdata, VmType};
 use vm::gc::{Gc, Traverseable};
 use vm::thread::Thread;
@@ -52,15 +52,22 @@ fn error_to_string(err: &Error) -> &str {
     err.description()
 }
 
+mod std {
+    pub use regex_bind as regex;
+}
 
-pub fn load(vm: &Thread) -> vm::Result<()> {
+pub fn load(vm: &Thread) -> vm::Result<ExternModule> {
+    use self::std;
+
     vm.register_type::<Regex>("Regex", &[])?;
     vm.register_type::<Error>("Error", &[])?;
-    vm.define_global(
-        "regex",
-        record!(new => primitive!(1 new),
-                             is_match => primitive!(2 is_match),
-                             error_to_string => primitive!(1 error_to_string)
-                            ),
+
+    ExternModule::new(
+        vm,
+        record!{
+            new => primitive!(1 std::regex::new),
+            is_match => primitive!(2 std::regex::is_match),
+            error_to_string => primitive!(1 std::regex::error_to_string)
+        },
     )
 }

--- a/std/array.glu
+++ b/std/array.glu
@@ -1,0 +1,8 @@
+//@NO-IMPLICIT-PRELUDE
+
+let prim = import! std.array.prim
+
+{
+    ..
+    prim
+}

--- a/std/bool.glu
+++ b/std/bool.glu
@@ -1,8 +1,8 @@
 //@NO-IMPLICIT-PRELUDE
 
-let { Bool, Ordering } = import! "std/types.glu"
-let { Semigroup, Monoid, Group, Eq, Ord, Show } = import! "std/prelude.glu"
-let { id } = import! "std/function.glu"
+let { Bool, Ordering } = import! std.types
+let { Semigroup, Monoid, Group, Eq, Ord, Show } = import! std.prelude
+let { id } = import! std.function
 
 /// Boolean 'not'
 let not x : Bool -> Bool = if x then False else True

--- a/std/char.glu
+++ b/std/char.glu
@@ -7,12 +7,12 @@ let ord : Ord Char = {
     compare = \l r -> if l #Char< r then LT else if l #Char== r then EQ else GT,
 }
 
-let show : Show Char = { show = prim.show_char }
+let show : Show Char = { show = (import! std.prim).show_char }
 
 {
     eq,
     ord,
     show,
     ..
-    import! "char_prim"
+    import! std.char.prim
 }

--- a/std/char.glu
+++ b/std/char.glu
@@ -14,5 +14,5 @@ let show : Show Char = { show = prim.show_char }
     ord,
     show,
     ..
-    char_prim
+    import! "char_prim"
 }

--- a/std/char.glu
+++ b/std/char.glu
@@ -1,4 +1,4 @@
-let { Eq, Ord, Ordering, Show } = import! "std/prelude.glu"
+let { Eq, Ord, Ordering, Show } = import! std.prelude
 
 let eq : Eq Char = { (==) = \l r -> l #Char== r }
 

--- a/std/float.glu
+++ b/std/float.glu
@@ -51,7 +51,7 @@ let num : Num Float = {
 }
 
 let show : Show Float = {
-    show = prim.show_float
+    show = (import! std.prim).show_float
 }
 
 {
@@ -62,5 +62,5 @@ let show : Show Float = {
     num,
     show,
     ..
-    import! "float_prim"
+    import! std.float.prim
 }

--- a/std/float.glu
+++ b/std/float.glu
@@ -62,5 +62,5 @@ let show : Show Float = {
     num,
     show,
     ..
-    float_prim
+    import! "float_prim"
 }

--- a/std/float.glu
+++ b/std/float.glu
@@ -1,6 +1,6 @@
 //@NO-IMPLICIT-PRELUDE
 
-let { Semigroup, Monoid, Group, Eq, Ord, Ordering, Num, Show } = import! "std/prelude.glu"
+let { Semigroup, Monoid, Group, Eq, Ord, Ordering, Num, Show } = import! std.prelude
 
 let additive =
     let semigroup : Semigroup Float = { append = \x y -> x #Float+ y }

--- a/std/function.glu
+++ b/std/function.glu
@@ -1,6 +1,6 @@
 //@NO-IMPLICIT-PRELUDE
 
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Semigroup, Monoid, Category, make_Category } = prelude
 let { Functor, Applicative, Monad } = prelude
 

--- a/std/int.glu
+++ b/std/int.glu
@@ -61,5 +61,5 @@ let show : Show Int = {
     num,
     show,
     ..
-    int_prim
+    import! "int_prim"
 }

--- a/std/int.glu
+++ b/std/int.glu
@@ -50,7 +50,7 @@ let num = {
 }
 
 let show : Show Int = {
-    show = prim.show_int
+    show = (import! std.prim).show_int
 }
 
 {
@@ -61,5 +61,5 @@ let show : Show Int = {
     num,
     show,
     ..
-    import! "int_prim"
+    import! std.int.prim
 }

--- a/std/int.glu
+++ b/std/int.glu
@@ -1,6 +1,6 @@
 //@NO-IMPLICIT-PRELUDE
 
-let { Semigroup, Monoid, Group, Eq, Ord, Ordering, Num, Show } = import! "std/prelude.glu"
+let { Semigroup, Monoid, Group, Eq, Ord, Ordering, Num, Show } = import! std.prelude
 
 let additive =
     let semigroup : Semigroup Int = {

--- a/std/io.glu
+++ b/std/io.glu
@@ -1,4 +1,4 @@
-let { Functor, Applicative, Monad } = import! "std/prelude.glu"
+let { Functor, Applicative, Monad } = import! std.prelude
 
 let functor : Functor IO = {
     map = \f -> io_flat_map (\x -> io_wrap (f x))

--- a/std/io.glu
+++ b/std/io.glu
@@ -1,18 +1,19 @@
+let io_prim = import! std.io.prim
 let { Functor, Applicative, Monad } = import! std.prelude
 
 let functor : Functor IO = {
-    map = \f -> io_flat_map (\x -> io_wrap (f x))
+    map = \f -> io_prim.flat_map (\x -> io_prim.wrap (f x))
 }
 
 let applicative : Applicative IO =
-    let wrap = io_wrap
-    let apply f x = io_flat_map (\g -> io_flat_map (\y -> wrap (g y)) x) f
+    let wrap = io_prim.wrap
+    let apply f x = io_prim.flat_map (\g -> io_prim.flat_map (\y -> wrap (g y)) x) f
 
     { functor, apply, wrap }
 
 let monad : Monad IO = {
     applicative = applicative,
-    flat_map = io_flat_map,
+    flat_map = io_prim.flat_map,
 }
 
 {

--- a/std/list.glu
+++ b/std/list.glu
@@ -1,8 +1,8 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Semigroup, Monoid, Eq, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
-let { Bool } = import! "std/bool.glu"
-let string = import! "std/string.glu"
+let { Bool } = import! std.bool
+let string = import! std.string
 let array = import! "array"
 
 /// A linked list type

--- a/std/list.glu
+++ b/std/list.glu
@@ -3,7 +3,7 @@ let { Semigroup, Monoid, Eq, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
 let { Bool } = import! std.bool
 let string = import! std.string
-let array = import! "array"
+let array = import! std.array
 
 /// A linked list type
 type List a = | Nil | Cons a (List a)

--- a/std/list.glu
+++ b/std/list.glu
@@ -3,6 +3,7 @@ let { Semigroup, Monoid, Eq, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
 let { Bool } = import! "std/bool.glu"
 let string = import! "std/string.glu"
+let array = import! "array"
 
 /// A linked list type
 type List a = | Nil | Cons a (List a)

--- a/std/map.glu
+++ b/std/map.glu
@@ -1,11 +1,11 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Ordering, Ord, Semigroup, Monoid } = prelude
 let { Functor, Applicative, Foldable, Traversable } = prelude
 
-let { flip, const } = import! "std/function.glu"
-let list = import! "std/list.glu"
+let { flip, const } = import! std.function
+let list = import! std.list
 let { List } = list
-let { Option } = import! "std/option.glu"
+let { Option } = import! std.option
 
 type Map k a = | Bin k a (Map k a) (Map k a) | Tip
 

--- a/std/option.glu
+++ b/std/option.glu
@@ -1,6 +1,7 @@
 //@NO-IMPLICIT-PRELUDE
 
 let prelude = import! std.prelude
+let { error } = import! std.prim
 let { Semigroup, Monoid, Eq, Ord, Ordering, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
 let { Bool } = import! std.bool

--- a/std/option.glu
+++ b/std/option.glu
@@ -5,6 +5,7 @@ let { Semigroup, Monoid, Eq, Ord, Ordering, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
 let { Bool } = import! "std/bool.glu"
 let { Option } = import! "std/types.glu"
+let string = import! "std/string.glu"
 
 let unwrap opt : Option a -> a =
     match opt with
@@ -107,7 +108,7 @@ let monad : Monad Option = {
 }
 
 let show : Show a -> Show (Option a) = \d ->
-    let (++) = string_prim.append
+    let (++) = string.append
 
     let show o =
         match o with

--- a/std/option.glu
+++ b/std/option.glu
@@ -1,11 +1,11 @@
 //@NO-IMPLICIT-PRELUDE
 
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Semigroup, Monoid, Eq, Ord, Ordering, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Foldable, Traversable } = prelude
-let { Bool } = import! "std/bool.glu"
-let { Option } = import! "std/types.glu"
-let string = import! "std/string.glu"
+let { Bool } = import! std.bool
+let { Option } = import! std.types
+let string = import! std.string
 
 let unwrap opt : Option a -> a =
     match opt with

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -1,15 +1,15 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Functor, Applicative, Alternative, Monad } = prelude
-let { id } = import! "std/function.glu"
-let { Bool } = import! "std/bool.glu"
-let char = import! "std/char.glu"
+let { id } = import! std.function
+let { Bool } = import! std.bool
+let char = import! std.char
 let { (==) } = char.eq
-let { Result } = import! "std/result.glu"
-let string = import! "std/string.glu"
+let { Result } = import! std.result
+let string = import! std.string
 let { (<>) } = prelude.make_Semigroup string.semigroup
-let list = import! "std/list.glu"
+let list = import! std.list
 let { List } = list
-let { Option } = import! "std/option.glu"
+let { Option } = import! std.option
 
 type OffsetString = { start : Int, end : Int, buffer : String }
 type Position = Int

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -1,6 +1,6 @@
 //@NO-IMPLICIT-PRELUDE
 
-let { Bool, Option, Ordering } = import! "std/types.glu"
+let { Bool, Option, Ordering } = import! std.types
 
 /// `Semigroup a` represents an associative operation on `a`.
 /// This means the following laws must hold:

--- a/std/result.glu
+++ b/std/result.glu
@@ -3,6 +3,7 @@ let { Eq, Ord, Ordering, Show } = prelude
 let { Functor, Applicative, Monad, Foldable, Traversable } = prelude
 let { Result } = import! "std/types.glu"
 let { Bool } = import! "std/bool.glu"
+let string = import! "std/string.glu"
 
 let unwrap_ok res : Result e a -> a =
     match res with
@@ -78,7 +79,7 @@ let traversable : Traversable (Result e) = {
 }
 
 let show : Show e -> Show t -> Show (Result e t) = \e t ->
-    let (++) = string_prim.append
+    let (++) = string.append
 
     let show o =
         match o with

--- a/std/result.glu
+++ b/std/result.glu
@@ -1,9 +1,9 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Eq, Ord, Ordering, Show } = prelude
 let { Functor, Applicative, Monad, Foldable, Traversable } = prelude
-let { Result } = import! "std/types.glu"
-let { Bool } = import! "std/bool.glu"
-let string = import! "std/string.glu"
+let { Result } = import! std.types
+let { Bool } = import! std.bool
+let string = import! std.string
 
 let unwrap_ok res : Result e a -> a =
     match res with

--- a/std/state.glu
+++ b/std/state.glu
@@ -1,4 +1,4 @@
-let { Applicative, Functor, Monad } = import! "std/prelude.glu"
+let { Applicative, Functor, Monad } = import! std.prelude
 
 type State s a = s -> { value : a, state : s }
 

--- a/std/stream.glu
+++ b/std/stream.glu
@@ -6,6 +6,7 @@ let list = import! "std/list.glu"
 let { Bool } = import! "std/bool.glu"
 let { List } = list
 let { Option } = import! "std/option.glu"
+let { lazy, force } = import! "lazy"
 
 type Stream_ a = | Value a (Stream a) | Empty
 and Stream a = Lazy (Stream_ a)

--- a/std/stream.glu
+++ b/std/stream.glu
@@ -1,11 +1,11 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 and { Functor, Applicative } = prelude
-let int = import! "std/int.glu"
+let int = import! std.int
 and { (+) } = int.num
-let list = import! "std/list.glu"
-let { Bool } = import! "std/bool.glu"
+let list = import! std.list
+let { Bool } = import! std.bool
 let { List } = list
-let { Option } = import! "std/option.glu"
+let { Option } = import! std.option
 let { lazy, force } = import! "lazy"
 
 type Stream_ a = | Value a (Stream a) | Empty

--- a/std/stream.glu
+++ b/std/stream.glu
@@ -6,7 +6,7 @@ let list = import! std.list
 let { Bool } = import! std.bool
 let { List } = list
 let { Option } = import! std.option
-let { lazy, force } = import! "lazy"
+let { lazy, force } = import! std.lazy
 
 type Stream_ a = | Value a (Stream a) | Empty
 and Stream a = Lazy (Stream_ a)

--- a/std/string.glu
+++ b/std/string.glu
@@ -1,9 +1,9 @@
 //@NO-IMPLICIT-PRELUDE
 
 let string_prim = import! "string_prim"
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Num, Eq, Ord, Ordering, Semigroup, Monoid, Show } = prelude
-let function = import! "std/function.glu"
+let function = import! std.function
 
 let semigroup : Semigroup String = { append = string_prim.append }
 

--- a/std/string.glu
+++ b/std/string.glu
@@ -1,6 +1,7 @@
 //@NO-IMPLICIT-PRELUDE
 
-let string_prim = import! "string_prim"
+let string_prim = import! std.string.prim
+let prim = import! std.prim
 let prelude = import! std.prelude
 let { Num, Eq, Ord, Ordering, Semigroup, Monoid, Show } = prelude
 let function = import! std.function
@@ -9,9 +10,9 @@ let semigroup : Semigroup String = { append = string_prim.append }
 
 let monoid : Monoid String = { semigroup, empty = "" }
 
-let eq : Eq String = { (==) = string_eq }
+let eq : Eq String = { (==) = prim.string_eq }
 
-let ord : Ord String = { eq, compare = import! "string_compare" }
+let ord : Ord String = { eq, compare = prim.string_compare }
 
 let show : Show String = { show = function.id }
 

--- a/std/string.glu
+++ b/std/string.glu
@@ -1,5 +1,6 @@
 //@NO-IMPLICIT-PRELUDE
 
+let string_prim = import! "string_prim"
 let prelude = import! "std/prelude.glu"
 let { Num, Eq, Ord, Ordering, Semigroup, Monoid, Show } = prelude
 let function = import! "std/function.glu"
@@ -10,7 +11,7 @@ let monoid : Monoid String = { semigroup, empty = "" }
 
 let eq : Eq String = { (==) = string_eq }
 
-let ord : Ord String = { eq, compare = string_compare }
+let ord : Ord String = { eq, compare = import! "string_compare" }
 
 let show : Show String = { show = function.id }
 

--- a/std/test.glu
+++ b/std/test.glu
@@ -1,16 +1,16 @@
-let string = import! "std/string.glu"
-and { Writer, make = make_Writer, tell } = import! "std/writer.glu"
-and prelude = import! "std/prelude.glu"
+let string = import! std.string
+and { Writer, make = make_Writer, tell } = import! std.writer
+and prelude = import! std.prelude
 and { Show, Num, Eq, Applicative, Monad, Monoid } = prelude
-let float = import! "std/float.glu"
-let int = import! "std/int.glu"
+let float = import! std.float
+let int = import! std.int
 and { (+) } = int.num
 and { (==) } = int.eq
 and { (<) } = prelude.make_Ord int.ord
-let list = import! "std/list.glu"
+let list = import! std.list
 let { List } = list
 and { foldl } = list.foldable
-let { Option } = import! "std/option.glu"
+let { Option } = import! std.option
 
 let (++) = string.semigroup.append
 

--- a/std/unit.glu
+++ b/std/unit.glu
@@ -1,6 +1,6 @@
-let { Eq, Ord, Ordering, Show } = import! "std/prelude.glu"
-let { const } = import! "std/function.glu"
-let { Bool } = import! "std/bool.glu"
+let { Eq, Ord, Ordering, Show } = import! std.prelude
+let { const } = import! std.function
+let { Bool } = import! std.bool
 
 let eq : Eq () = { (==) = const (const True) }
 

--- a/std/writer.glu
+++ b/std/writer.glu
@@ -1,4 +1,4 @@
-let prelude = import! "std/prelude.glu"
+let prelude = import! std.prelude
 let { Applicative, Functor, Monad, Monoid } = prelude
 
 type Writer w a = { value : a, writer : w }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -204,7 +204,7 @@ fn io_future() {
     }
 
     let expr = r#"
-    let { applicative, monad }  = import! "std/io.glu"
+    let { applicative, monad }  = import! std.io
     monad.flat_map (\x -> applicative.wrap (x + 1)) (test ())
 "#;
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -7,6 +7,7 @@ mod support;
 
 test_expr!{ array,
 r#"
+let array = import! "array"
 let arr = [1,2,3]
 
 array.index arr 0 #Int== 1
@@ -17,6 +18,7 @@ true
 
 test_expr!{ array_byte,
 r#"
+let array = import! "array"
 let arr = [1b,2b,3b]
 
 let b = array.index arr 2 #Byte== 3b && array.len arr #Int== 3
@@ -29,6 +31,7 @@ true
 
 test_expr!{ array_float,
 r#"
+let array = import! "array"
 let arr = [1.0,2.0,3.0]
 
 let b = array.index arr 2 #Float== 3.0 && array.len arr #Int== 3
@@ -41,6 +44,7 @@ true
 
 test_expr!{ array_data,
 r#"
+let array = import! "array"
 let arr = [{x = 1, y = "a" }, { x = 2, y = "b" }]
 
 let b = (array.index arr 1).x #Int== 2 && array.len arr #Int== 2
@@ -52,6 +56,7 @@ true
 
 test_expr!{ array_array,
 r#"
+let array = import! "array"
 let arr = [[], [1], [2, 3]]
 
 let b = array.len (array.index arr 1) #Int== 1 && array.len arr #Int== 3
@@ -64,6 +69,7 @@ true
 // Test that empty variants are handled correctly in arrays
 test_expr!{ array_empty_variant,
 r#"
+let array = import! "array"
 type Test = | Empty | Some Int
 let arr = [Empty, Some 1]
 match array.index arr 0 with
@@ -76,6 +82,7 @@ match array.index arr 0 with
 // Test that array append handles array types correctly
 test_expr!{ array_empty_append,
 r#"
+let array = import! "array"
 type Test = | Empty | Some Int
 let arr = array.append [] [Empty, Some 1]
 match array.index arr 0 with

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -7,7 +7,7 @@ mod support;
 
 test_expr!{ array,
 r#"
-let array = import! "array"
+let array = import! std.array
 let arr = [1,2,3]
 
 array.index arr 0 #Int== 1
@@ -18,7 +18,7 @@ true
 
 test_expr!{ array_byte,
 r#"
-let array = import! "array"
+let array = import! std.array
 let arr = [1b,2b,3b]
 
 let b = array.index arr 2 #Byte== 3b && array.len arr #Int== 3
@@ -31,7 +31,7 @@ true
 
 test_expr!{ array_float,
 r#"
-let array = import! "array"
+let array = import! std.array
 let arr = [1.0,2.0,3.0]
 
 let b = array.index arr 2 #Float== 3.0 && array.len arr #Int== 3
@@ -44,7 +44,7 @@ true
 
 test_expr!{ array_data,
 r#"
-let array = import! "array"
+let array = import! std.array
 let arr = [{x = 1, y = "a" }, { x = 2, y = "b" }]
 
 let b = (array.index arr 1).x #Int== 2 && array.len arr #Int== 2
@@ -56,7 +56,7 @@ true
 
 test_expr!{ array_array,
 r#"
-let array = import! "array"
+let array = import! std.array
 let arr = [[], [1], [2, 3]]
 
 let b = array.len (array.index arr 1) #Int== 1 && array.len arr #Int== 3
@@ -69,7 +69,7 @@ true
 // Test that empty variants are handled correctly in arrays
 test_expr!{ array_empty_variant,
 r#"
-let array = import! "array"
+let array = import! std.array
 type Test = | Empty | Some Int
 let arr = [Empty, Some 1]
 match array.index arr 0 with
@@ -82,7 +82,7 @@ match array.index arr 0 with
 // Test that array append handles array types correctly
 test_expr!{ array_empty_append,
 r#"
-let array = import! "array"
+let array = import! std.array
 type Test = | Empty | Some Int
 let arr = array.append [] [Empty, Some 1]
 match array.index arr 0 with

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -91,3 +91,11 @@ match array.index arr 0 with
 "#,
 0i32
 }
+
+test_expr!{ array_load,
+r#"
+let array = import! std.array
+0
+"#,
+0i32
+}

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -7,7 +7,7 @@ mod support;
 
 test_expr!{ array,
 r#"
-let array = import! std.array
+let array = import! std.array.prim
 let arr = [1,2,3]
 
 array.index arr 0 #Int== 1
@@ -18,7 +18,7 @@ true
 
 test_expr!{ array_byte,
 r#"
-let array = import! std.array
+let array = import! std.array.prim
 let arr = [1b,2b,3b]
 
 let b = array.index arr 2 #Byte== 3b && array.len arr #Int== 3
@@ -31,7 +31,7 @@ true
 
 test_expr!{ array_float,
 r#"
-let array = import! std.array
+let array = import! std.array.prim
 let arr = [1.0,2.0,3.0]
 
 let b = array.index arr 2 #Float== 3.0 && array.len arr #Int== 3
@@ -44,7 +44,7 @@ true
 
 test_expr!{ array_data,
 r#"
-let array = import! std.array
+let array = import! std.array.prim
 let arr = [{x = 1, y = "a" }, { x = 2, y = "b" }]
 
 let b = (array.index arr 1).x #Int== 2 && array.len arr #Int== 2
@@ -56,7 +56,7 @@ true
 
 test_expr!{ array_array,
 r#"
-let array = import! std.array
+let array = import! std.array.prim
 let arr = [[], [1], [2, 3]]
 
 let b = array.len (array.index arr 1) #Int== 1 && array.len arr #Int== 3
@@ -69,7 +69,7 @@ true
 // Test that empty variants are handled correctly in arrays
 test_expr!{ array_empty_variant,
 r#"
-let array = import! std.array
+let array = import! std.array.prim
 type Test = | Empty | Some Int
 let arr = [Empty, Some 1]
 match array.index arr 0 with
@@ -82,7 +82,7 @@ match array.index arr 0 with
 // Test that array append handles array types correctly
 test_expr!{ array_empty_append,
 r#"
-let array = import! std.array
+let array = import! std.array.prim
 type Test = | Empty | Some Int
 let arr = array.append [] [Empty, Some 1]
 match array.index arr 0 with

--- a/tests/compile-fail/getable-reference-str.rs
+++ b/tests/compile-fail/getable-reference-str.rs
@@ -1,6 +1,8 @@
 extern crate gluon;
 use gluon::new_vm;
-use gluon::vm::thread::{Thread, Status};
+use gluon::import::add_extern_module;
+use gluon::vm::ExternModule;
+use gluon::vm::thread::{Status, Thread};
 use gluon::vm::api::primitive_f;
 
 extern "C" fn dummy(_: &Thread) -> Status {
@@ -11,6 +13,8 @@ fn f(_: &'static str) {}
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     let vm = new_vm();
-    vm.define_global("test", unsafe { primitive_f("f", dummy, f as fn (_)) });
-    //~^ Error `vm` does not live long enough
+    add_extern_module(&vm, "test", |vm| {
+        ExternModule::new(vm, unsafe { primitive_f("f", dummy, f as fn (_)) })
+        //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
+    });
 }

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -1,8 +1,10 @@
 extern crate gluon;
 use gluon::new_vm;
-use gluon::vm::thread::{Thread, Status};
+use gluon::import::add_extern_module;
+use gluon::vm::ExternModule;
+use gluon::vm::thread::{Status, Thread};
 use gluon::vm::gc::{Gc, Traverseable};
-use gluon::vm::api::{VmType, Userdata, primitive_f};
+use gluon::vm::api::{primitive_f, Userdata, VmType};
 
 #[derive(Debug)]
 struct Test;
@@ -25,6 +27,8 @@ fn f(_: &'static Test) {}
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     let vm = new_vm();
-    vm.define_global("test", unsafe { primitive_f("f", dummy, f as fn (_)) });
-    //~^ Error `vm` does not live long enough
+    add_extern_module(&vm, "test", |vm| {
+        ExternModule::new(vm, unsafe { primitive_f("f", dummy, f as fn (_)) })
+        //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
+    });
 }

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -3,8 +3,10 @@ use std::fmt;
 use std::sync::Mutex;
 
 use gluon::new_vm;
-use gluon::vm::thread::{Thread, Status};
-use gluon::vm::api::{Userdata, VmType, primitive_f};
+use gluon::import::add_extern_module;
+use gluon::vm::ExternModule;
+use gluon::vm::thread::{Status, Thread};
+use gluon::vm::api::{primitive_f, Userdata, VmType};
 use gluon::vm::gc::Traverseable;
 
 struct Test<'vm>(Mutex<&'vm str>);
@@ -33,6 +35,8 @@ fn f<'vm>(test: &'vm Test<'vm>, s: &'vm str) {
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     let vm = new_vm();
-    vm.define_global("test", unsafe { primitive_f("f", dummy, f as fn (_, _)) });
-    //~^ `vm` does not live long enough
+    add_extern_module(&vm, "test", |vm| {
+        ExternModule::new(vm, unsafe { primitive_f("f", dummy, f as fn (_, _)) })
+        //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
+    });
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -21,7 +21,7 @@ fn bool() {
         .run_expr::<De<bool>>(
             &thread,
             "test",
-            r#"let { Bool } = import! "std/bool.glu" in True"#,
+            r#"let { Bool } = import! std.bool in True"#,
         )
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(b, true);
@@ -63,7 +63,7 @@ fn option() {
         .run_expr::<De<Option<f64>>>(
             &thread,
             "test",
-            r#"let { Option } = import! "std/option.glu" in Some 1.0 "#,
+            r#"let { Option } = import! std.option in Some 1.0 "#,
         )
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(opt, Some(1.0));
@@ -131,7 +131,7 @@ fn optional_field() {
         .run_expr::<OpaqueValue<&Thread, Hole>>(
             &thread,
             "test",
-            r#"let { Option } = import! "std/option.glu" in { test = Some 2 } "#,
+            r#"let { Option } = import! std.option in { test = Some 2 } "#,
         )
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(

--- a/tests/fail/unwrap.glu
+++ b/tests/fail/unwrap.glu
@@ -1,3 +1,3 @@
-let { Option, unwrap }  = import! "std/option.glu"
+let { Option, unwrap }  = import! std.option
 
 unwrap None

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -46,8 +46,8 @@ fn read_file() {
 test_expr!{ no_io_eval,
 r#"
 let { error } = import! std.prim
-let io = import! std.io
-let x = io_flat_map (\x -> error "NOOOOOOOO") (io.println "1")
+let io = import! std.io.prim
+let x = io.flat_map (\x -> error "NOOOOOOOO") (io.println "1")
 in { x }
 "#
 }
@@ -84,8 +84,8 @@ fn run_expr_int() {
 
 test_expr!{ io run_expr_io,
 r#"
-let io = import! std.io
-io_flat_map (\x -> io_wrap 100)
+let io = import! std.io.prim
+io.flat_map (\x -> io.wrap 100)
             (io.run_expr "
                 let io = import! \"std/io.glu\"
                 io.print \"123\"

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -17,10 +17,10 @@ fn read_file() {
 
     let thread = new_vm();
     let text = r#"
-        let prelude = import! "std/prelude.glu"
+        let prelude = import! std.prelude
         let array = import! "array"
-        let { assert }  = import! "std/test.glu"
-        let io = import! "std/io.glu"
+        let { assert }  = import! std.test
+        let io = import! std.io
         let { wrap } = io.applicative
         let { (>>=) } = prelude.make_Monad io.monad
 
@@ -45,7 +45,7 @@ fn read_file() {
 
 test_expr!{ no_io_eval,
 r#"
-let io = import! "std/io.glu"
+let io = import! std.io
 let x = io_flat_map (\x -> error "NOOOOOOOO") (io.println "1")
 in { x }
 "#
@@ -53,7 +53,7 @@ in { x }
 
 test_expr!{ io_print,
 r#"
-let io = import! "std/io.glu"
+let io = import! std.io
 io.print "123"
 "#
 }
@@ -63,7 +63,7 @@ fn run_expr_int() {
     let _ = ::env_logger::init();
 
     let text = r#"
-        let io = import! "std/io.glu"
+        let io = import! std.io
         io.run_expr "123"
     "#;
     let mut vm = make_vm();
@@ -83,7 +83,7 @@ fn run_expr_int() {
 
 test_expr!{ io run_expr_io,
 r#"
-let io = import! "std/io.glu"
+let io = import! std.io
 io_flat_map (\x -> io_wrap 100)
             (io.run_expr "
                 let io = import! \"std/io.glu\"
@@ -99,8 +99,8 @@ fn dont_execute_io_in_run_expr_async() {
     let _ = ::env_logger::init();
     let vm = make_vm();
     let expr = r#"
-let prelude  = import! "std/prelude.glu"
-let io = import! "std/io.glu"
+let prelude  = import! std.prelude
+let io = import! std.io
 let { wrap } = io.applicative
 wrap 123
 "#;

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -45,6 +45,7 @@ fn read_file() {
 
 test_expr!{ no_io_eval,
 r#"
+let { error } = import! std.prim
 let io = import! std.io
 let x = io_flat_map (\x -> error "NOOOOOOOO") (io.println "1")
 in { x }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -18,7 +18,7 @@ fn read_file() {
     let thread = new_vm();
     let text = r#"
         let prelude = import! std.prelude
-        let array = import! "array"
+        let array = import! std.array
         let { assert }  = import! std.test
         let io = import! std.io
         let { wrap } = io.applicative

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -17,7 +17,8 @@ fn read_file() {
 
     let thread = new_vm();
     let text = r#"
-        let prelude  = import! "std/prelude.glu"
+        let prelude = import! "std/prelude.glu"
+        let array = import! "array"
         let { assert }  = import! "std/test.glu"
         let io = import! "std/io.glu"
         let { wrap } = io.applicative

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -59,8 +59,7 @@ fn main_() -> Result<(), Box<Error>> {
     };
 
     let vm = new_vm();
-    let mut compiler = Compiler::new();
-    compiler
+    Compiler::new()
         .load_file_async(&vm, "std/prelude.glu")
         .sync_or_error()?;
     let mut text = String::new();
@@ -68,6 +67,8 @@ fn main_() -> Result<(), Box<Error>> {
     let iter = test_files("tests/pass")?.into_iter().filter(|filename| {
         filter.map_or(true, |filter| filename.to_string_lossy().contains(filter))
     });
+
+    let mut compiler = Compiler::new();
     for filename in iter {
         let mut file = File::open(&filename)?;
         text.clear();

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -21,7 +21,7 @@ fn metadata_from_other_module() {
     let _ = ::env_logger::init();
     let vm = make_vm();
     let text = r#"
-let { List, of }  = import! "std/list.glu"
+let { List, of }  = import! std.list
 { List, of }
 "#;
     Compiler::new()

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -21,8 +21,17 @@ fn parallel() {
 fn parallel_() -> Result<(), Error> {
     let vm = new_vm();
     let mut compiler = Compiler::new();
+
+    compiler
+        .run_expr_async::<()>(&vm, "<top>", " let _ = import! std.channel in () ")
+        .sync_or_error()?;
+
     let (value, _) = compiler
-        .run_expr_async(&vm, "<top>", " channel 0 ")
+        .run_expr_async(
+            &vm,
+            "<top>",
+            " let { channel } = import! std.channel in channel 0 ",
+        )
         .sync_or_error()?;
     let record_p!{ sender, receiver }: ChannelRecord<
         OpaqueValue<RootedThread, Sender<i32>>,
@@ -32,6 +41,7 @@ fn parallel_() -> Result<(), Error> {
     let child = vm.new_thread()?;
     let handle1 = spawn(move || -> Result<(), Error> {
         let expr = r#"
+        let { send } = import! std.channel
         let f sender =
             send sender 1
             send sender 2
@@ -52,6 +62,7 @@ fn parallel_() -> Result<(), Error> {
         let { assert }  = import! std.test
         let { Bool } = import! std.bool
         let { Result }  = import! std.result
+        let { recv } = import! std.channel
 
         let f receiver =
             match recv receiver with

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -49,9 +49,9 @@ fn parallel_() -> Result<(), Error> {
     let child2 = vm.new_thread()?;
     let handle2 = spawn(move || -> Result<(), Error> {
         let expr = r#"
-        let { assert }  = import! "std/test.glu"
-        let { Bool } = import! "std/bool.glu"
-        let { Result }  = import! "std/result.glu"
+        let { assert }  = import! std.test
+        let { Bool } = import! std.bool
+        let { Result }  = import! std.result
 
         let f receiver =
             match recv receiver with

--- a/tests/pass/alternative.glu
+++ b/tests/pass/alternative.glu
@@ -1,9 +1,9 @@
-let { run, writer, assert_eq }  = import! "std/test.glu"
-let prelude  = import! "std/prelude.glu"
+let { run, writer, assert_eq }  = import! std.test
+let prelude  = import! std.prelude
 let { (*>) } = prelude.make_Applicative writer.applicative
-let int = import! "std/int.glu"
-let list = import! "std/list.glu"
-let option = import! "std/option.glu"
+let int = import! std.int
+let list = import! std.list
+let option = import! std.option
 
 let test_alt show eq alt =
     let { (<|>), or, empty } = prelude.make_Alternative alt

--- a/tests/pass/arithmetic.glu
+++ b/tests/pass/arithmetic.glu
@@ -1,8 +1,8 @@
-let { run, writer, assert, assert_ieq, assert_feq }  = import! "std/test.glu"
-let prelude  = import! "std/prelude.glu"
+let { run, writer, assert, assert_ieq, assert_feq }  = import! std.test
+let prelude  = import! std.prelude
 let { (*>) } = prelude.make_Applicative writer.applicative
-let int = import! "std/int.glu"
-let float = import! "std/float.glu"
+let int = import! std.int
+let float = import! std.float
 
 let int_tests =
     let { (+), (-), (*) } = int.num

--- a/tests/pass/channel.glu
+++ b/tests/pass/channel.glu
@@ -5,6 +5,7 @@ let int = import! std.int
 let result = import! std.result
 let { Result } = result
 let unit = import! std.unit
+let { send, recv, channel } = import! std.channel
 
 let assert =
     assert_eq (result.show unit.show int.show )

--- a/tests/pass/channel.glu
+++ b/tests/pass/channel.glu
@@ -1,10 +1,10 @@
-let { run, writer, assert_eq }  = import! "std/test.glu"
-let prelude  = import! "std/prelude.glu"
+let { run, writer, assert_eq }  = import! std.test
+let prelude  = import! std.prelude
 let { (*>) } = prelude.make_Applicative writer.applicative
-let int = import! "std/int.glu"
-let result = import! "std/result.glu"
+let int = import! std.int
+let result = import! std.result
 let { Result } = result
-let unit = import! "std/unit.glu"
+let unit = import! std.unit
 
 let assert =
     assert_eq (result.show unit.show int.show )

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -1,7 +1,7 @@
-let { run, writer, assert, assert_ieq, assert_feq } = import! "std/test.glu"
-let prelude = import! "std/prelude.glu"
+let { run, writer, assert, assert_ieq, assert_feq } = import! std.test
+let prelude = import! std.prelude
 let { (*>) } = prelude.make_Applicative writer.applicative
-let { Result } = import! "std/result.glu"
+let { Result } = import! std.result
 let { ref, load } = import! "reference"
 let { lazy, force } = import! "lazy"
 

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -1,25 +1,25 @@
-let { run, writer, assert, assert_ieq, assert_feq }  = import! "std/test.glu"
-let prelude  = import! "std/prelude.glu"
+let { run, writer, assert, assert_ieq, assert_feq } = import! "std/test.glu"
+let prelude = import! "std/prelude.glu"
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { Result } = import! "std/result.glu"
+let { ref, load } = import! "reference"
+let { lazy, force } = import! "lazy"
 
 
 let _ =
     let { sender, receiver } = channel (lazy (\_ -> 0))
 
     let thread = spawn (\_ ->
-        send sender (lazy (\_ -> 1))
-        let l = lazy (\_ -> 2)
-        force l
-        send sender l
-        ())
+            send sender (lazy (\_ -> 1))
+            let l = lazy (\_ -> 2)
+            force l
+            send sender l
+            ())
 
     resume thread
-
     match recv receiver with
     | Ok x -> assert (force x == 1)
     | Err e -> error "Receive 1 error"
-
     match recv receiver with
     | Ok x -> assert (force x == 2)
     | Err e -> error "Receive 2 error"
@@ -28,11 +28,10 @@ let _ =
     let { sender, receiver } = channel (ref 0)
 
     let thread = spawn (\_ ->
-        send sender (ref 3)
-        ())
+            send sender (ref 3)
+            ())
 
     resume thread
-
     match recv receiver with
     | Ok x -> assert (load x == 3)
     | Err e -> error "Receive 3 error"

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -2,8 +2,8 @@ let { run, writer, assert, assert_ieq, assert_feq } = import! std.test
 let prelude = import! std.prelude
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { Result } = import! std.result
-let { ref, load } = import! "reference"
-let { lazy, force } = import! "lazy"
+let { ref, load } = import! std.reference
+let { lazy, force } = import! std.lazy
 
 
 let _ =

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -4,6 +4,8 @@ let { (*>) } = prelude.make_Applicative writer.applicative
 let { Result } = import! std.result
 let { ref, load } = import! std.reference
 let { lazy, force } = import! std.lazy
+let { channel, send, recv } = import! std.channel
+let { resume, spawn } = import! std.thread
 
 
 let _ =

--- a/tests/pass/lazy.glu
+++ b/tests/pass/lazy.glu
@@ -3,7 +3,7 @@ let prelude = import! std.prelude
 let { (*>), wrap } = prelude.make_Applicative writer.applicative
 let int = import! std.int
 let { (+), (-), (*) } = int.num
-let { lazy, force } = import! "lazy"
+let { lazy, force } = import! std.lazy
 
 let l = lazy (\_ -> 123 + 57)
 

--- a/tests/pass/lazy.glu
+++ b/tests/pass/lazy.glu
@@ -1,11 +1,11 @@
-let { run, writer, assert_ieq }  = import! "std/test.glu"
-let prelude  = import! "std/prelude.glu"
+let { run, writer, assert_ieq } = import! "std/test.glu"
+let prelude = import! "std/prelude.glu"
 let { (*>), wrap } = prelude.make_Applicative writer.applicative
 let int = import! "std/int.glu"
 let { (+), (-), (*) } = int.num
+let { lazy, force } = import! "lazy"
 
 let l = lazy (\_ -> 123 + 57)
 
-assert_ieq (force (lazy (\_ -> 2))) 2
-    *> wrap ()
+assert_ieq (force (lazy (\_ -> 2))) 2 *> wrap ()
     *> assert_ieq 180 (force l)

--- a/tests/pass/lazy.glu
+++ b/tests/pass/lazy.glu
@@ -1,7 +1,7 @@
-let { run, writer, assert_ieq } = import! "std/test.glu"
-let prelude = import! "std/prelude.glu"
+let { run, writer, assert_ieq } = import! std.test
+let prelude = import! std.prelude
 let { (*>), wrap } = prelude.make_Applicative writer.applicative
-let int = import! "std/int.glu"
+let int = import! std.int
 let { (+), (-), (*) } = int.num
 let { lazy, force } = import! "lazy"
 

--- a/tests/pass/lisp.glu
+++ b/tests/pass/lisp.glu
@@ -1,13 +1,13 @@
-let prelude = import! "std/prelude.glu"
-let { Test, run, writer, assert_eq, assert_seq, assert_ieq } = import! "std/test.glu"
+let prelude = import! std.prelude
+let { Test, run, writer, assert_eq, assert_seq, assert_ieq } = import! std.test
 let { (*>) } = prelude.make_Applicative writer.applicative
-let list = import! "std/list.glu"
+let list = import! std.list
 let { List } = list
 
-let result = import! "std/result.glu"
+let result = import! std.result
 let { Result } = result
-let string = import! "std/string.glu"
-let parser = import! "std/parser.glu"
+let string = import! std.string
+let parser = import! std.parser
 
 let lisp = import! "examples/lisp/lisp.glu"
 let { Expr } = lisp

--- a/tests/pass/list.glu
+++ b/tests/pass/list.glu
@@ -1,8 +1,8 @@
-let prelude  = import! "std/prelude.glu"
-let { Test, run, writer, assert, assert_eq }  = import! "std/test.glu"
+let prelude  = import! std.prelude
+let { Test, run, writer, assert, assert_eq }  = import! std.test
 let { (*>) } = prelude.make_Applicative writer.applicative
-let int = import! "std/int.glu"
-let list = import! "std/list.glu"
+let int = import! std.int
+let list = import! std.list
 let { List } = list
 
 let assert_list show eq = assert_eq (list.show show) (list.eq eq)

--- a/tests/pass/map.glu
+++ b/tests/pass/map.glu
@@ -1,15 +1,15 @@
-let prelude  = import! "std/prelude.glu"
+let prelude  = import! std.prelude
 let { Eq, Show } = prelude
-let int = import! "std/int.glu"
-let option = import! "std/option.glu"
+let int = import! std.int
+let option = import! std.option
 let { Option } = option
-let string  = import! "std/string.glu"
+let string  = import! std.string
 let { (==) } = string.eq
 let { (<>) } = prelude.make_Semigroup string.semigroup
-let { Test, run, writer, assert, assert_eq }  = import! "std/test.glu"
-let map  = import! "std/map.glu"
+let { Test, run, writer, assert, assert_eq }  = import! std.test
+let map  = import! std.map
 let { (*>) } = prelude.make_Applicative writer.applicative
-let list = import! "std/list.glu"
+let list = import! std.list
 let { List } = list
 
 let show_Entry : Show { key : String, value : Int } = {

--- a/tests/pass/parser.glu
+++ b/tests/pass/parser.glu
@@ -1,12 +1,12 @@
-let prelude = import! "std/prelude.glu"
-let char = import! "std/char.glu"
-let string = import! "std/string.glu"
-let result = import! "std/result.glu"
+let prelude = import! std.prelude
+let char = import! std.char
+let string = import! std.string
+let result = import! std.result
 let { Result } = result
-let { Test, run, writer, assert, assert_eq } = import! "std/test.glu"
-let { Writer } = import! "std/writer.glu"
+let { Test, run, writer, assert, assert_eq } = import! std.test
+let { Writer } = import! std.writer
 
-let { Parser, applicative, functor, alternative, monad, any, parse } = import! "std/parser.glu"
+let { Parser, applicative, functor, alternative, monad, any, parse } = import! std.parser
 let { (*>), wrap } = prelude.make_Applicative applicative
 let { (<|>) } = prelude.make_Alternative alternative
 

--- a/tests/pass/reference.glu
+++ b/tests/pass/reference.glu
@@ -2,7 +2,7 @@ let { assert } = import! std.test
 let int = import! std.int
 let { (==) } = int.eq
 let { Bool } = import! std.bool
-let { ref, (<-), load } = import! "reference"
+let { ref, (<-), load } = import! std.reference
 
 let ri = ref 0
 assert (0 == load ri)

--- a/tests/pass/reference.glu
+++ b/tests/pass/reference.glu
@@ -1,7 +1,7 @@
-let { assert } = import! "std/test.glu"
-let int = import! "std/int.glu"
+let { assert } = import! std.test
+let int = import! std.int
 let { (==) } = int.eq
-let { Bool } = import! "std/bool.glu"
+let { Bool } = import! std.bool
 let { ref, (<-), load } = import! "reference"
 
 let ri = ref 0

--- a/tests/pass/reference.glu
+++ b/tests/pass/reference.glu
@@ -1,7 +1,8 @@
-let { assert }  = import! "std/test.glu"
+let { assert } = import! "std/test.glu"
 let int = import! "std/int.glu"
 let { (==) } = int.eq
 let { Bool } = import! "std/bool.glu"
+let { ref, (<-), load } = import! "reference"
 
 let ri = ref 0
 assert (0 == load ri)

--- a/tests/pass/state.glu
+++ b/tests/pass/state.glu
@@ -1,9 +1,9 @@
-let prelude  = import! "std/prelude.glu"
+let prelude  = import! std.prelude
 let { Monad, Num } = prelude
-let { Test, run, writer, assert, assert_ieq, assert_feq, assert_seq }  = import! "std/test.glu"
-let int = import! "std/int.glu"
-let state  = import! "std/state.glu"
-let { State, put, get, modify, runState, evalState, execState }  = import! "std/state.glu"
+let { Test, run, writer, assert, assert_ieq, assert_feq, assert_seq }  = import! std.test
+let int = import! std.int
+let state  = import! std.state
+let { State, put, get, modify, runState, evalState, execState }  = import! std.state
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { (*>) } = prelude.make_Applicative state.applicative
 let { (+), (-), (*) } = int.num

--- a/tests/pass/stream.glu
+++ b/tests/pass/stream.glu
@@ -1,14 +1,14 @@
-let prelude = import! "std/prelude.glu"
-let { run, writer, assert_eq, assert_ieq } = import! "std/test.glu"
-let int = import! "std/int.glu"
-let stream  = import! "std/stream.glu"
+let prelude = import! std.prelude
+let { run, writer, assert_eq, assert_ieq } = import! std.test
+let int = import! std.int
+let stream  = import! std.stream
 let { Ord, Num } = prelude
 let { (<) } = prelude.make_Ord int.ord
 let { (+) } = int.num
 let { (*>) } = prelude.make_Applicative writer.applicative
-let list = import! "std/list.glu"
+let list = import! std.list
 let { List } = list
-let { Option } = import! "std/option.glu"
+let { Option } = import! std.option
 
 let s = stream.from (\i -> if i < 5 then Some i else None)
 

--- a/tests/pass/string.glu
+++ b/tests/pass/string.glu
@@ -1,18 +1,18 @@
-let prelude  = import! "std/prelude.glu"
-let { run, writer, assert_eq, assert_seq, assert_ieq }  = import! "std/test.glu"
-let int = import! "std/int.glu"
+let prelude  = import! std.prelude
+let { run, writer, assert_eq, assert_seq, assert_ieq }  = import! std.test
+let int = import! std.int
 let { (<) } = prelude.make_Ord int.ord
 let { (+) } = int.num
 let { (*>) } = prelude.make_Applicative writer.applicative
 
-let bool = import! "std/bool.glu"
+let bool = import! std.bool
 let { Bool } = bool
-let option = import! "std/option.glu"
+let option = import! std.option
 let { Option } = option
-let string = import! "std/string.glu"
-let result = import! "std/result.glu"
+let string = import! std.string
+let result = import! std.result
 let { Result } = result
-let unit = import! "std/unit.glu"
+let unit = import! std.unit
 
 let assert_oieq = assert_eq (option.show int.show) (option.eq int.eq)
 let assert_beq = assert_eq bool.show bool.eq

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -1,11 +1,11 @@
-let { run, writer, assert_eq }  = import! "std/test.glu"
-let prelude  = import! "std/prelude.glu"
-let { Bool } = import! "std/bool.glu"
-let int = import! "std/int.glu"
-let result = import! "std/result.glu"
+let { run, writer, assert_eq }  = import! std.test
+let prelude  = import! std.prelude
+let { Bool } = import! std.bool
+let int = import! std.int
+let result = import! std.result
 let { Result } = result
-let string = import! "std/string.glu"
-let unit = import! "std/unit.glu"
+let string = import! std.string
+let unit = import! std.unit
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { (>>=) } = prelude.make_Monad writer.monad
 

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -8,6 +8,8 @@ let string = import! std.string
 let unit = import! std.unit
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { (>>=) } = prelude.make_Monad writer.monad
+let { send, recv, channel } = import! std.channel
+let { spawn, yield, resume } = import! std.thread
 
 let assert =
     assert_eq (result.show unit.show int.show) (result.eq unit.eq int.eq)

--- a/tests/pass/unwrap.glu
+++ b/tests/pass/unwrap.glu
@@ -1,7 +1,7 @@
-let { (|>) } = import! "std/function.glu"
-let { Option, unwrap } = import! "std/option.glu"
-let { Result, unwrap_ok, unwrap_err } = import! "std/result.glu"
-let { assert_ieq }  = import! "std/test.glu"
+let { (|>) } = import! std.function
+let { Option, unwrap } = import! std.option
+let { Result, unwrap_ok, unwrap_err } = import! std.result
+let { assert_ieq }  = import! std.test
 
 let one = Some 1 |> unwrap
 assert_ieq one 1

--- a/tests/pass/writer.glu
+++ b/tests/pass/writer.glu
@@ -1,7 +1,7 @@
-let prelude  = import! "std/prelude.glu"
-let list  = import! "std/list.glu"
-let { Writer }  = import! "std/writer.glu"
-let { Test, run, writer, assert, assert_ieq, assert_feq }  = import! "std/test.glu"
+let prelude  = import! std.prelude
+let list  = import! std.list
+let { Writer }  = import! std.writer
+let { Test, run, writer, assert, assert_ieq, assert_feq }  = import! std.test
 let { (*>) } = prelude.make_Applicative writer.applicative
 let { count } = prelude.make_Foldable list.foldable
 

--- a/tests/pattern_match.rs
+++ b/tests/pattern_match.rs
@@ -10,7 +10,7 @@ use support::*;
 
 test_expr!{ prelude match_on_bool,
 r#"
-let { Bool } = import! "std/bool.glu"
+let { Bool } = import! std.bool
 match True with
 | False -> 10
 | True -> 11

--- a/tests/pattern_match.rs
+++ b/tests/pattern_match.rs
@@ -35,7 +35,7 @@ match A with
 
 test_expr!{ match_record_pattern,
 r#"
-let string_prim = import! "string_prim"
+let string_prim = import! std.string.prim
 match { x = 1, y = "abc" } with
 | { x, y = z } -> x #Int+ string_prim.len z
 "#,
@@ -44,7 +44,7 @@ match { x = 1, y = "abc" } with
 
 test_expr!{ match_stack,
 r#"
-let string_prim = import! "string_prim"
+let string_prim = import! std.string.prim
 1 #Int+ (match string_prim with
          | { len } -> len "abc")
 "#,
@@ -53,7 +53,7 @@ let string_prim = import! "string_prim"
 
 test_expr!{ let_record_pattern,
 r#"
-let string_prim = import! "string_prim"
+let string_prim = import! std.string.prim
 let (+) x y = x #Int+ y
 in
 let a = { x = 10, y = "abc" }

--- a/tests/pattern_match.rs
+++ b/tests/pattern_match.rs
@@ -35,6 +35,7 @@ match A with
 
 test_expr!{ match_record_pattern,
 r#"
+let string_prim = import! "string_prim"
 match { x = 1, y = "abc" } with
 | { x, y = z } -> x #Int+ string_prim.len z
 "#,
@@ -43,6 +44,7 @@ match { x = 1, y = "abc" } with
 
 test_expr!{ match_stack,
 r#"
+let string_prim = import! "string_prim"
 1 #Int+ (match string_prim with
          | { len } -> len "abc")
 "#,
@@ -51,6 +53,7 @@ r#"
 
 test_expr!{ let_record_pattern,
 r#"
+let string_prim = import! "string_prim"
 let (+) x y = x #Int+ y
 in
 let a = { x = 10, y = "abc" }

--- a/tests/regex_bind.rs
+++ b/tests/regex_bind.rs
@@ -10,6 +10,7 @@ fn regex_match() {
 
     let thread = new_vm();
     let text = r#"
+        let regex = import! std.regex
         let { (|>) } = import! std.function
         let { not } = import! std.bool
         let { unwrap_ok } = import! std.result
@@ -25,7 +26,7 @@ fn regex_match() {
         .run_expr_async::<bool>(&thread, "<top>", text)
         .sync_or_error();
 
-    assert!(result.unwrap().0);
+    assert!(result.unwrap_or_else(|err| panic!("{}", err)).0);
 }
 
 #[test]
@@ -34,6 +35,7 @@ fn regex_error() {
 
     let thread = new_vm();
     let text = r#"
+        let regex = import! std.regex
         let { (|>) } = import! std.function
         let { unwrap_err } = import! std.result
 
@@ -44,7 +46,7 @@ fn regex_error() {
         .sync_or_error();
 
     assert_eq!(
-        result.unwrap().0,
+        result.unwrap_or_else(|err| panic!("{}", err)).0,
         "Error parsing regex near \')\' at character offset 0: Unopened parenthesis."
     );
 }

--- a/tests/regex_bind.rs
+++ b/tests/regex_bind.rs
@@ -10,10 +10,10 @@ fn regex_match() {
 
     let thread = new_vm();
     let text = r#"
-        let { (|>) } = import! "std/function.glu"
-        let { not } = import! "std/bool.glu"
-        let { unwrap_ok } = import! "std/result.glu"
-        let { assert }  = import! "std/test.glu"
+        let { (|>) } = import! std.function
+        let { not } = import! std.bool
+        let { unwrap_ok } = import! std.result
+        let { assert }  = import! std.test
 
         let match_a = regex.new "a" |> unwrap_ok
         assert (regex.is_match match_a "a")
@@ -34,8 +34,8 @@ fn regex_error() {
 
     let thread = new_vm();
     let text = r#"
-        let { (|>) } = import! "std/function.glu"
-        let { unwrap_err } = import! "std/result.glu"
+        let { (|>) } = import! std.function
+        let { unwrap_err } = import! std.result
 
         regex.new ")" |> unwrap_err |> regex.error_to_string
         "#;

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -12,14 +12,14 @@ use support::*;
 
 fn verify_value_cloned(from: &Thread, to: &Thread) {
     Compiler::new()
-        .run_expr::<()>(&from, "load", r#"let _ = import! "reference" in () "#)
+        .run_expr::<()>(&from, "load", r#"let _ = import! std.reference in () "#)
         .unwrap_or_else(|err| panic!("{}", err));
     Compiler::new()
-        .run_expr::<()>(&to, "load", r#"let _ = import! "reference" in () "#)
+        .run_expr::<()>(&to, "load", r#"let _ = import! std.reference in () "#)
         .unwrap_or_else(|err| panic!("{}", err));
 
     let expr = r#"
-        let { ref } = import! "reference"
+        let { ref } = import! std.reference
         ref 0
         "#;
 
@@ -31,7 +31,7 @@ fn verify_value_cloned(from: &Thread, to: &Thread) {
     // Load the prelude
     type Fn<'t> = FunctionRef<'t, fn(OpaqueValue<RootedThread, Reference<i32>>)>;
     let store_expr = r#"
-        let { (<-) } = import! "reference"
+        let { (<-) } = import! std.reference
         \r -> r <- 1
         "#;
     let (mut store_1, _) = Compiler::new()
@@ -41,7 +41,7 @@ fn verify_value_cloned(from: &Thread, to: &Thread) {
     assert_eq!(store_1.call(value.clone()), Ok(()));
 
     let mut load: FunctionRef<fn(OpaqueValue<RootedThread, Reference<i32>>) -> i32> =
-        from.get_global("reference.load").unwrap();
+        from.get_global("std.reference.load").unwrap();
     assert_eq!(load.call(value), Ok(0));
 }
 

--- a/tests/safety.rs
+++ b/tests/safety.rs
@@ -11,7 +11,10 @@ use gluon::{Compiler, RootedThread, Thread};
 use support::*;
 
 fn verify_value_cloned(from: &Thread, to: &Thread) {
-    let expr = r#" ref 0 "#;
+    let expr = r#"
+        let { ref } = import! "reference"
+        ref 0
+        "#;
 
     let (value, _) = Compiler::new()
         .run_expr_async::<OpaqueValue<RootedThread, Reference<i32>>>(&from, "example", expr)
@@ -20,14 +23,18 @@ fn verify_value_cloned(from: &Thread, to: &Thread) {
 
     // Load the prelude
     type Fn<'t> = FunctionRef<'t, fn(OpaqueValue<RootedThread, Reference<i32>>)>;
+    let store_expr = r#"
+        let { (<-) } import! "reference"
+        \r -> r <- 1
+        "#;
     let (mut store_1, _) = Compiler::new()
-        .run_expr_async::<Fn>(&to, "store_1", r#"\r -> r <- 1"#)
+        .run_expr_async::<Fn>(&to, "store_1", store_expr)
         .sync_or_error()
         .unwrap();
     assert_eq!(store_1.call(value.clone()), Ok(()));
 
     let mut load: FunctionRef<fn(OpaqueValue<RootedThread, Reference<i32>>) -> i32> =
-        from.get_global("load").unwrap();
+        from.get_global("reference.load").unwrap();
     assert_eq!(load.call(value), Ok(0));
 }
 

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -92,7 +92,7 @@ fn roundtrip_recursive_closure() {
 #[test]
 fn roundtrip_std_prelude() {
     let thread = new_vm();
-    let expr = r#" import! "std/prelude.glu" "#;
+    let expr = r#" import! std.prelude "#;
     let (value, _) = Compiler::new()
         .run_expr::<OpaqueValue<&Thread, Hole>>(&thread, "test", expr)
         .unwrap();

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -164,3 +164,23 @@ fn precompile() {
         serialize_value(&thread, &precompiled_result.value)
     );
 }
+
+#[test]
+fn roundtrip_reference() {
+    let thread = new_vm();
+    let expr = r#" import! std.reference "#;
+    let (value, _) = Compiler::new()
+        .run_expr::<OpaqueValue<&Thread, Hole>>(&thread, "test", &expr)
+        .unwrap_or_else(|err| panic!("{}", err));
+    roundtrip(&thread, &value);
+}
+
+#[test]
+fn roundtrip_lazy() {
+    let thread = new_vm();
+    let expr = r#" import! std.lazy "#;
+    let (value, _) = Compiler::new()
+        .run_expr::<OpaqueValue<&Thread, Hole>>(&thread, "test", &expr)
+        .unwrap_or_else(|err| panic!("{}", err));
+    roundtrip(&thread, &value);
+}

--- a/tests/tutorial.rs
+++ b/tests/tutorial.rs
@@ -25,7 +25,7 @@ fn access_field_through_alias() {
     let _ = ::env_logger::init();
     let vm = new_vm();
     Compiler::new()
-        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example", r#" import! "std/int.glu" "#)
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example", r#" import! std.int "#)
         .sync_or_error()
         .unwrap();
     let mut add: FunctionRef<fn(i32, i32) -> i32> = vm.get_global("std.int.num.(+)").unwrap();

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -301,6 +301,7 @@ Value::Tag(1)
 
 test_expr!{ any marshalled_option_none_is_int,
 r#"
+import! "string_prim"
 string_prim.find "a" "b"
 "#,
 Value::Tag(0)
@@ -308,6 +309,7 @@ Value::Tag(0)
 
 test_expr!{ any marshalled_ordering_is_int,
 r#"
+import! "string_prim"
 string_compare "a" "b"
 "#,
 Value::Tag(0)
@@ -343,7 +345,10 @@ in (id { x = 1 }).x
 }
 
 test_expr!{ module_function,
-r#"let x = string_prim.len "test" in x"#,
+r#"
+import! "string_prim"
+let x = string_prim.len "test" in x
+"#,
 4i32
 }
 
@@ -696,6 +701,7 @@ fn completion_with_prelude() {
 let prelude  = import! "std/prelude.glu"
 and { Option } = import! "std/option.glu"
 and { Num } = prelude
+let { lazy } = import! "lazy"
 
 type Stream_ a =
     | Value a (Stream a)
@@ -722,7 +728,7 @@ let from f : (Int -> Option a) -> Stream a =
     let result = completion::find(
         &*vm.get_env(),
         &expr,
-        lines.offset(13.into(), 29.into()).unwrap(),
+        lines.offset(14.into(), 29.into()).unwrap(),
     );
     assert_eq!(result, Ok(Type::int()));
 }

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -301,7 +301,7 @@ Value::Tag(1)
 
 test_expr!{ any marshalled_option_none_is_int,
 r#"
-import! "string_prim"
+let string_prim = import! std.string.prim
 string_prim.find "a" "b"
 "#,
 Value::Tag(0)
@@ -309,7 +309,7 @@ Value::Tag(0)
 
 test_expr!{ any marshalled_ordering_is_int,
 r#"
-import! "string_prim"
+let { string_compare } = import! std.prim
 string_compare "a" "b"
 "#,
 Value::Tag(0)
@@ -346,7 +346,7 @@ in (id { x = 1 }).x
 
 test_expr!{ module_function,
 r#"
-import! "string_prim"
+let string_prim = import! std.string.prim
 let x = string_prim.len "test" in x
 "#,
 4i32

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -697,7 +697,7 @@ fn completion_with_prelude() {
 let prelude  = import! std.prelude
 and { Option } = import! std.option
 and { Num } = prelude
-let { lazy } = import! "lazy"
+let { lazy } = import! std.lazy
 
 type Stream_ a =
     | Value a (Stream a)

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -575,6 +575,13 @@ fn access_types_by_path() {
 fn opaque_value_type_mismatch() {
     let _ = ::env_logger::init();
     let vm = make_vm();
+
+    Compiler::new()
+        .implicit_prelude(false)
+        .run_expr_async::<()>(&vm, "<top>", "let _ = import! std.channel in ()")
+        .sync_or_error()
+        .unwrap();
+
     let expr = r#"
 let { sender, receiver } = channel 0
 send sender 1

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -354,7 +354,7 @@ let x = string_prim.len "test" in x
 
 test_expr!{ prelude true_branch_not_affected_by_false_branch,
 r#"
-let { Bool } = import! "std/bool.glu"
+let { Bool } = import! std.bool
 if True then
     let x = 1
     x
@@ -366,7 +366,7 @@ else
 
 test_expr!{ prelude and_operator_stack,
 r#"
-let { Bool } = import! "std/bool.glu"
+let { Bool } = import! std.bool
 let b = True && True
 let b2 = False
 b
@@ -376,7 +376,7 @@ true
 
 test_expr!{ prelude or_operator_stack,
 r#"
-let { Bool } = import! "std/bool.glu"
+let { Bool } = import! std.bool
 let b = False || True
 let b2 = False
 b
@@ -450,7 +450,7 @@ fn rename_types_after_binding() {
     let _ = ::env_logger::init();
 
     let text = r#"
-let list  = import! "std/list.glu"
+let list  = import! std.list
 in
 let { List } = list
 and { (==) }: Eq (List Int) = list.eq { (==) }
@@ -514,11 +514,7 @@ fn access_operator_without_parentheses() {
     let _ = ::env_logger::init();
     let vm = make_vm();
     Compiler::new()
-        .run_expr_async::<OpaqueValue<&Thread, Hole>>(
-            &vm,
-            "example",
-            r#" import! "std/prelude.glu" "#,
-        )
+        .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example", r#" import! std.prelude "#)
         .sync_or_error()
         .unwrap();
     let result: Result<FunctionRef<fn(i32, i32) -> i32>, _> =
@@ -545,7 +541,7 @@ fn get_binding_with_generic_params() {
     let _ = ::env_logger::init();
 
     let vm = make_vm();
-    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! "std/function.glu" "#);
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! std.function "#);
     let mut id: FunctionRef<fn(String) -> String> = vm.get_global("std.function.id")
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(id.call("test".to_string()), Ok("test".to_string()));
@@ -555,7 +551,7 @@ fn get_binding_with_generic_params() {
 fn test_prelude() {
     let _ = ::env_logger::init();
     let vm = make_vm();
-    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! "std/prelude.glu" "#);
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! std.prelude "#);
 }
 
 #[test]
@@ -563,8 +559,8 @@ fn access_types_by_path() {
     let _ = ::env_logger::init();
 
     let vm = make_vm();
-    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! "std/option.glu" "#);
-    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! "std/result.glu" "#);
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! std.option "#);
+    run_expr::<OpaqueValue<&Thread, Hole>>(&vm, r#" import! std.result "#);
 
     assert!(vm.find_type_info("std.option.Option").is_ok());
     assert!(vm.find_type_info("std.result.Result").is_ok());
@@ -599,7 +595,7 @@ sender
 fn invalid_string_slice_dont_panic() {
     let _ = ::env_logger::init();
     let text = r#"
-let string = import! "std/string.glu"
+let string = import! std.string
 let s = "åäö"
 string.slice s 1 (string.len s)
 "#;
@@ -622,7 +618,7 @@ fn partially_applied_constructor_is_lambda() {
     let result = Compiler::new().run_expr::<FunctionRef<fn(i32) -> Option<i32>>>(
         &vm,
         "test",
-        r#"let { Option } = import! "std/option.glu" in Some"#,
+        r#"let { Option } = import! std.option in Some"#,
     );
     assert!(result.is_ok(), "{}", result.err().unwrap());
     assert_eq!(result.unwrap().0.call(123), Ok(Some(123)));
@@ -698,8 +694,8 @@ fn completion_with_prelude() {
     let vm = make_vm();
 
     let source = r#"
-let prelude  = import! "std/prelude.glu"
-and { Option } = import! "std/option.glu"
+let prelude  = import! std.prelude
+and { Option } = import! std.option
 and { Num } = prelude
 let { lazy } = import! "lazy"
 

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -81,8 +81,6 @@ assert_eq!(vec, Vec2 {
 extern crate serde_derive;
 
 extern crate gluon;
-#[macro_use]
-extern crate gluon_vm;
 
 use gluon::{Compiler, Thread, new_vm};
 use gluon::base::types::ArcType;

--- a/vm/src/core/interpreter.rs
+++ b/vm/src/core/interpreter.rs
@@ -560,9 +560,8 @@ impl<'a, 'e> Compiler<'a, 'e> {
                 }
             }
             Expr::Match(expr, alts) => {
-                let expr = self.compile(expr, function)?.unwrap_or(
-                    Reduced::Local(expr),
-                );
+                let expr = self.compile(expr, function)?
+                    .unwrap_or(Reduced::Local(expr));
                 for alt in alts {
                     self.stack_constructors.enter_scope();
                     function.stack.enter_scope();

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -602,7 +602,12 @@ impl<'a, 'e> Translator<'a, 'e> {
                             // Only load fields that aren't named in this record constructor
                             .filter(|field| !defined_fields.contains(field.name.declared_name()))
                             .map(move |field| {
-                                self.project_expr(base_ident_expr.span(), base_ident_expr, &field.name, &field.typ)
+                                self.project_expr(
+                                    base_ident_expr.span(),
+                                    base_ident_expr,
+                                    &field.name,
+                                    &field.typ
+                                )
                             })
                     },
                 ));

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -1183,9 +1183,8 @@ impl<'a, 'e> PatternTranslator<'a, 'e> {
         equations: &[Equation<'a, 'p>],
     ) -> Expr<'a> {
         let arena = &self.0.allocator.arena;
-        // FIXME Symbol::from
         let error = arena.alloc(Expr::Ident(
-            TypedIdent::new(Symbol::from("error")),
+            TypedIdent::new(Symbol::from("#error")),
             Span::default(),
         ));
         let args = arena.alloc_extend(

--- a/vm/src/debug.rs
+++ b/vm/src/debug.rs
@@ -1,18 +1,23 @@
 use api::generic::A;
 use api::Generic;
 use thread::Thread;
-use Result;
+use {ExternModule, Result};
 
 fn trace(a: Generic<A>) {
     println!("{:?}", a.0);
 }
 
-pub fn load(vm: &Thread) -> Result<()> {
-    vm.define_global(
-        "debug",
+mod std {
+    pub use debug;
+}
+
+pub fn load(vm: &Thread) -> Result<ExternModule> {
+    use self::std;
+
+    ExternModule::new(
+        vm,
         record!{
-            trace => primitive!(1 trace)
+            trace => primitive!(1 std::debug::trace)
         },
-    )?;
-    Ok(())
+    )
 }

--- a/vm/src/future.rs
+++ b/vm/src/future.rs
@@ -26,13 +26,19 @@ where
     pub fn sync_or_error(self) -> Result<F::Item, F::Error> {
         match self {
             FutureValue::Value(v) => v,
-            FutureValue::Future(_) => Err(
-                Error::Message("Future needs to be resolved asynchronously".into()).into(),
-            ),
+            FutureValue::Future(_) => {
+                Err(Error::Message("Future needs to be resolved asynchronously".into()).into())
+            }
             FutureValue::Polled => {
                 ice!("`FutureValue` may not be polled again if it contained a value")
             }
         }
+    }
+}
+
+impl<T, E> From<Result<T, E>> for FutureValue<FutureResult<T, E>> {
+    fn from(result: Result<T, E>) -> FutureValue<FutureResult<T, E>> {
+        FutureValue::Value(result)
     }
 }
 

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -11,7 +11,7 @@ use api::{FunctionRef, Getable, OpaqueValue, RuntimeResult, Userdata, VmType, Wi
 use api::Generic;
 use api::generic::A;
 use vm::Thread;
-use {Error, Result, Variants};
+use {Error, ExternModule, Result, Variants};
 use value::{Cloner, Value};
 use thread::ThreadInternal;
 
@@ -110,8 +110,13 @@ fn lazy(f: OpaqueValue<&Thread, fn(()) -> A>) -> Lazy<A> {
     }
 }
 
-pub fn load<'vm>(vm: &'vm Thread) -> Result<()> {
-    vm.define_global("lazy", primitive!(1 lazy))?;
-    vm.define_global("force", primitive!(1 force))?;
-    Ok(())
+pub fn load(vm: &Thread) -> Result<ExternModule> {
+    use lazy;
+    ExternModule::new(
+        vm,
+        record!{
+            lazy => primitive!(1 lazy::lazy),
+            force => primitive!(1 lazy::force)
+        },
+    )
 }

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -110,13 +110,18 @@ fn lazy(f: OpaqueValue<&Thread, fn(()) -> A>) -> Lazy<A> {
     }
 }
 
+mod std {
+    pub use lazy;
+}
+
 pub fn load(vm: &Thread) -> Result<ExternModule> {
-    use lazy;
+    use self::std;
+
     ExternModule::new(
         vm,
         record!{
-            lazy => primitive!(1 lazy::lazy),
-            force => primitive!(1 lazy::force)
+            lazy => primitive!(1 std::lazy::lazy),
+            force => primitive!(1 std::lazy::force)
         },
     )
 }

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -103,6 +103,9 @@ impl<'a> MacroExpander<'a> {
 
     pub fn run(&mut self, expr: &mut SpannedExpr<Symbol>) {
         self.visit_expr(expr);
+        if self.errors.has_errors() {
+            info!("Macro errors: {}", self.errors);
+        }
     }
 }
 

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -4,7 +4,6 @@ use std::string::String as StdString;
 use std::str::FromStr;
 
 use {Error, ExternModule, Variants};
-use primitives as prim;
 use api::{generic, primitive, Array, Generic, Getable, RuntimeResult, WithVM};
 use api::generic::A;
 use gc::{DataDef, Gc, Traverseable, WriteOnly};
@@ -241,9 +240,30 @@ extern "C" fn error(_: &Thread) -> Status {
 }
 
 #[allow(non_camel_case_types)]
+mod std {
+    pub use primitives as prim;
+
+    pub mod string {
+        pub type prim = str;
+    }
+    pub mod char {
+        pub type prim = char;
+    }
+    pub mod array {
+        pub use primitives::array as prim;
+    }
+    pub mod int {
+        pub type prim = ::types::VmInt;
+    }
+    pub mod float {
+        pub type prim = f64;
+    }
+}
+
+#[allow(non_camel_case_types)]
 pub fn load_float(thread: &Thread) -> Result<ExternModule> {
     use std::f64;
-    type float_prim = f64;
+    use self::std;
 
     ExternModule::new(
         thread,
@@ -264,82 +284,78 @@ pub fn load_float(thread: &Thread) -> Result<ExternModule> {
             e => f64::consts::E,
             pi => f64::consts::PI,
             radix => f64::RADIX,
-            is_nan => primitive!(1 float_prim::is_nan),
-            is_infinite => primitive!(1 float_prim::is_infinite),
-            is_finite => primitive!(1 float_prim::is_finite),
-            is_normal => primitive!(1 float_prim::is_normal),
-            floor => primitive!(1 float_prim::floor),
-            ceil => primitive!(1 float_prim::ceil),
-            round => primitive!(1 float_prim::round),
-            trunc => primitive!(1 float_prim::trunc),
-            fract => primitive!(1 float_prim::fract),
-            abs => primitive!(1 float_prim::abs),
-            signum => primitive!(1 float_prim::signum),
-            is_sign_positive => primitive!(1 float_prim::is_sign_positive),
-            is_sign_negative => primitive!(1 float_prim::is_sign_negative),
-            mul_add => primitive!(3 float_prim::mul_add),
-            recip => primitive!(1 float_prim::recip),
-            powi => primitive!(2 float_prim::powi),
-            powf => primitive!(2 float_prim::powf),
-            sqrt => primitive!(1 float_prim::sqrt),
-            exp => primitive!(1 float_prim::exp),
-            exp2 => primitive!(1 float_prim::exp2),
-            ln => primitive!(1 float_prim::ln),
-            log2 => primitive!(1 float_prim::log2),
-            log10 => primitive!(1 float_prim::log10),
-            to_degrees => primitive!(1 float_prim::to_degrees),
-            to_radians => primitive!(1 float_prim::to_radians),
-            max => primitive!(2 float_prim::max),
-            min => primitive!(2 float_prim::min),
-            cbrt => primitive!(1 float_prim::cbrt),
-            hypot => primitive!(2 float_prim::hypot),
-            sin => primitive!(1 float_prim::sin),
-            cos => primitive!(1 float_prim::cos),
-            tan => primitive!(1 float_prim::tan),
-            acos => primitive!(1 float_prim::acos),
-            atan => primitive!(1 float_prim::atan),
-            atan2 => primitive!(2 float_prim::atan2),
-            sin_cos => primitive!(1 float_prim::sin_cos),
-            exp_m1 => primitive!(1 float_prim::exp_m1),
-            ln_1p => primitive!(1 float_prim::ln_1p),
-            sinh => primitive!(1 float_prim::sinh),
-            cosh => primitive!(1 float_prim::cosh),
-            tanh => primitive!(1 float_prim::tanh),
-            acosh => primitive!(1 float_prim::acosh),
-            atanh => primitive!(1 float_prim::atanh),
-            parse => named_primitive!(1, "float_prim.parse", parse::<f64>)
+            is_nan => primitive!(1 std::float::prim::is_nan),
+            is_infinite => primitive!(1 std::float::prim::is_infinite),
+            is_finite => primitive!(1 std::float::prim::is_finite),
+            is_normal => primitive!(1 std::float::prim::is_normal),
+            floor => primitive!(1 std::float::prim::floor),
+            ceil => primitive!(1 std::float::prim::ceil),
+            round => primitive!(1 std::float::prim::round),
+            trunc => primitive!(1 std::float::prim::trunc),
+            fract => primitive!(1 std::float::prim::fract),
+            abs => primitive!(1 std::float::prim::abs),
+            signum => primitive!(1 std::float::prim::signum),
+            is_sign_positive => primitive!(1 std::float::prim::is_sign_positive),
+            is_sign_negative => primitive!(1 std::float::prim::is_sign_negative),
+            mul_add => primitive!(3 std::float::prim::mul_add),
+            recip => primitive!(1 std::float::prim::recip),
+            powi => primitive!(2 std::float::prim::powi),
+            powf => primitive!(2 std::float::prim::powf),
+            sqrt => primitive!(1 std::float::prim::sqrt),
+            exp => primitive!(1 std::float::prim::exp),
+            exp2 => primitive!(1 std::float::prim::exp2),
+            ln => primitive!(1 std::float::prim::ln),
+            log2 => primitive!(1 std::float::prim::log2),
+            log10 => primitive!(1 std::float::prim::log10),
+            to_degrees => primitive!(1 std::float::prim::to_degrees),
+            to_radians => primitive!(1 std::float::prim::to_radians),
+            max => primitive!(2 std::float::prim::max),
+            min => primitive!(2 std::float::prim::min),
+            cbrt => primitive!(1 std::float::prim::cbrt),
+            hypot => primitive!(2 std::float::prim::hypot),
+            sin => primitive!(1 std::float::prim::sin),
+            cos => primitive!(1 std::float::prim::cos),
+            tan => primitive!(1 std::float::prim::tan),
+            acos => primitive!(1 std::float::prim::acos),
+            atan => primitive!(1 std::float::prim::atan),
+            atan2 => primitive!(2 std::float::prim::atan2),
+            sin_cos => primitive!(1 std::float::prim::sin_cos),
+            exp_m1 => primitive!(1 std::float::prim::exp_m1),
+            ln_1p => primitive!(1 std::float::prim::ln_1p),
+            sinh => primitive!(1 std::float::prim::sinh),
+            cosh => primitive!(1 std::float::prim::cosh),
+            tanh => primitive!(1 std::float::prim::tanh),
+            acosh => primitive!(1 std::float::prim::acosh),
+            atanh => primitive!(1 std::float::prim::atanh),
+            parse => named_primitive!(1, "std.float.prim.parse", parse::<f64>)
         },
     )
 }
 
 #[allow(non_camel_case_types)]
 pub fn load_int(vm: &Thread) -> Result<ExternModule> {
-    use types::VmInt as int_prim;
+    use self::std;
     ExternModule::new(
         vm,
         record! {
-            min_value => int_prim::min_value(),
-            max_value => int_prim::max_value(),
-            count_ones => primitive!(1 int_prim::count_ones),
-            rotate_left => primitive!(2 int_prim::rotate_left),
-            rotate_right => primitive!(2 int_prim::rotate_right),
-            swap_bytes => primitive!(1 int_prim::swap_bytes),
-            from_be => primitive!(1 int_prim::from_be),
-            from_le => primitive!(1 int_prim::from_le),
-            to_be => primitive!(1 int_prim::to_be),
-            to_le => primitive!(1 int_prim::to_le),
-            pow => primitive!(2 int_prim::pow),
-            abs => primitive!(1 int_prim::abs),
-            signum => primitive!(1 int_prim::signum),
-            is_positive => primitive!(1 int_prim::is_positive),
-            is_negative => primitive!(1 int_prim::is_negative),
-            parse => named_primitive!(1, "int_prim.parse", parse::<VmInt>)
+            min_value => std::int::prim::min_value(),
+            max_value => std::int::prim::max_value(),
+            count_ones => primitive!(1 std::int::prim::count_ones),
+            rotate_left => primitive!(2 std::int::prim::rotate_left),
+            rotate_right => primitive!(2 std::int::prim::rotate_right),
+            swap_bytes => primitive!(1 std::int::prim::swap_bytes),
+            from_be => primitive!(1 std::int::prim::from_be),
+            from_le => primitive!(1 std::int::prim::from_le),
+            to_be => primitive!(1 std::int::prim::to_be),
+            to_le => primitive!(1 std::int::prim::to_le),
+            pow => primitive!(2 std::int::prim::pow),
+            abs => primitive!(1 std::int::prim::abs),
+            signum => primitive!(1 std::int::prim::signum),
+            is_positive => primitive!(1 std::int::prim::is_positive),
+            is_negative => primitive!(1 std::int::prim::is_negative),
+            parse => named_primitive!(1, "std.int.prim.parse", parse::<VmInt>)
         },
     )
-}
-
-mod std {
-    pub use super::array;
 }
 
 #[allow(non_camel_case_types)]
@@ -348,100 +364,86 @@ pub fn load_array(vm: &Thread) -> Result<ExternModule> {
     ExternModule::new(
         vm,
         record! {
-            len => primitive!(1 std::array::len),
-            index => primitive!(2 std::array::index),
-            append => primitive!(2 std::array::append)
+            len => primitive!(1 std::array::prim::len),
+            index => primitive!(2 std::array::prim::index),
+            append => primitive!(2 std::array::prim::append)
         },
     )
 }
 
-#[allow(non_camel_case_types)]
 pub fn load_string(vm: &Thread) -> Result<ExternModule> {
     use self::string;
-    type string_prim = str;
-    vm.define_global(
-        "string_compare",
-        named_primitive!(2, "string_compare", string_prim::cmp),
-    )?;
-    vm.define_global(
-        "string_eq",
-        named_primitive!(2, "string_eq", <str as PartialEq>::eq),
-    )?;
     ExternModule::new(
         vm,
         record! {
-            len => primitive!(1 string_prim::len),
-            is_empty => primitive!(1 string_prim::is_empty),
-            split_at => primitive!(2 string_prim::split_at),
-            find => named_primitive!(2, "string_prim.find", string_prim::find::<&str>),
-            rfind => named_primitive!(2, "string_prim.rfind", string_prim::rfind::<&str>),
+            len => primitive!(1 std::string::prim::len),
+            is_empty => primitive!(1 std::string::prim::is_empty),
+            split_at => primitive!(2 std::string::prim::split_at),
+            find => named_primitive!(2, "std.string.prim.find", std::string::prim::find::<&str>),
+            rfind => named_primitive!(2, "std.string.prim.rfind", std::string::prim::rfind::<&str>),
             starts_with => named_primitive!(
                 2,
-                "string_prim.starts_with",
-                string_prim::starts_with::<&str>
+                "std.string.prim.starts_with",
+                std::string::prim::starts_with::<&str>
             ),
             ends_with => named_primitive!(
                 2,
-                "string_prim.ends_with",
-                string_prim::ends_with::<&str>
+                "std.string.prim.ends_with",
+                std::string::prim::ends_with::<&str>
             ),
-            trim => primitive!(1 string_prim::trim),
-            trim_left => primitive!(1 string_prim::trim_left),
-            trim_right => primitive!(1 string_prim::trim_right),
-            append => named_primitive!(2, "string_prim.append", string::append),
-            slice => named_primitive!(3, "string_prim.slice", string::slice),
+            trim => primitive!(1 std::string::prim::trim),
+            trim_left => primitive!(1 std::string::prim::trim_left),
+            trim_right => primitive!(1 std::string::prim::trim_right),
+            append => named_primitive!(2, "std.string.prim.append", string::append),
+            slice => named_primitive!(3, "std.string.prim.slice", string::slice),
             from_utf8 => primitive::<fn(Vec<u8>) -> StdResult<String, ()>>(
-                "string_prim.from_utf8",
+                "std.string.prim.from_utf8",
                 string::from_utf8
             ),
-            char_at => named_primitive!(2, "string_prim.char_at", string::char_at),
-            as_bytes => primitive!(1 string_prim::as_bytes)
+            char_at => named_primitive!(2, "std.string.prim.char_at", string::char_at),
+            as_bytes => primitive!(1 std::string::prim::as_bytes)
         },
     )
 }
 
 #[allow(non_camel_case_types)]
 pub fn load_char(vm: &Thread) -> Result<ExternModule> {
-    use std::char;
-    type char_prim = char;
     ExternModule::new(
         vm,
         record! {
-            is_digit => primitive!(2 char_prim::is_digit),
-            to_digit => primitive!(2 char_prim::to_digit),
-            len_utf8 => primitive!(1 char_prim::len_utf8),
-            len_utf16 => primitive!(1 char_prim::len_utf16),
-            is_alphabetic => primitive!(1 char_prim::is_alphabetic),
-            is_lowercase => primitive!(1 char_prim::is_lowercase),
-            is_uppercase => primitive!(1 char_prim::is_uppercase),
-            is_whitespace => primitive!(1 char_prim::is_whitespace),
-            is_alphanumeric => primitive!(1 char_prim::is_alphanumeric),
-            is_control => primitive!(1 char_prim::is_control),
-            is_numeric => primitive!(1 char_prim::is_numeric)
+            is_digit => primitive!(2 std::char::prim::is_digit),
+            to_digit => primitive!(2 std::char::prim::to_digit),
+            len_utf8 => primitive!(1 std::char::prim::len_utf8),
+            len_utf16 => primitive!(1 std::char::prim::len_utf16),
+            is_alphabetic => primitive!(1 std::char::prim::is_alphabetic),
+            is_lowercase => primitive!(1 std::char::prim::is_lowercase),
+            is_uppercase => primitive!(1 std::char::prim::is_uppercase),
+            is_whitespace => primitive!(1 std::char::prim::is_whitespace),
+            is_alphanumeric => primitive!(1 std::char::prim::is_alphanumeric),
+            is_control => primitive!(1 std::char::prim::is_control),
+            is_numeric => primitive!(1 std::char::prim::is_numeric)
         },
     )
 }
 
 #[allow(non_camel_case_types)]
-pub fn load(vm: &Thread) -> Result<()> {
-    vm.define_global(
-        "prim",
-        record! {
-            show_int => primitive!(1 prim::show_int),
-            show_float => primitive!(1 prim::show_float),
-            show_char => primitive!(1 prim::show_char)
-        },
-    )?;
+pub fn load(vm: &Thread) -> Result<ExternModule> {
+    use self::std;
 
     vm.define_global(
         "#error",
-        primitive::<fn(StdString) -> Generic<A>>("#error", prim::error),
+        primitive::<fn(StdString) -> Generic<A>>("#error", std::prim::error),
     )?;
 
-    vm.define_global(
-        "error",
-        primitive::<fn(StdString) -> Generic<A>>("error", prim::error),
-    )?;
-
-    Ok(())
+    ExternModule::new(
+        vm,
+        record! {
+            show_int => primitive!(1 std::prim::show_int),
+            show_float => primitive!(1 std::prim::show_float),
+            show_char => primitive!(1 std::prim::show_char),
+            string_compare => named_primitive!(2, "std.prim.string_compare", str::cmp),
+            string_eq => named_primitive!(2, "std.prim.string_eq", <str as PartialEq>::eq),
+            error => primitive::<fn(StdString) -> Generic<A>>("std.prim.error", std::prim::error)
+        },
+    )
 }

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -14,7 +14,8 @@ use value::{Def, GcStr, Repr, Value, ValueArray};
 use stack::StackFrame;
 use types::VmInt;
 
-mod array {
+#[doc(hidden)]
+pub mod array {
     use super::*;
     use thread::ThreadInternal;
 
@@ -337,15 +338,19 @@ pub fn load_int(vm: &Thread) -> Result<ExternModule> {
     )
 }
 
+mod std {
+    pub use super::array;
+}
+
 #[allow(non_camel_case_types)]
 pub fn load_array(vm: &Thread) -> Result<ExternModule> {
-    use self::array;
+    use self::std;
     ExternModule::new(
         vm,
         record! {
-            len => primitive!(1 array::len),
-            index => primitive!(2 array::index),
-            append => primitive!(2 array::append)
+            len => primitive!(1 std::array::len),
+            index => primitive!(2 std::array::index),
+            append => primitive!(2 std::array::append)
         },
     )
 }

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -426,7 +426,7 @@ pub fn load_char(vm: &Thread) -> Result<ExternModule> {
     )
 }
 
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, deprecated)]
 pub fn load(vm: &Thread) -> Result<ExternModule> {
     use self::std;
 

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use std::marker::PhantomData;
 
 use base::types::{ArcType, Type};
-use Result;
+use {Result, ExternModule};
 use gc::{Gc, GcPtr, Move, Traverseable};
 use vm::Thread;
 use thread::ThreadInternal;
@@ -83,10 +83,14 @@ fn make_ref(a: WithVM<Generic<A>>) -> Reference<A> {
     }
 }
 
-pub fn load(vm: &Thread) -> Result<()> {
+pub fn load(vm: &Thread) -> Result<ExternModule> {
     let _ = vm.register_type::<Reference<A>>("Ref", &["a"]);
-    vm.define_global("<-", primitive!(2 set))?;
-    vm.define_global("load", primitive!(1 get))?;
-    vm.define_global("ref", primitive!(1 make_ref))?;
-    Ok(())
+    ExternModule::new(
+        vm,
+        record!{
+            (store "<-") => primitive!(2 set),
+            load => primitive!(1 get),
+            (ref_ "ref") => primitive!(1 make_ref),
+        }
+    )
 }

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -425,6 +425,7 @@ impl Thread {
     /// # }
     /// ```
     ///
+    #[deprecated(since = "0.7.0", note = "Use `gluon::import::add_extern_module` instead")]
     pub fn define_global<'vm, T>(&'vm self, name: &str, value: T) -> Result<()>
     where
         T: Pushable<'vm> + VmType,

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -452,7 +452,7 @@ impl Thread {
     ///
     /// ```rust
     /// # extern crate gluon;
-    /// # use gluon::{new_vm,Compiler,RootedThread, Thread};
+    /// # use gluon::{new_vm, Compiler, Thread};
     /// # use gluon::vm::api::{FunctionRef, Hole, OpaqueValue};
     /// # fn main() {
     /// let vm = new_vm();

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -227,8 +227,7 @@ pub struct Thread {
     // thread can refer to any value in the parent thread
     #[cfg_attr(feature = "serde_derive", serde(state))] parent: Option<RootedThread>,
     #[cfg_attr(feature = "serde_derive", serde(skip))]
-    roots:
-        RwLock<Vec<GcPtr<Traverseable + Send + Sync>>>,
+    roots: RwLock<Vec<GcPtr<Traverseable + Send + Sync>>>,
     #[cfg_attr(feature = "serde_derive", serde(state))] rooted_values: RwLock<Vec<Value>>,
     /// All threads which this thread have spawned in turn. Necessary as this thread needs to scan
     /// the roots of all its children as well since those may contain references to this threads
@@ -458,7 +457,7 @@ impl Thread {
     /// let vm = new_vm();
     /// Compiler::new()
     ///     .run_expr_async::<OpaqueValue<&Thread, Hole>>(&vm, "example",
-    ///         r#" import! "std/int.glu" "#)
+    ///         r#" import! std.int "#)
     ///     .sync_or_error()
     ///     .unwrap_or_else(|err| panic!("{}", err));
     /// let mut add: FunctionRef<fn(i32, i32) -> i32> =
@@ -992,8 +991,7 @@ pub struct Context {
     max_stack_size: VmIndex,
 
     #[cfg_attr(feature = "serde_derive", serde(skip))]
-    poll_fn:
-        Option<Box<FnMut(&Thread, &mut Context) -> Result<Async<()>> + Send>>,
+    poll_fn: Option<Box<FnMut(&Thread, &mut Context) -> Result<Async<()>> + Send>>,
 }
 
 impl Context {

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -29,8 +29,6 @@ pub enum Instruction {
     PushUpVar(VmIndex),
     /// Push the value at `index`
     Push(VmIndex),
-    /// Push the value at `index`
-    PushGlobal(VmIndex),
     /// Call a function by passing it `args` number of arguments. The function is at the index in
     /// the stack just before the arguments. After the call is all arguments are removed and the
     /// function is replaced by the result of the call.
@@ -123,7 +121,7 @@ impl Instruction {
     /// Returns by how much the stack is adjusted when executing the instruction `self`.
     pub fn adjust(&self) -> i32 {
         match *self {
-            PushInt(_) | PushByte(_) | PushFloat(_) | PushString(_) | Push(_) | PushGlobal(_) => 1,
+            PushInt(_) | PushByte(_) | PushFloat(_) | PushString(_) | Push(_) => 1,
             Call(n) => -(n as i32),
             TailCall(n) => -(n as i32),
             Construct { args, .. } | ConstructRecord { args, .. } | ConstructArray(args) => {

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -123,7 +123,6 @@ pub struct BytecodeFunction {
 impl Traverseable for BytecodeFunction {
     fn traverse(&self, gc: &mut Gc) {
         self.inner_functions.traverse(gc);
-        self.globals.traverse(gc);
     }
 }
 

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -113,8 +113,6 @@ pub struct BytecodeFunction {
     #[cfg_attr(feature = "serde_derive", serde(state))]
     pub strings: Vec<InternedStr>,
     #[cfg_attr(feature = "serde_derive", serde(state))]
-    pub globals: Vec<Value>,
-    #[cfg_attr(feature = "serde_derive", serde(state))]
     pub records: Vec<Vec<InternedStr>>,
     #[cfg_attr(feature = "serde_derive", serde(state))]
     pub debug_info: DebugInfo,


### PR DESCRIPTION
Will tackle #340 as well as some other related things with global variables (see  e26c12803c4f691ae895d5176c356ec8cd4c08bd).

🚲 🏠 

* What should `string_prim`, etc be called?
* Should we hide them away with more obviously internal names or lock them away with something like `@NO-IMPLICIT-PRELUDE`?
* `array`, `reference`, `lazy` are full modules meant to be used. Should we perhaps put make them loadable as `import! "std.array"` etc? (Probably)
* Since we have non-file modules now. Should we call `import!` as `import! "std.bool"` instead of `import! "std/bool.glu"`?
  * `import! "std.bool"` vs `import! std.bool`?