### PR TITLE
fix(repl): Don't expand macros twice in repl completion

### DIFF
--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -45,10 +45,9 @@ fn find_kind(args: WithVM<RootStr>) -> IO<Result<String, String>> {
     let args = args.value.trim();
     IO::Value(match vm.find_type_info(args) {
         Ok(ref alias) => {
-            let kind = alias.params().iter().rev().fold(
-                Kind::typ(),
-                |acc, arg| Kind::function(arg.kind.clone(), acc),
-            );
+            let kind = alias.params().iter().rev().fold(Kind::typ(), |acc, arg| {
+                Kind::function(arg.kind.clone(), acc)
+            });
             Ok(format!("{}", kind))
         }
         Err(err) => Err(format!("{}", err)),
@@ -109,21 +108,16 @@ fn complete(thread: &Thread, name: &str, fileinput: &str, pos: usize) -> GluonRe
             Err((Some(expr), err)) => (expr, Err(err.into())),
         };
 
-    expr.expand_macro(&mut compiler, thread, &name)
-        .map_err(|(_, err)| err)?;
-
     // Only need the typechecker to fill infer the types as best it can regardless of errors
-    let _ = compiler.typecheck_expr(thread, &name, fileinput, &mut expr);
+    let _ = expr.typecheck(&mut compiler, thread, &name, fileinput);
     let suggestions = completion::suggest(&*thread.get_env(), &expr, BytePos::from(pos));
-    Ok(
-        suggestions
-            .into_iter()
-            .map(|ident| {
-                let s: &str = ident.name.as_ref();
-                s.to_string()
-            })
-            .collect(),
-    )
+    Ok(suggestions
+        .into_iter()
+        .map(|ident| {
+            let s: &str = ident.name.as_ref();
+            s.to_string()
+        })
+        .collect())
 }
 
 struct Completer(RootedThread);
@@ -320,7 +314,8 @@ pub fn run() -> Result<(), Box<StdError + Send + Sync>> {
 
 #[cfg(test)]
 mod tests {
-    use super::compile_repl;
+    use super::*;
+
     use vm::api::{FunctionRef, IO};
     use gluon::{self, RootedThread};
     use gluon::import::Import;
@@ -386,5 +381,13 @@ mod tests {
             Ok(IO::Value(Ok(_))) => (),
             x => assert!(false, "{:?}", x),
         }
+    }
+
+    #[test]
+    fn complete_repl_empty() {
+        let _ = ::env_logger::init();
+        let vm = new_vm();
+        compile_repl(&vm).unwrap_or_else(|err| panic!("{}", err));
+        complete(&vm, "<repl>", "", 0).unwrap_or_else(|err| panic!("{}", err));
     }
 }


### PR DESCRIPTION
When running completion in the repl I accidentally expanded macros twice which caused the implicit prelude to be inserted twice which caused an error in the implicit prelude (which is assumed to never happen). This caused a crash when trying to print the error since the error location is out of bounds (the crash happens when trying to complete any small enough input).

Fixes #408 