### PR TITLE
Don't instantiate variables during unification inside aliases

### DIFF
--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -17,7 +17,6 @@ pub type SpannedError<I> = Spanned<Error<I>, BytePos>;
 
 pub type Result<T> = StdResult<T, SpannedError<Symbol>>;
 
-
 /// Struct containing methods for kindchecking types
 pub struct KindCheck<'a> {
     variables: Vec<Generic<Symbol>>,
@@ -127,9 +126,7 @@ impl<'a> KindCheck<'a> {
             .iter()
             .find(|var| var.id == *id)
             .map(|t| t.kind.clone())
-            .or_else(|| {
-                self.locals.iter().find(|t| t.0 == *id).map(|t| t.1.clone())
-            })
+            .or_else(|| self.locals.iter().find(|t| t.0 == *id).map(|t| t.1.clone()))
             .or_else(|| self.info.find_kind(id))
             .map_or_else(
                 || {
@@ -343,8 +340,7 @@ where
         TypeMismatch(ref expected, ref actual) => write!(
             f,
             "Kind mismatch\nExpected: {}\nFound: {}",
-            expected,
-            actual
+            expected, actual
         ),
         Substitution(ref err) => write!(f, "{}", err),
         Other(ref err) => write!(f, "{}", err),

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -38,8 +38,7 @@ pub fn check_signature(env: &TypeEnv, signature: &ArcType, actual: &ArcType) -> 
     let state = unify_type::State::new(env, &subs);
     let actual = unify_type::new_skolem_scope(&subs, &FnvMap::default(), actual);
     let actual = actual.instantiate_generics(&mut FnvMap::default());
-    let result =
-        unify_type::merge_signature(&subs, &mut ScopedMap::new(), 0, state, signature, &actual);
+    let result = unify_type::subsumes(&subs, &mut ScopedMap::new(), 0, state, signature, &actual);
     if let Err(ref err) = result {
         debug!("Check signature error: {}", err);
     }

--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -24,28 +24,24 @@ pub fn metadata(
         fn new_binding(&mut self, metadata: Metadata, bind: &ValueBinding<Symbol>) {
             match bind.name.value {
                 Pattern::As(ref id, _) => {
-                    let metadata = bind.comment.as_ref().map_or(metadata, |comment| {
-                        Metadata {
-                            comment: Some(comment.content.clone()),
-                            module: BTreeMap::new(),
-                        }
+                    let metadata = bind.comment.as_ref().map_or(metadata, |comment| Metadata {
+                        comment: Some(comment.content.clone()),
+                        module: BTreeMap::new(),
                     });
                     self.stack_var(id.clone(), metadata.clone());
                     self.new_pattern(metadata, &bind.name);
                 }
                 Pattern::Ident(ref id) => {
-                    let metadata = bind.comment.as_ref().map_or(metadata, |comment| {
-                        Metadata {
-                            comment: Some(comment.content.clone()),
-                            module: BTreeMap::new(),
-                        }
+                    let metadata = bind.comment.as_ref().map_or(metadata, |comment| Metadata {
+                        comment: Some(comment.content.clone()),
+                        module: BTreeMap::new(),
                     });
                     self.stack_var(id.name.clone(), metadata);
                 }
-                Pattern::Constructor(..) |
-                Pattern::Tuple { .. } |
-                Pattern::Record { .. } |
-                Pattern::Error => self.new_pattern(metadata, &bind.name),
+                Pattern::Constructor(..)
+                | Pattern::Tuple { .. }
+                | Pattern::Record { .. }
+                | Pattern::Error => self.new_pattern(metadata, &bind.name),
             }
         }
 
@@ -126,11 +122,9 @@ pub fn metadata(
                             }
                             None => self.metadata(&field.name.value).cloned(),
                         };
-                        let field_metadata = field.comment.clone().map(|comment| {
-                            Metadata {
-                                comment: Some(comment.content),
-                                module: BTreeMap::new(),
-                            }
+                        let field_metadata = field.comment.clone().map(|comment| Metadata {
+                            comment: Some(comment.content),
+                            module: BTreeMap::new(),
                         });
                         let maybe_metadata = match (field_metadata, maybe_metadata) {
                             (Some(l), Some(r)) => Some(l.merge(r)),
@@ -173,11 +167,9 @@ pub fn metadata(
                 }
                 Expr::TypeBindings(ref bindings, ref expr) => {
                     for bind in bindings {
-                        let maybe_metadata = bind.comment.as_ref().map(|comment| {
-                            Metadata {
-                                comment: Some(comment.content.clone()),
-                                module: BTreeMap::new(),
-                            }
+                        let maybe_metadata = bind.comment.as_ref().map(|comment| Metadata {
+                            comment: Some(comment.content.clone()),
+                            module: BTreeMap::new(),
                         });
                         if let Some(metadata) = maybe_metadata {
                             self.stack_var(bind.name.value.clone(), metadata);

--- a/check/src/substitution.rs
+++ b/check/src/substitution.rs
@@ -341,6 +341,11 @@ impl<T: Substitutable> Substitution<T> {
         union.get_mut(other as usize).level = level;
     }
 
+    pub fn set_level(&self, var: u32, level: u32) {
+        let mut union = self.union.borrow_mut();
+        union.get_mut(var as usize).level = level;
+    }
+
     pub fn get_level(&self, mut var: u32) -> u32 {
         if let Some(v) = self.find_type_for_var(var) {
             var = v.get_var().map_or(var, |v| v.get_id());
@@ -552,10 +557,7 @@ impl<T: Substitutable + PartialEq + Clone> Substitution<T> {
                         typ.get_var().map(|x| x.get_id()),
                         resolved.get_var().map(|x| x.get_id()),
                     ) {
-                        (Some(x), Some(y)) if x > y => {
-                            typ = Cow::Owned(resolved);
-                        }
-                        (_, None) => {
+                        (Some(_), Some(_)) | (_, None) => {
                             typ = Cow::Owned(resolved);
                         }
                         _ => (),

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -348,8 +348,7 @@ impl<'a> Typecheck<'a> {
                 Ok(typ)
             }
             None => {
-                // Don't report global variables inserted by the `import!` macro as non-existing
-                // existing
+                // Don't report global variables inserted by the `import!` macro as undefined
                 // (if they don't exist the error will already have been reported by the macro)
                 if id.is_global() {
                     Ok(self.subs.new_var())
@@ -638,7 +637,8 @@ impl<'a> Typecheck<'a> {
         let returned_type;
         loop {
             let expected_type = expected_type.map(|t| self.skolemize(t));
-            match self.typecheck_(expr, expected_type.as_ref()) {
+            let mut expected_type = expected_type.as_ref();
+            match self.typecheck_(expr, &mut expected_type) {
                 Ok(tailcall) => {
                     match tailcall {
                         TailCall::TailCall => {
@@ -655,7 +655,13 @@ impl<'a> Typecheck<'a> {
                             scope_count += 1;
                         }
                         TailCall::Type(typ) => {
-                            returned_type = typ;
+                            returned_type = match expected_type {
+                                Some(expected_type) => {
+                                    let level = self.subs.var_id();
+                                    self.merge_signature(expr.span, level, &expected_type, typ)
+                                }
+                                None => typ,
+                            };
                             break;
                         }
                     }
@@ -676,10 +682,12 @@ impl<'a> Typecheck<'a> {
         returned_type
     }
 
+    /// `expected_type` should be set to `None` if subsumption is done with it (to prevent us from
+    /// doing it twice)
     fn typecheck_(
         &mut self,
         expr: &mut SpannedExpr<Symbol>,
-        expected_type: Option<&ArcType<Symbol>>,
+        expected_type: &mut Option<&ArcType<Symbol>>,
     ) -> Result<TailCall, TypeError<Symbol>> {
         match expr.value {
             Expr::Ident(ref mut id) => {
@@ -706,8 +714,8 @@ impl<'a> Typecheck<'a> {
                 self.unify_span(expr_check_span(pred), &bool_type, pred_type);
 
                 // Both branches must unify to the same type
-                let true_type = self.typecheck_opt(&mut **if_true, expected_type);
-                let false_type = self.typecheck_opt(&mut **if_false, expected_type);
+                let true_type = self.typecheck_opt(&mut **if_true, expected_type.clone());
+                let false_type = self.typecheck_opt(&mut **if_false, expected_type.take());
 
                 let true_type = self.instantiate_generics(&true_type);
                 let false_type = self.instantiate_generics(&false_type);
@@ -753,7 +761,7 @@ impl<'a> Typecheck<'a> {
             } => {
                 *typ = match exprs.len() {
                     0 => Type::unit(),
-                    1 => self.typecheck_opt(&mut exprs[0], expected_type),
+                    1 => self.typecheck_opt(&mut exprs[0], expected_type.take()),
                     _ => {
                         let fields = exprs
                             .iter_mut()
@@ -774,6 +782,8 @@ impl<'a> Typecheck<'a> {
             Expr::Match(ref mut expr, ref mut alts) => {
                 let typ = self.infer_expr(&mut **expr);
                 let mut expected_alt_type = expected_type.cloned();
+
+                let expected_type = expected_type.take();
 
                 for alt in alts.iter_mut() {
                     self.enter_scope();
@@ -855,10 +865,13 @@ impl<'a> Typecheck<'a> {
             Expr::Lambda(ref mut lambda) => {
                 let loc = format!("{}.lambda:{}", self.symbols.module(), expr.span.start);
                 lambda.id.name = self.symbols.symbol(loc);
+                let level = self.subs.var_id();
                 let function_type = expected_type
                     .cloned()
                     .unwrap_or_else(|| self.subs.new_var());
-                let typ = self.typecheck_lambda(function_type, &mut lambda.args, &mut lambda.body);
+                let mut typ =
+                    self.typecheck_lambda(function_type, &mut lambda.args, &mut lambda.body);
+                self.generalize_type(level, &mut typ);
                 lambda.id.typ = typ.clone();
                 Ok(TailCall::Type(typ))
             }
@@ -896,23 +909,34 @@ impl<'a> Typecheck<'a> {
                 for field in fields {
                     let level = self.subs.var_id();
 
+                    let name = &field.name.value;
+                    let expected_field_type = expected_type
+                        .and_then(|expected_type| {
+                            expected_type
+                                .row_iter()
+                                .find(|expected_field| expected_field.name.name_eq(&name))
+                        })
+                        .map(|field| &field.typ);
+
                     let typ = match field.value {
                         Some(ref mut expr) => {
-                            let name = &field.name.value;
-                            let expected_type = expected_type
-                                .and_then(|expected_type| {
-                                    expected_type
-                                        .row_iter()
-                                        .find(|expected_field| expected_field.name.name_eq(&name))
-                                })
-                                .map(|field| &field.typ);
-
-                            let mut typ = self.typecheck_opt(expr, expected_type);
+                            let mut typ = self.typecheck_opt(expr, expected_field_type);
 
                             self.generalize_type(level, &mut typ);
                             new_skolem_scope(&self.subs, &FnvMap::default(), &typ)
                         }
-                        None => self.find(&field.name.value)?,
+                        None => {
+                            let typ = self.find(&field.name.value)?;
+                            match expected_field_type {
+                                Some(expected_field_type) => self.merge_signature(
+                                    field.name.span,
+                                    level,
+                                    &expected_field_type,
+                                    typ,
+                                ),
+                                None => typ,
+                            }
+                        }
                     };
                     if self.error_on_duplicated_field(&mut duplicated_fields, field.name.clone()) {
                         new_fields.push(Field::new(field.name.value.clone(), typ));
@@ -970,7 +994,10 @@ impl<'a> Typecheck<'a> {
                 for expr in exprs {
                     self.infer_expr(expr);
                 }
-                Ok(TailCall::Type(self.typecheck_opt(last, expected_type)))
+                Ok(TailCall::Type(self.typecheck_opt(
+                    last,
+                    expected_type.take(),
+                )))
             }
             Expr::Do(Do {
                 ref mut id,
@@ -1037,6 +1064,7 @@ impl<'a> Typecheck<'a> {
     where
         I: IntoIterator<Item = &'e mut SpannedExpr<Symbol>>,
     {
+        func_type = self.new_skolem_scope(&func_type);
         for arg in args {
             let f = self.type_cache
                 .function(once(self.subs.new_var()), self.subs.new_var());
@@ -1378,23 +1406,15 @@ impl<'a> Typecheck<'a> {
                     bind.resolved_type = typ;
                 }
 
-                bind.resolved_type = self.new_skolem_scope_signature(&bind.resolved_type);
-                self.typecheck(&mut bind.expr, &bind.resolved_type)
+                let typ = self.new_skolem_scope_signature(&bind.resolved_type);
+                self.typecheck(&mut bind.expr, &typ)
             } else {
-                bind.resolved_type = self.new_skolem_scope_signature(&bind.resolved_type);
-                let function_type = self.instantiate_generics(&bind.resolved_type);
+                let typ = self.new_skolem_scope_signature(&bind.resolved_type);
+                let function_type = self.skolemize(&typ);
                 self.typecheck_lambda(function_type, &mut bind.args, &mut bind.expr)
             };
 
             debug!("let {:?} : {}", bind.name, typ);
-
-            let bind_span = Span::new(
-                bind.name.span.start,
-                bind.args
-                    .last()
-                    .map_or(bind.name.span.end, |last_arg| last_arg.span.end),
-            );
-            typ = self.merge_signature(bind_span, level, &bind.resolved_type, typ);
 
             if !is_recursive {
                 // Merge the type declaration and the actual type
@@ -1616,9 +1636,11 @@ impl<'a> Typecheck<'a> {
                 let typ = self.instantiate_generics(&typ);
                 let record_type = self.remove_alias(typ.clone());
                 with_pattern_types(fields, &record_type, |field_name, binding, field_type| {
+                    let mut field_type = field_type.clone();
+                    self.generalize_type(level, &mut field_type);
                     match *binding {
                         Some(ref mut pat) => {
-                            self.finish_pattern(level, pat, field_type);
+                            self.finish_pattern(level, pat, &field_type);
                         }
                         None => {
                             self.environment
@@ -1628,7 +1650,7 @@ impl<'a> Typecheck<'a> {
                                 .typ = field_type.clone();
                             debug!("{}: {}", field_name, field_type);
 
-                            self.intersect_type(level, field_name, field_type);
+                            self.intersect_type(level, field_name, &field_type);
                         }
                     }
                 });
@@ -1642,7 +1664,9 @@ impl<'a> Typecheck<'a> {
                 let typ = self.top_skolem_scope(typ);
                 let typ = self.instantiate_generics(&typ);
                 for (elem, field) in elems.iter_mut().zip(typ.row_iter()) {
-                    self.finish_pattern(level, elem, &field.typ);
+                    let mut field_type = field.typ.clone();
+                    self.generalize_type(level, &mut field_type);
+                    self.finish_pattern(level, elem, &field_type);
                 }
             }
             Pattern::Constructor(ref id, ref mut args) => {
@@ -1670,8 +1694,8 @@ impl<'a> Typecheck<'a> {
             // Only allow overloading for bindings whose types which do not contain type variables
             // It might be possible to lift this restriction but currently it causes problems
             // which I am not sure how to solve
-            debug!("Looking for intersection `{}`", symbol_type);
             if existing_types.len() >= 2 {
+                debug!("Looking for intersection `{}`", symbol_type);
                 let existing_binding = &existing_types[existing_types.len() - 2];
                 debug!(
                     "Intersect `{}`\n{} ∩ {}",
@@ -1709,7 +1733,7 @@ impl<'a> Typecheck<'a> {
         {
             let constraints: FnvMap<_, _> = intersection_constraints
                 .into_iter()
-                .map(|((l, mut r), name)| {
+                .map(|((mut l, mut r), name)| {
                     let constraints = match *l {
                         Type::Generic(ref gen) => existing_binding.constraints.get(&gen.id),
                         Type::Skolem(ref skolem) => existing_binding.constraints.get(&skolem.name),
@@ -1728,6 +1752,7 @@ impl<'a> Typecheck<'a> {
                         _ => None,
                     };
 
+                    self.generalize_type(level, &mut l);
                     self.generalize_type(level, &mut r);
 
                     (
@@ -1925,6 +1950,11 @@ impl<'a> Typecheck<'a> {
                     id: skolem.name.clone(),
                     kind: skolem.kind.clone(),
                 };
+
+                if self.type_variables.get(&generic.id).is_none() {
+                    unbound_variables.insert(generic.id.clone(), generic.clone());
+                }
+
                 Some(Type::generic(generic))
             }
 
@@ -2328,7 +2358,13 @@ impl<'a, 'b> Iterator for FunctionArgIter<'a, 'b> {
                         Some(typ) => (None, typ.clone()),
                         None => return None,
                     },
-                    None => (Some(self.tc.subs.new_var()), self.tc.subs.new_var()),
+                    None => {
+                        let arg = self.tc.subs.new_var();
+                        let ret = self.tc.subs.new_var();
+                        let f = self.tc.type_cache.function(Some(arg.clone()), ret.clone());
+                        self.tc.unify(&self.typ, f).unwrap();
+                        (Some(arg), ret)
+                    }
                 },
             };
             self.typ = new;

--- a/check/src/unify.rs
+++ b/check/src/unify.rs
@@ -423,13 +423,9 @@ mod test {
                 (&Type::Arrow(ref l1, ref l2), &Type::Arrow(ref r1, ref r2)) => {
                     let arg = f.try_match(l1, r1);
                     let ret = f.try_match(l2, r2);
-                    Ok(merge(
-                        l1,
-                        arg,
-                        l2,
-                        ret,
-                        |a, r| TType(Box::new(Type::Arrow(a, r))),
-                    ))
+                    Ok(merge(l1, arg, l2, ret, |a, r| {
+                        TType(Box::new(Type::Arrow(a, r)))
+                    }))
                 }
                 _ => Err(Error::TypeMismatch(self.clone(), other.clone())),
             }
@@ -496,9 +492,9 @@ mod test {
         let result = unify(&subs, &var1, &int);
         assert_eq!(
             result,
-            Err(Errors::from(
-                vec![Error::TypeMismatch(string.clone(), int.clone())],
-            ),)
+            Err(Errors::from(vec![
+                Error::TypeMismatch(string.clone(), int.clone()),
+            ],),)
         );
     }
 

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -902,7 +902,8 @@ pub fn top_skolem_scope(
     }
 }
 
-pub fn merge_signature(
+/// Performs subsumption between `l` and `r` (`r` is-a `l`)
+pub fn subsumes(
     subs: &Substitution<ArcType>,
     variables: &mut ScopedMap<Symbol, ArcType>,
     level: u32,
@@ -913,7 +914,7 @@ pub fn merge_signature(
     debug!("Subsume {} <=> {}", l, r);
     let mut unifier = UnifierState {
         state: state,
-        unifier: Merge {
+        unifier: Subsume {
             subs: subs,
             variables: variables,
             errors: Errors::new(),
@@ -929,14 +930,14 @@ pub fn merge_signature(
     }
 }
 
-struct Merge<'e> {
+struct Subsume<'e> {
     subs: &'e Substitution<ArcType>,
     variables: &'e mut ScopedMap<Symbol, ArcType>,
     errors: Errors<Error<Symbol>>,
     level: u32,
 }
 
-impl<'a, 'e> Unifier<State<'a>, ArcType> for Merge<'e> {
+impl<'a, 'e> Unifier<State<'a>, ArcType> for Subsume<'e> {
     fn report_error(
         unifier: &mut UnifierState<Self>,
         error: UnifyError<ArcType, TypeError<Symbol>>,

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -63,18 +63,6 @@ impl<'a> State<'a> {
         }
     }
 
-    fn replace_forall(
-        &mut self,
-        typ: &ArcType,
-        named_variables: &mut FnvMap<Symbol, ArcType>,
-    ) -> ArcType {
-        if self.in_alias {
-            typ.instantiate_generics(named_variables)
-        } else {
-            typ.skolemize(named_variables)
-        }
-    }
-
     fn remove_aliases(
         &mut self,
         subs: &Substitution<ArcType>,
@@ -91,7 +79,17 @@ impl<'a> State<'a> {
             Some(mut typ) => {
                 loop {
                     typ = types::walk_move_type(typ.clone(), &mut |typ| match **typ {
-                        Type::Forall(_, _, None) => Some(typ.instantiate(subs, &FnvMap::default())),
+                        Type::Forall(_, _, None) => {
+                            let typ = new_skolem_scope(subs, &FnvMap::default(), typ);
+                            if let Type::Forall(_, _, Some(ref vars)) = *typ {
+                                for var in vars {
+                                    if let Type::Variable(ref var) = **var {
+                                        subs.set_level(var.id, 0);
+                                    }
+                                }
+                            }
+                            Some(typ)
+                        }
                         _ => None,
                     });
                     if let Some(alias_id) = typ.alias_ident() {
@@ -139,8 +137,7 @@ where
             TypeError::FieldMismatch(ref l, ref r) => write!(
                 f,
                 "Field names in record do not match.\n\tExpected: {}\n\tFound: {}",
-                l,
-                r
+                l, r
             ),
             TypeError::UndefinedType(ref id) => write!(f, "Type `{}` does not exist.", id),
             TypeError::SelfRecursive(ref id) => write!(
@@ -390,9 +387,9 @@ where
             let mut named_variables = FnvMap::default();
 
             if unifier.state.in_alias {
-                let l = unifier.state.replace_forall(expected, &mut named_variables);
+                let l = expected.skolemize(&mut named_variables);
                 named_variables.clear();
-                let r = unifier.state.replace_forall(actual, &mut named_variables);
+                let r = actual.skolemize(&mut named_variables);
 
                 Ok(unifier.try_match_res(&l, &r)?.map(|inner_type| {
                     reconstruct_forall(unifier.state.subs, params, inner_type, vars)
@@ -410,9 +407,7 @@ where
                         }),
                     )
                 }));
-                let l = unifier
-                    .state
-                    .replace_forall(expected_iter.typ, &mut named_variables);
+                let l = expected_iter.typ.skolemize(&mut named_variables);
 
                 named_variables.clear();
                 let mut actual_iter = actual.forall_scope_iter();
@@ -430,10 +425,7 @@ where
                         )
                     },
                 ));
-                let r = unifier
-                    .state
-                    .replace_forall(actual_iter.typ, &mut named_variables);
-
+                let r = actual_iter.typ.skolemize(&mut named_variables);
 
                 Ok(unifier.try_match_res(&l, &r)?.map(|inner_type| {
                     reconstruct_forall(unifier.state.subs, params, inner_type, vars)
@@ -442,16 +434,14 @@ where
         }
 
         (&Type::Forall(ref params, _, Some(ref vars)), _) => {
-            let l = unifier
-                .state
-                .replace_forall(expected, &mut FnvMap::default());
-            Ok(unifier.try_match_res(&l, &actual)?.map(|inner_type| {
-                reconstruct_forall(unifier.state.subs, params, inner_type, vars)
-            }))
+            let l = expected.skolemize(&mut FnvMap::default());
+            Ok(unifier
+                .try_match_res(&l, &actual)?
+                .map(|inner_type| reconstruct_forall(unifier.state.subs, params, inner_type, vars)))
         }
 
         (_, &Type::Forall(_, _, Some(_))) => {
-            let r = unifier.state.replace_forall(actual, &mut FnvMap::default());
+            let r = actual.skolemize(&mut FnvMap::default());
             Ok(unifier.try_match_res(expected, &r)?)
         }
 
@@ -834,7 +824,6 @@ where
     Ok((l, r))
 }
 
-
 // HACK
 // Currently the substitution assumes that once a variable has been unified to a
 // concrete type it cannot be unified to another type later.
@@ -868,9 +857,8 @@ pub fn new_skolem_scope(
     constraints: &FnvMap<Symbol, Constraints<ArcType>>,
     typ: &ArcType,
 ) -> ArcType {
-    types::walk_move_type(
-        typ.clone(),
-        &mut |typ| if let Type::Forall(ref params, ref inner_type, None) = **typ {
+    types::walk_move_type(typ.clone(), &mut |typ| {
+        if let Type::Forall(ref params, ref inner_type, None) = **typ {
             let mut skolem = Vec::new();
             for param in params {
                 let constraint = constraints.get(&param.id).cloned();
@@ -886,8 +874,8 @@ pub fn new_skolem_scope(
             )))
         } else {
             None
-        },
-    )
+        }
+    })
 }
 
 pub fn top_skolem_scope(
@@ -974,9 +962,9 @@ impl<'a, 'e> Unifier<State<'a>, ArcType> for Merge<'e> {
             (&Type::Skolem(ref skolem), &Type::Variable(ref r_var))
                 if subs.get_level(skolem.id) > r_var.id =>
             {
-                return Err(UnifyError::Other(
-                    TypeError::UnableToGeneralize(skolem.name.clone()),
-                ));
+                return Err(UnifyError::Other(TypeError::UnableToGeneralize(
+                    skolem.name.clone(),
+                )));
             }
             (&Type::Generic(ref l_gen), &Type::Variable(ref r_var)) => {
                 let left = match unifier.unifier.variables.get(&l_gen.id) {
@@ -989,14 +977,14 @@ impl<'a, 'e> Unifier<State<'a>, ArcType> for Merge<'e> {
                             }
                             // `r_var` is outside the scope of the generic variable.
                             Type::Variable(ref var) if var.id > r_var.id => {
-                                return Err(UnifyError::Other(
-                                    TypeError::UnableToGeneralize(l_gen.id.clone()),
-                                ));
+                                return Err(UnifyError::Other(TypeError::UnableToGeneralize(
+                                    l_gen.id.clone(),
+                                )));
                             }
-                            Type::Skolem(ref skolem) if skolem.id > r_var.id => {
-                                return Err(UnifyError::Other(
-                                    TypeError::UnableToGeneralize(l_gen.id.clone()),
-                                ));
+                            Type::Skolem(ref skolem) if subs.get_level(skolem.id) > r_var.id => {
+                                return Err(UnifyError::Other(TypeError::UnableToGeneralize(
+                                    l_gen.id.clone(),
+                                )));
                             }
                             _ => l,
                         }
@@ -1029,12 +1017,12 @@ impl<'a, 'e> Unifier<State<'a>, ArcType> for Merge<'e> {
             //     // `Typecheck::find`
             //     { id, compose, (<<) }
             // ```
-            (&Type::Forall(ref params, ref l, None), _) => {
-                unifier.unifier.variables.extend(
-                    params
-                        .iter()
-                        .map(|param| (param.id.clone(), subs.new_var())),
-                );
+            (&Type::Forall(ref params, ref l, _), _) => {
+                let mut variables = params
+                    .iter()
+                    .map(|param| (param.id.clone(), subs.new_var()))
+                    .collect();
+                let l = l.instantiate_generics(&mut variables);
                 unifier.try_match_res(&l, r)
             }
             (_, &Type::Variable(ref r)) => {

--- a/check/tests/forall.rs
+++ b/check/tests/forall.rs
@@ -335,7 +335,6 @@ fn field_access_tuple() {
     assert_eq!(result, Ok(Type::int()));
 }
 
-
 #[test]
 fn unit_tuple_match() {
     let _ = ::env_logger::init();
@@ -414,7 +413,6 @@ x
 
     assert_eq!(result, Ok(Type::int()));
 }
-
 
 #[test]
 fn record_expr_base() {
@@ -674,7 +672,6 @@ let { List, f } = make 1
 
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
-
 
 // Unsure if this should be able to compile as is (without  type annotations)
 #[test]
@@ -984,7 +981,6 @@ let show : Show a -> Show (List a) = \d ->
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
 
-
 #[test]
 fn show_list_bug_with_as_pattern() {
     let _ = ::env_logger::init();
@@ -1005,6 +1001,65 @@ let list@{ } = { show }
 
 list.show string_show
 list.show int_show
+"#;
+    let result = support::typecheck(text);
+
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+fn generalize_record_unpacks() {
+    let _ = ::env_logger::init();
+
+    let text = r#"
+type Semigroup a = {
+    append : a -> a -> a
+}
+
+/// A linked list type
+type List a = | Nil | Cons a (List a)
+
+let semigroup : Semigroup (List a) =
+    let append xs ys =
+        match xs with
+        | Cons x zs -> Cons x (append zs ys)
+        | Nil -> ys
+
+    { append }
+
+let { append } = semigroup
+
+append (Cons 1 Nil) Nil
+append (Cons "" Nil) Nil
+"#;
+    let result = support::typecheck(text);
+
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
+#[test]
+#[ignore]
+fn generalize_tuple_unpacks() {
+    let _ = ::env_logger::init();
+
+    let text = r#"
+type Semigroup a = (a -> a -> a, Int)
+
+/// A linked list type
+type List a = | Nil | Cons a (List a)
+
+let semigroup : Semigroup (List a) =
+    let append xs ys =
+        match xs with
+        | Cons x zs -> Cons x (append zs ys)
+        | Nil -> ys
+
+    (append, 0)
+
+let (append, _) = semigroup
+
+append (Cons 1 Nil) Nil
+append (Cons "" Nil) Nil
 "#;
     let result = support::typecheck(text);
 

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -390,9 +390,10 @@ macro_rules! assert_multi_unify_err {
                                     }
                                     None => {
                                         assert!(false,
-                                            "Found {} less errors than expected at {}.\n\
+                                            "Found {} errors but expected {} than expected at {}.\n\
                                             Errors:\n{}\nbut expected {}",
-                                            expected_count - errors.len(),
+                                            errors.len(),
+                                            expected_count,
                                             i,
                                             error,
                                             stringify!($id)

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -198,7 +198,6 @@ impl<'vm> Deref for RootStr<'vm> {
     }
 }
 
-
 struct Roots<'b> {
     vm: GcPtr<Thread>,
     stack: &'b Stack,
@@ -557,9 +556,7 @@ impl Thread {
         // Finally check that type of the returned value is correct
         let expected = T::make_type(self);
         if check_signature(&*env, &expected, &actual) {
-            unsafe {
-                Ok(T::from_value(self, Variants::new(&value)))
-            }
+            unsafe { Ok(T::from_value(self, Variants::new(&value))) }
         } else {
             Err(Error::WrongType(expected, actual.into_owned()))
         }
@@ -650,10 +647,14 @@ impl Thread {
     {
         // For this to be safe we require that the received stack is the same one that is in this
         // VM
-        assert!(unsafe {
-            context as *const _ as usize >= &self.context as *const _ as usize
-                && context as *const _ as usize <= (&self.context as *const _).offset(1) as usize
-        });
+        {
+            let self_context: *const _ = &self.context;
+            let context: *const _ = context;
+            assert!(unsafe {
+                context as usize >= self_context as usize
+                    && context as usize <= self_context.offset(1) as usize
+            });
+        }
         let roots = Roots {
             vm: unsafe {
                 // Threads must only be on the garbage collectors heap which makes this safe
@@ -690,7 +691,6 @@ impl<'a> VmRoot<'a> for RootedThread {
     }
 }
 
-
 /// Internal functions for interacting with threads. These functions should be considered both
 /// unsafe and unstable.
 pub trait ThreadInternal
@@ -710,7 +710,6 @@ where
     fn root_value<'vm, T>(&'vm self, value: Value) -> RootedValue<T>
     where
         T: VmRoot<'vm>;
-
 
     /// Evaluates a zero argument function (a thunk)
     fn call_thunk(&self, closure: GcPtr<ClosureData>) -> FutureValue<Execute<&Self>>;
@@ -1948,7 +1947,6 @@ where
 {
     binop(vm, stack, |l, r| Value::Tag(if f(l, r) { 1 } else { 0 }))
 }
-
 
 #[inline]
 fn binop<'b, F, T>(vm: &'b Thread, stack: &mut StackFrame<'b>, f: F)


### PR DESCRIPTION
The unification algorithm accidentally were to eager to instantiate
generic variables with fresh type variables which allowed programs to
pass typechecking even though they differed in the placement of
variables (see tests).

This fixes that by *ONLY* instantiating fresh typevariables during
subsumption (deduced from Purescript's implementation), otherwise we
only skolemize the variables (which ensures that different variables do
not unify with each other).

This would be enough to fix this, except the a quirk in how typechecking
proceeds throw a wrench into the mix. Consider the following example.

```f#
type Functor f = {
    map : forall a b . (a -> b) -> f a -> f b,
}

let functor : Functor List =
    let map = ...
    { map }
```

Since we want to preserve the alias during typechecking as long as
possible (both as an optimization as well as to present better error
messages), we do not immediately skolemize the inner `forall` binding
(this is what Purescript does).
Instead we only do this once unification forces us to look inside
`Functor List`. This is a problem if we end up skolemizing the same type
*twice* as the skolem constants from each time will not match.

```
{ map : (a@0 -> b@1) -> List a@0 -> List b@1 } <=>
{ map : (a@2 -> b@3) -> List a@2 -> List b@3 }

a@0 != a@2
```

I remedied this by moving the `merge_signature/subsumption` call that
was done on each `let` binding into the typechecking procedure itself
which has the effect of making this subsumption only happen once for
each part of the type.