### PR TITLE
chore: Write lalrpop files to OUT_DIR instead of the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@
 
 target
 Cargo.lock
-
-parser/src/grammar.rs
-vm/src/core/grammar.rs

--- a/parser/build.rs
+++ b/parser/build.rs
@@ -3,6 +3,9 @@ extern crate lalrpop;
 fn main() {
     ::std::env::set_var("LALRPOP_LANE_TABLE", "disabled");
 
-    lalrpop::Configuration::new().process_current_dir().unwrap();
-    println!("cargo:rerun-if-changed=src/grammar.lalrpop");
+    lalrpop::Configuration::new()
+        .use_cargo_dir_conventions()
+        .process_file("src/grammar.lalrpop")
+        .unwrap();
+    println!("cargo:rerun-if-changed=grammar.lalrpop");
 }

--- a/parser/src/grammar.rs
+++ b/parser/src/grammar.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/grammar.rs"));

--- a/vm/build.rs
+++ b/vm/build.rs
@@ -1,10 +1,14 @@
-
 #[cfg(feature = "test")]
 mod build {
     extern crate lalrpop;
+
     pub fn main() {
-        lalrpop::Configuration::new().process_current_dir().unwrap();
-        println!("cargo:rerun-if-changed=src/core/grammar.lalrpop");
+        lalrpop::Configuration::new()
+            .use_cargo_dir_conventions()
+            .process_file("src/core/grammar.lalrpop")
+            .unwrap();
+
+        println!("cargo:rerun-if-changed=core/grammar.lalrpop");
     }
 }
 

--- a/vm/src/core/grammar.rs
+++ b/vm/src/core/grammar.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/core/grammar.rs"));


### PR DESCRIPTION
Should let gluon be ran under cargobomb https://github.com/rust-lang-nursery/crater/issues/157 but I think that regardless of that it is better to generate files outside of the source tree