### PR TITLE
fix(vm): child_threads must be traversed for all threads

### DIFF
--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -98,6 +98,10 @@ impl<'s> WriteOnly<'s, str> {
 pub struct Generation(i32);
 
 impl Generation {
+    pub fn is_root(self) -> bool {
+        self.0 == 0
+    }
+
     /// Returns a generation which compared to any normal generation is always younger.
     pub fn disjoint() -> Generation {
         Generation(-1)

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -254,7 +254,6 @@ impl Traverseable for Thread {
     fn traverse(&self, gc: &mut Gc) {
         self.traverse_fields_except_stack(gc);
         self.context.lock().unwrap().stack.get_values().traverse(gc);
-        self.child_threads.read().unwrap().traverse(gc);
     }
 }
 
@@ -553,6 +552,7 @@ impl Thread {
         self.global_state.traverse(gc);
         self.roots.read().unwrap().traverse(gc);
         self.rooted_values.read().unwrap().traverse(gc);
+        self.child_threads.read().unwrap().traverse(gc);
     }
 
     fn parent_threads(&self) -> RwLockWriteGuard<Vec<GcPtr<Thread>>> {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -445,6 +445,7 @@ impl GlobalVmState {
         metadata: Metadata,
         value: Value,
     ) -> Result<()> {
+        assert!(value.generation().is_root());
         let mut env = self.env.write().unwrap();
         let globals = &mut env.globals;
         let global = Global {


### PR DESCRIPTION
Fixes a memory unsafety issue where a child thread could be freed if it only existed as a `RootedThread`