### PR TITLE
feat: Let gluon compile to WASM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,25 @@
 language: rust
 sudo: required
 cache: cargo
-rust:
-- nightly-2017-12-18
-- beta
-- stable
+matrix:
+  include:
+  - rust: nightly-2017-12-18
+  - rust: beta
+  - rust: stable
+  - rust: nightly-2017-12-18
+    env: WASM=1
 os:
 - linux
 env:
 - RUST_BACKTRACE=1
 script:
-- ./scripts/travis.sh
+- >
+    if [[ -z ${WASM+set} ]]; then
+        ./scripts/travis.sh
+    else
+        rustup target add wasm32-unknown-unknown
+        cargo check --target wasm32-unknown-unknown -p gluon_c-api
+    fi
 notifications:
   webhooks:
     urls:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ collect-mac = "0.1.0"
 either = "1.0.0"
 itertools = "0.7.0"
 futures = "0.1.11"
-tokio-core = "0.1"
+tokio-core = { version = "0.1", optional = true }
 
 serde = { version = "1.0.0", optional = true }
 serde_state = { version = "0.4.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/lib.rs"
 gluon_base = { path = "base", version = "0.7.0" } # GLUON
 gluon_check = { path = "check", version = "0.7.0" } # GLUON
 gluon_parser = { path = "parser", version = "0.7.0" } # GLUON
-gluon_vm = { path = "vm", version = "0.7.0" } # GLUON
+gluon_vm = { path = "vm", version = "0.7.0", default-features = false } # GLUON
 
 log = "0.3.6"
 quick-error = "1.0.0"
@@ -33,7 +33,8 @@ collect-mac = "0.1.0"
 either = "1.0.0"
 itertools = "0.7.0"
 futures = "0.1.11"
-tokio-core = { version = "0.1", optional = true }
+# WASM Does not support tokio
+# tokio-core = { version = "0.1", optional = true }
 
 serde = { version = "1.0.0", optional = true }
 serde_state = { version = "0.4.0", optional = true }
@@ -41,11 +42,14 @@ serde_derive_state = { version = "0.4.0", optional = true }
 
 # Binding crates
 regex = { version = "0.2.1", optional = true }
-rand = { version = "0.3", optional = true }
 
-# Crates used in testing Testing
+# Crates used in testing
 compiletest_rs = { version = "0.3", optional = true }
 skeptic = { version = "0.6", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio-core = "0.1"
+rand = { version = "0.3", optional = true }
 
 [build-dependencies]
 skeptic = { version = "0.6", optional = true }

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -11,13 +11,16 @@ repository = "https://github.com/gluon-lang/gluon"
 documentation = "https://docs.rs/gluon"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 libc = "0.2.14"
-gluon = { version = "0.7.0", path = ".." } # GLUON
+gluon = { version = "0.7.0", path = "..", default-features = false } # GLUON
 
 [features]
+default = ["c_void", "gluon/default"]
+
 test = ["gluon/test"]
 nightly = ["gluon/nightly"]
 skeptic = ["gluon/skeptic"]
+c_void = []

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -14,13 +14,12 @@ documentation = "https://docs.rs/gluon"
 crate-type = ["cdylib"]
 
 [dependencies]
+gluon = { version = "0.7.0", path = ".." } # GLUON
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc = "0.2.14"
-gluon = { version = "0.7.0", path = "..", default-features = false } # GLUON
 
 [features]
-default = ["c_void", "gluon/default"]
-
 test = ["gluon/test"]
 nightly = ["gluon/nightly"]
 skeptic = ["gluon/skeptic"]
-c_void = []

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -25,15 +25,18 @@ pub enum Error {
     Unknown,
 }
 
+#[no_mangle]
 pub extern "C" fn glu_new_vm() -> *const Thread {
     let vm = RootedThread::new();
     vm.into_raw()
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn glu_free_vm(vm: &Thread) {
     RootedThread::from_raw(vm);
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn glu_run_expr(
     vm: &Thread,
     module: &u8,
@@ -56,6 +59,7 @@ pub unsafe extern "C" fn glu_run_expr(
     }
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn glu_load_script(
     vm: &Thread,
     module: &u8,
@@ -78,6 +82,7 @@ pub unsafe extern "C" fn glu_load_script(
     }
 }
 
+#[no_mangle]
 pub extern "C" fn glu_call_function(thread: &Thread, args: VmIndex) -> Error {
     let context = thread.context();
     match thread.call_function(context, args) {
@@ -86,12 +91,14 @@ pub extern "C" fn glu_call_function(thread: &Thread, args: VmIndex) -> Error {
     }
 }
 
+#[no_mangle]
 pub extern "C" fn glu_len(vm: &Thread) -> usize {
     let mut context = vm.context();
     let stack = context.stack.current_frame();
     stack.len() as usize
 }
 
+#[no_mangle]
 pub extern "C" fn glu_pop(vm: &Thread, n: usize) {
     let mut context = vm.context();
     for _ in 0..n {
@@ -99,22 +106,27 @@ pub extern "C" fn glu_pop(vm: &Thread, n: usize) {
     }
 }
 
+#[no_mangle]
 pub extern "C" fn glu_push_int(vm: &Thread, int: VmInt) {
     Thread::push(vm, int).unwrap();
 }
 
+#[no_mangle]
 pub extern "C" fn glu_push_byte(vm: &Thread, b: u8) {
     Thread::push(vm, b).unwrap();
 }
 
+#[no_mangle]
 pub extern "C" fn glu_push_float(vm: &Thread, float: f64) {
     Thread::push(vm, float).unwrap();
 }
 
+#[no_mangle]
 pub extern "C" fn glu_push_bool(vm: &Thread, b: i8) {
     Thread::push(vm, b != 0).unwrap();
 }
 
+#[no_mangle]
 pub unsafe extern "C" fn glu_push_function(
     vm: &Thread,
     name: &u8,
@@ -133,6 +145,7 @@ pub unsafe extern "C" fn glu_push_function(
 }
 
 /// Push a string to the stack. The string must be valid utf-8 or an error will be returned
+#[no_mangle]
 pub unsafe extern "C" fn glu_push_string(vm: &Thread, s: &u8, len: usize) -> Error {
     let s = match str::from_utf8(slice::from_raw_parts(s, len)) {
         Ok(s) => s,
@@ -146,6 +159,7 @@ pub unsafe extern "C" fn glu_push_string(vm: &Thread, s: &u8, len: usize) -> Err
 
 /// Push a string to the stack. If the string is not utf-8 this function will trigger undefined
 /// behaviour.
+#[no_mangle]
 pub unsafe extern "C" fn glu_push_string_unchecked(vm: &Thread, s: &u8, len: usize) -> Error {
     let s = str::from_utf8_unchecked(slice::from_raw_parts(s, len));
     match s.push(vm, &mut vm.context()) {
@@ -155,22 +169,27 @@ pub unsafe extern "C" fn glu_push_string_unchecked(vm: &Thread, s: &u8, len: usi
 }
 
 #[cfg(feature = "c_void")]
+#[no_mangle]
 pub extern "C" fn glu_push_light_userdata(vm: &Thread, data: *mut libc::c_void) {
     Thread::push(vm, data as usize).unwrap()
 }
 
+#[no_mangle]
 pub extern "C" fn glu_get_byte(vm: &Thread, index: VmIndex, out: &mut u8) -> Error {
     get_value(vm, index, out)
 }
 
+#[no_mangle]
 pub extern "C" fn glu_get_int(vm: &Thread, index: VmIndex, out: &mut VmInt) -> Error {
     get_value(vm, index, out)
 }
 
+#[no_mangle]
 pub extern "C" fn glu_get_float(vm: &Thread, index: VmIndex, out: &mut f64) -> Error {
     get_value(vm, index, out)
 }
 
+#[no_mangle]
 pub extern "C" fn glu_get_bool(vm: &Thread, index: VmIndex, out: &mut i8) -> Error {
     let mut b = false;
     let err = get_value(vm, index, &mut b);
@@ -182,6 +201,7 @@ pub extern "C" fn glu_get_bool(vm: &Thread, index: VmIndex, out: &mut i8) -> Err
 
 /// The returned string is garbage collected and may not be valid after the string is removed from
 /// its slot in the stack
+#[no_mangle]
 pub unsafe extern "C" fn glu_get_string(
     vm: &Thread,
     index: VmIndex,
@@ -204,6 +224,7 @@ pub unsafe extern "C" fn glu_get_string(
 }
 
 #[cfg(feature = "c_void")]
+#[no_mangle]
 pub extern "C" fn glu_get_light_userdata(
     vm: &Thread,
     index: VmIndex,

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -2,6 +2,7 @@
 #![doc(html_root_url = "https://docs.rs/gluon_c-api/0.7.0")] // # GLUON
 
 extern crate gluon;
+#[cfg(feature = "c_void")]
 extern crate libc;
 
 use std::str;
@@ -153,6 +154,7 @@ pub unsafe extern "C" fn glu_push_string_unchecked(vm: &Thread, s: &u8, len: usi
     }
 }
 
+#[cfg(feature = "c_void")]
 pub extern "C" fn glu_push_light_userdata(vm: &Thread, data: *mut libc::c_void) {
     Thread::push(vm, data as usize).unwrap()
 }
@@ -188,9 +190,10 @@ pub unsafe extern "C" fn glu_get_string(
 ) -> Error {
     let mut context = vm.context();
     let stack = context.stack.current_frame();
-    match stack.get_variants(index).map(|value| {
-        <&str>::from_value(vm, value)
-    }) {
+    match stack
+        .get_variants(index)
+        .map(|value| <&str>::from_value(vm, value))
+    {
         Some(value) => {
             *out = &*value.as_ptr();
             *out_len = value.len();
@@ -200,6 +203,7 @@ pub unsafe extern "C" fn glu_get_string(
     }
 }
 
+#[cfg(feature = "c_void")]
 pub extern "C" fn glu_get_light_userdata(
     vm: &Thread,
     index: VmIndex,
@@ -219,9 +223,10 @@ where
 {
     let mut context = vm.context();
     let stack = context.stack.current_frame();
-    match stack.get_variants(index).map(
-        |value| T::from_value(vm, value),
-    ) {
+    match stack
+        .get_variants(index)
+        .map(|value| T::from_value(vm, value))
+    {
         Some(value) => {
             *out = value;
             Error::Ok
@@ -287,6 +292,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "c_void")]
     #[test]
     fn push_userdata() {
         unsafe {

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -2,7 +2,7 @@
 #![doc(html_root_url = "https://docs.rs/gluon_c-api/0.7.0")] // # GLUON
 
 extern crate gluon;
-#[cfg(feature = "c_void")]
+#[cfg(not(target_arch = "wasm32"))]
 extern crate libc;
 
 use std::str;
@@ -168,7 +168,7 @@ pub unsafe extern "C" fn glu_push_string_unchecked(vm: &Thread, s: &u8, len: usi
     }
 }
 
-#[cfg(feature = "c_void")]
+#[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub extern "C" fn glu_push_light_userdata(vm: &Thread, data: *mut libc::c_void) {
     Thread::push(vm, data as usize).unwrap()
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn glu_get_string(
     }
 }
 
-#[cfg(feature = "c_void")]
+#[cfg(feature = "libc")]
 #[no_mangle]
 pub extern "C" fn glu_get_light_userdata(
     vm: &Thread,
@@ -313,7 +313,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "c_void")]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn push_userdata() {
         unsafe {

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn glu_get_string(
     }
 }
 
-#[cfg(feature = "libc")]
+#[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub extern "C" fn glu_get_light_userdata(
     vm: &Thread,

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -30,7 +30,6 @@ use vm::thread::{Execute, RootedValue, Thread, ThreadInternal, VmRoot};
 
 use {Compiler, Error, Result};
 
-
 fn execute<T, F>(vm: T, f: F) -> FutureValue<Execute<T>>
 where
     T: Deref<Target = Thread>,
@@ -438,13 +437,11 @@ where
 
         let vm1 = vm.clone();
         execute(vm1, |vm| vm.call_thunk(closure))
-            .map(|(vm, value)| {
-                ExecuteValue {
-                    id: module_id,
-                    expr: expr,
-                    typ: typ,
-                    value: vm.root_value_with_self(value),
-                }
+            .map(|(vm, value)| ExecuteValue {
+                id: module_id,
+                expr: expr,
+                typ: typ,
+                value: vm.root_value_with_self(value),
             })
             .map_err(Error::from)
             .and_then(move |v| {
@@ -537,8 +534,7 @@ where
         if filename != module_id.as_ref() {
             return FutureValue::sync(Err(format!(
                 "filenames do not match `{}` != `{}`",
-                filename,
-                module_id
+                filename, module_id
             ).into()))
                 .boxed();
         }
@@ -546,13 +542,11 @@ where
         let vm1 = vm.clone();
         let closure = try_future!(vm.global_env().new_global_thunk(module.module));
         execute(vm1, |vm| vm.call_thunk(closure))
-            .map(|(vm, value)| {
-                ExecuteValue {
-                    id: module_id,
-                    expr: (),
-                    typ: typ,
-                    value: vm.root_value_with_self(value),
-                }
+            .map(|(vm, value)| ExecuteValue {
+                id: module_id,
+                expr: (),
+                typ: typ,
+                value: vm.root_value_with_self(value),
             })
             .map_err(Error::from)
             .boxed()
@@ -642,7 +636,6 @@ where
             typ,
             value,
         } = v;
-
 
         let vm1 = vm.clone();
         execute(vm1, |vm| vm.execute_io(*value))

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -502,7 +502,8 @@ pub struct Module {
 
     pub metadata: Metadata,
 
-    #[cfg_attr(feature = "serde_derive_state", serde(state))] pub module: CompiledModule,
+    #[cfg_attr(feature = "serde_derive_state", serde(state))]
+    pub module: CompiledModule,
 }
 
 #[cfg(feature = "serde")]

--- a/src/import.rs
+++ b/src/import.rs
@@ -17,7 +17,6 @@ use base::pos::{self, BytePos, Span};
 use base::symbol::Symbol;
 use base::types::ArcType;
 
-
 use vm::{ExternLoader, ExternModule};
 use vm::macros::{Error as MacroError, Macro, MacroExpander};
 use vm::thread::{Thread, ThreadInternal};
@@ -406,7 +405,6 @@ fn get_state<'m>(macros: &'m mut MacroExpander) -> &'m mut State {
         .downcast_mut::<State>()
         .unwrap()
 }
-
 
 struct State {
     visited: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ extern crate itertools;
 extern crate log;
 #[macro_use]
 extern crate quick_error;
-#[cfg(feature = "tokio-core")]
+#[cfg(not(target_arch = "wasm32"))]
 extern crate tokio_core;
 
 #[cfg(feature = "serde_derive_state")]
@@ -546,7 +546,7 @@ in ()
 
 #[derive(Default)]
 pub struct VmBuilder {
-    #[cfg(feature = "tokio-core")]
+    #[cfg(not(target_arch = "wasm32"))]
     event_loop: Option<::tokio_core::reactor::Remote>,
 }
 
@@ -555,7 +555,7 @@ impl VmBuilder {
         VmBuilder::default()
     }
 
-    #[cfg(feature = "tokio-core")]
+    #[cfg(not(target_arch = "wasm32"))]
     option!{
         /// Sets then event loop which threads are run on
         /// (default: None)
@@ -563,12 +563,12 @@ impl VmBuilder {
     }
 
     pub fn build(self) -> RootedThread {
-        #[cfg(not(feature = "tokio-core"))]
+        #[cfg(target_arch = "wasm32")]
         let vm = RootedThread::new();
 
-        #[cfg(feature = "tokio-core")]
+        #[cfg(not(target_arch = "wasm32"))]
         let vm = RootedThread::with_global_state(
-            GlobalVmStateBuilder::new()
+            ::vm::vm::GlobalVmStateBuilder::new()
                 .event_loop(self.event_loop)
                 .build(),
         );

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -23,7 +23,7 @@ pretty = "0.3.2"
 bitflags = "1.0.0"
 itertools = "0.7.0"
 futures = "0.1.0"
-tokio-core = "0.1.0"
+tokio-core = { version = "0.1.0", optional = true }
 typed-arena = "1.2.0"
 smallvec = "0.2.1"
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -23,7 +23,6 @@ pretty = "0.3.2"
 bitflags = "1.0.0"
 itertools = "0.7.0"
 futures = "0.1.0"
-tokio-core = { version = "0.1.0", optional = true }
 typed-arena = "1.2.0"
 smallvec = "0.2.1"
 
@@ -34,6 +33,9 @@ serde_derive_state = { version = "0.4.0", optional = true }
 
 gluon_base = { path = "../base", version = "0.7.0" } # GLUON
 gluon_check = { path = "../check", version = "0.7.0" } # GLUON
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio-core = "0.1"
 
 [build-dependencies]
 lalrpop = { version = "0.13.1", optional = true }

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -132,9 +132,7 @@ impl<'a> Data<'a> {
     pub fn get_variants(&self, index: usize) -> Option<Variants<'a>> {
         match self.0 {
             DataInner::Tag(_) => None,
-            DataInner::Data(data) => unsafe {
-                data.fields.get(index).map(|v| Variants::new(v))
-            },
+            DataInner::Data(data) => unsafe { data.fields.get(index).map(|v| Variants::new(v)) },
         }
     }
 
@@ -700,9 +698,7 @@ impl<'vm, 's> Pushable<'vm> for &'s String {
 }
 impl<'vm, 's> Pushable<'vm> for &'s str {
     fn push(self, thread: &'vm Thread, context: &mut Context) -> Result<()> {
-        let s = unsafe {
-            GcStr::from_utf8_unchecked(context.alloc_with(thread, self.as_bytes())?)
-        };
+        let s = unsafe { GcStr::from_utf8_unchecked(context.alloc_with(thread, self.as_bytes())?) };
         context.stack.push(Value::String(s));
         Ok(())
     }
@@ -733,11 +729,9 @@ impl<'vm> Pushable<'vm> for char {
 impl<'vm> Getable<'vm> for char {
     fn from_value(_: &'vm Thread, value: Variants) -> char {
         match value.as_ref() {
-            ValueRef::Int(x) => {
-                match ::std::char::from_u32(x as u32) {
-                    Some(ch) => ch,
-                    None => ice!("Failed conversion from Int to char for: {}", x),
-                }
+            ValueRef::Int(x) => match ::std::char::from_u32(x as u32) {
+                Some(ch) => ch,
+                None => ice!("Failed conversion from Int to char for: {}", x),
             },
             _ => ice!("ValueRef is not an Int"),
         }
@@ -789,7 +783,7 @@ impl<'s, 'vm, T: Copy + ArrayRepr> Getable<'vm> for &'s [T] {
             ValueRef::Array(ptr) => {
                 let s = ptr.0.as_slice().unwrap();
                 &*(s as *const _)
-            },
+            }
             _ => ice!("ValueRef is not an Array"),
         }
     }
@@ -852,7 +846,7 @@ impl<'vm, T: vm::Userdata> Getable<'vm> for *const T {
             ValueRef::Userdata(data) => {
                 let x = data.downcast_ref::<T>().unwrap();
                 x as *const T
-            },
+            }
             _ => ice!("ValueRef is not an Userdata"),
         }
     }
@@ -967,7 +961,6 @@ impl<F> FutureResult<F> {
         FutureResult(f)
     }
 }
-
 
 impl<F> VmType for FutureResult<F>
 where
@@ -1270,7 +1263,6 @@ where
     }
 }
 
-
 impl<'vm, T: VmType> Pushable<'vm> for Array<'vm, T>
 where
     T::Type: Sized,
@@ -1414,7 +1406,6 @@ macro_rules! define_tuples {
     }
 }
 define_tuples! { A B C D E F G H I J K L }
-
 
 pub use self::record::Record;
 
@@ -1592,7 +1583,6 @@ impl<'vm, F: VmType> VmType for RefPrimitive<'vm, F> {
     }
 }
 
-
 impl<'vm, F> Pushable<'vm> for RefPrimitive<'vm, F>
 where
     F: VmFunction<'vm> + FunctionType + VmType + 'vm,
@@ -1653,7 +1643,6 @@ impl<'vm> Pushable<'vm> for CPrimitive {
         Ok(())
     }
 }
-
 
 fn make_type<T: ?Sized + VmType>(vm: &Thread) -> ArcType {
     <T as VmType>::make_type(vm)
@@ -1962,14 +1951,12 @@ make_vm_function!(A, B, C, D, E);
 make_vm_function!(A, B, C, D, E, F);
 make_vm_function!(A, B, C, D, E, F, G);
 
-
 pub struct TypedBytecode<T> {
     id: Symbol,
     args: VmIndex,
     instructions: Vec<Instruction>,
     _marker: PhantomData<T>,
 }
-
 
 impl<T> TypedBytecode<T> {
     pub fn new(name: &str, args: VmIndex, instructions: Vec<Instruction>) -> TypedBytecode<T>

--- a/vm/src/api/ser.rs
+++ b/vm/src/api/ser.rs
@@ -135,7 +135,6 @@ where
     }
 }
 
-
 impl<'vm, T> Pushable<'vm> for Ser<T>
 where
     T: Serialize,
@@ -555,7 +554,6 @@ impl<'a, 'vm> ser::SerializeStructVariant for RecordSerializer<'a, 'vm> {
         self.serializer.alloc(self.variant_index, self.values)
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/vm/src/api/typ.rs
+++ b/vm/src/api/typ.rs
@@ -20,8 +20,7 @@ where
 type {0} = {1}
 {{ {0} }}
 "#,
-        name,
-        typ
+        name, typ
     ))
 }
 
@@ -537,7 +536,6 @@ impl<'de, 'a> VariantAccess<'de> for Enum<'a, 'de> {
         self.tuple_variant(fields.len(), visitor)
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -212,7 +212,7 @@ fn spawn_<'vm>(value: WithVM<'vm, Function<&'vm Thread, fn(())>>) -> VmResult<Ro
 
 type Action = fn(()) -> OpaqueValue<RootedThread, IO<Generic<A>>>;
 
-#[cfg(not(feature = "tokio-core"))]
+#[cfg(target_arch = "wasm32")]
 fn spawn_on<'vm>(
     _thread: RootedThread,
     _action: WithVM<'vm, FunctionRef<Action>>,
@@ -220,7 +220,7 @@ fn spawn_on<'vm>(
     IO::Exception("spawn_on requires the `tokio_core` crate".to_string())
 }
 
-#[cfg(feature = "tokio-core")]
+#[cfg(not(target_arch = "wasm32"))]
 fn spawn_on<'vm>(
     thread: RootedThread,
     action: WithVM<'vm, FunctionRef<Action>>,

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -212,15 +212,15 @@ fn spawn_<'vm>(value: WithVM<'vm, Function<&'vm Thread, fn(())>>) -> VmResult<Ro
 
 type Action = fn(()) -> OpaqueValue<RootedThread, IO<Generic<A>>>;
 
-#[cfg(not(feature = "tokio_core"))]
+#[cfg(not(feature = "tokio-core"))]
 fn spawn_on<'vm>(
-    thread: RootedThread,
-    action: WithVM<'vm, FunctionRef<Action>>,
+    _thread: RootedThread,
+    _action: WithVM<'vm, FunctionRef<Action>>,
 ) -> IO<OpaqueValue<&'vm Thread, IO<Generic<A>>>> {
     IO::Exception("spawn_on requires the `tokio_core` crate".to_string())
 }
 
-#[cfg(feature = "tokio_core")]
+#[cfg(feature = "tokio-core")]
 fn spawn_on<'vm>(
     thread: RootedThread,
     action: WithVM<'vm, FunctionRef<Action>>,

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -47,8 +47,10 @@ pub struct UpvarInfo {
 pub struct DebugInfo {
     /// Maps instruction indexes to the line that spawned them
     pub source_map: SourceMap,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub local_map: LocalMap,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub upvars: Vec<UpvarInfo>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub local_map: LocalMap,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub upvars: Vec<UpvarInfo>,
     pub source_name: String,
 }
 
@@ -83,12 +85,14 @@ pub struct CompiledFunction {
     #[cfg_attr(feature = "serde_derive_state", serde(state))]
     pub inner_functions: Vec<CompiledFunction>,
 
-    #[cfg_attr(feature = "serde_derive_state", serde(state))] pub strings: Vec<InternedStr>,
+    #[cfg_attr(feature = "serde_derive_state", serde(state))]
+    pub strings: Vec<InternedStr>,
 
     #[cfg_attr(feature = "serde_derive", serde(state_with = "::serialization::borrow"))]
     pub records: Vec<Vec<Symbol>>,
 
-    #[cfg_attr(feature = "serde_derive_state", serde(state))] pub debug_info: DebugInfo,
+    #[cfg_attr(feature = "serde_derive_state", serde(state))]
+    pub debug_info: DebugInfo,
 }
 
 impl From<CompiledFunction> for CompiledModule {

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -187,12 +187,15 @@ impl FunctionEnvs {
                     .function
                     .debug_info
                     .upvars
-                    .extend(function.free_vars.iter().map(|&(ref name, ref typ)| {
-                        UpvarInfo {
-                            name: name.declared_name().to_string(),
-                            typ: typ.clone(),
-                        }
-                    }));
+                    .extend(
+                        function
+                            .free_vars
+                            .iter()
+                            .map(|&(ref name, ref typ)| UpvarInfo {
+                                name: name.declared_name().to_string(),
+                                typ: typ.clone(),
+                            }),
+                    );
             }
         }
 
@@ -271,7 +274,6 @@ impl FunctionEnv {
         }
         Ok(())
     }
-
 
     fn add_record_map(&mut self, fields: Vec<Symbol>) -> VmIndex {
         match self.function.records.iter().position(|t| *t == fields) {

--- a/vm/src/core/interpreter.rs
+++ b/vm/src/core/interpreter.rs
@@ -499,13 +499,11 @@ impl<'a, 'e> Compiler<'a, 'e> {
                                         return None;
                                     }
                                 };
-                                let new_body = new_body.map(|expr| {
-                                    Closure {
-                                        pos: closure.pos,
-                                        name: closure.name.clone(),
-                                        args: closure.args.clone(),
-                                        expr: expr.into_local(self.allocator),
-                                    }
+                                let new_body = new_body.map(|expr| Closure {
+                                    pos: closure.pos,
+                                    name: closure.name.clone(),
+                                    args: closure.args.clone(),
+                                    expr: expr.into_local(self.allocator),
                                 });
 
                                 function.exit_scope();
@@ -880,7 +878,6 @@ mod tests {
             "let f x y = (#Int+) x y in { f }",
         ).unwrap();
         let global: CExpr = global_allocator.arena.alloc(global);
-
 
         let expr = r#"
             let g y = (match global with | { f } -> f end) 2 y in

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -120,7 +120,6 @@ impl<'a> fmt::Display for Expr<'a> {
 
 const INDENT: usize = 4;
 
-
 #[derive(Default)]
 #[must_use]
 struct Binder<'a> {
@@ -539,11 +538,9 @@ impl<'a, 'e> Translator<'a, 'e> {
             ast::Expr::Match(ref expr, ref alts) => {
                 let expr = self.translate_alloc(expr);
                 let alts: Vec<_> = alts.iter()
-                    .map(|alt| {
-                        Equation {
-                            patterns: vec![&alt.pattern],
-                            result: self.translate_alloc(&alt.expr),
-                        }
+                    .map(|alt| Equation {
+                        patterns: vec![&alt.pattern],
+                        result: self.translate_alloc(&alt.expr),
                     })
                     .collect();
                 PatternTranslator(self).translate_top(expr, &alts).clone()
@@ -727,16 +724,14 @@ impl<'a, 'e> Translator<'a, 'e> {
         if is_recursive {
             let closures = binds
                 .iter()
-                .map(|bind| {
-                    Closure {
-                        pos: bind.name.span.start,
-                        name: match bind.name.value {
-                            ast::Pattern::Ident(ref id) => id.clone(),
-                            _ => unreachable!(),
-                        },
-                        args: bind.args.iter().map(|arg| arg.value.clone()).collect(),
-                        expr: self.translate_alloc(&bind.expr),
-                    }
+                .map(|bind| Closure {
+                    pos: bind.name.span.start,
+                    name: match bind.name.value {
+                        ast::Pattern::Ident(ref id) => id.clone(),
+                        _ => unreachable!(),
+                    },
+                    args: bind.args.iter().map(|arg| arg.value.clone()).collect(),
+                    expr: self.translate_alloc(&bind.expr),
                 })
                 .collect();
             Expr::Let(
@@ -827,11 +822,9 @@ impl<'a, 'e> Translator<'a, 'e> {
             let mut args = arg_iter(typ.remove_forall());
             unapplied_args = args.by_ref()
                 .enumerate()
-                .map(|(i, arg)| {
-                    TypedIdent {
-                        name: Symbol::from(format!("#{}", i)),
-                        typ: arg.clone(),
-                    }
+                .map(|(i, arg)| TypedIdent {
+                    name: Symbol::from(format!("#{}", i)),
+                    typ: arg.clone(),
                 })
                 .collect();
             data_type = args.typ.clone();
@@ -985,7 +978,6 @@ impl<'a> Visitor<'a, 'a> for ReplaceVariables<'a> {
     }
 }
 
-
 /// `PatternTranslator` translated nested (AST) patterns into non-nested (core) patterns.
 ///
 /// It does this this by looking at each nested pattern as part of an `Equation` to be solved.
@@ -1081,15 +1073,13 @@ impl<'a, 'e> PatternTranslator<'a, 'e> {
                 .iter()
                 .map(|equation| (&equation.patterns[1..], equation.result))
                 .zip(&temp)
-                .map(|((remaining_equations, result), first)| {
-                    Equation {
-                        patterns: first
-                            .iter()
-                            .map(|pattern| &**pattern)
-                            .chain(remaining_equations.iter().cloned())
-                            .collect(),
-                        result,
-                    }
+                .map(|((remaining_equations, result), first)| Equation {
+                    patterns: first
+                        .iter()
+                        .map(|pattern| &**pattern)
+                        .chain(remaining_equations.iter().cloned())
+                        .collect(),
+                    result,
                 })
                 .collect::<Vec<_>>();
 
@@ -1228,11 +1218,9 @@ impl<'a, 'e> PatternTranslator<'a, 'e> {
             &variables[1..],
             &equations
                 .iter()
-                .map(|equation| {
-                    Equation {
-                        patterns: equation.patterns[1..].to_owned(),
-                        result: equation.result,
-                    }
+                .map(|equation| Equation {
+                    patterns: equation.patterns[1..].to_owned(),
+                    result: equation.result,
                 })
                 .collect::<Vec<_>>(),
         );
@@ -1546,11 +1534,9 @@ impl<'a> Iterator for PatternIdentifiers<'a> {
                     field
                         .1
                         .as_ref()
-                        .map(|name| {
-                            TypedIdent {
-                                name: name.clone(),
-                                typ: field.0.typ.clone(),
-                            }
+                        .map(|name| TypedIdent {
+                            name: name.clone(),
+                            typ: field.0.typ.clone(),
                         })
                         .unwrap_or_else(|| field.0.clone()),
                 )
@@ -1578,11 +1564,9 @@ impl<'a> DoubleEndedIterator for PatternIdentifiers<'a> {
                     field
                         .1
                         .as_ref()
-                        .map(|name| {
-                            TypedIdent {
-                                name: name.clone(),
-                                typ: field.0.typ.clone(),
-                            }
+                        .map(|name| TypedIdent {
+                            name: name.clone(),
+                            typ: field.0.typ.clone(),
                         })
                         .unwrap_or_else(|| field.0.clone()),
                 )

--- a/vm/src/core/optimize.rs
+++ b/vm/src/core/optimize.rs
@@ -68,7 +68,6 @@ impl<'a, 'b> Visitor<'a, 'b> for DifferentLifetime<'a, 'b> {
     }
 }
 
-
 pub trait Visitor<'a, 'b> {
     type Producer: ExprProducer<'a, 'b>;
 
@@ -261,11 +260,9 @@ where
                 &alts,
                 |a| {
                     let a = a.iter()
-                        .map(|a| {
-                            Alternative {
-                                pattern: a.pattern.clone(),
-                                expr: V::Producer::new(visitor.allocator()).produce(a.expr),
-                            }
+                        .map(|a| Alternative {
+                            pattern: a.pattern.clone(),
+                            expr: V::Producer::new(visitor.allocator()).produce(a.expr),
                         })
                         .collect::<Vec<_>>();
                     visitor.allocator().alternative_arena.alloc_extend(a)
@@ -277,7 +274,6 @@ where
     }
 }
 
-
 fn walk_bind<'a, 'b, V>(visitor: &mut V, bind: &LetBinding<'b>) -> Option<LetBinding<'a>>
 where
     V: ?Sized + Visitor<'a, 'b>,
@@ -287,32 +283,26 @@ where
         Named::Recursive(ref closures) => merge_iter(
             closures,
             |closure| {
-                visitor.visit_expr(closure.expr).map(|new_expr| {
-                    Closure {
-                        pos: closure.pos,
-                        name: closure.name.clone(),
-                        args: closure.args.clone(),
-                        expr: new_expr,
-                    }
-                })
-            },
-            |closure| {
-                Closure {
+                visitor.visit_expr(closure.expr).map(|new_expr| Closure {
                     pos: closure.pos,
                     name: closure.name.clone(),
                     args: closure.args.clone(),
-                    expr: V::Producer::new(allocator.expect("Allocator")).produce(closure.expr),
-                }
+                    expr: new_expr,
+                })
+            },
+            |closure| Closure {
+                pos: closure.pos,
+                name: closure.name.clone(),
+                args: closure.args.clone(),
+                expr: V::Producer::new(allocator.expect("Allocator")).produce(closure.expr),
             },
         ).map(Named::Recursive),
         Named::Expr(bind_expr) => visitor.visit_expr(bind_expr).map(Named::Expr),
     };
-    new_named.map(|named| {
-        LetBinding {
-            name: bind.name.clone(),
-            expr: named,
-            span_start: bind.span_start,
-        }
+    new_named.map(|named| LetBinding {
+        name: bind.name.clone(),
+        expr: named,
+        span_start: bind.span_start,
     })
 }
 
@@ -321,14 +311,11 @@ where
     V: ?Sized + Visitor<'a, 'b>,
 {
     let new_expr = visitor.visit_expr(alt.expr);
-    new_expr.map(|expr| {
-        Alternative {
-            pattern: alt.pattern.clone(),
-            expr: expr,
-        }
+    new_expr.map(|expr| Alternative {
+        pattern: alt.pattern.clone(),
+        expr: expr,
     })
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -169,7 +169,6 @@ pub struct Gc {
     generation: Generation,
 }
 
-
 /// Trait which creates a typed pointer from a *mut () pointer.
 /// For `Sized` types this is just a cast but for unsized types some more metadata must be taken
 /// from the provided `D` value to make it initialize correctly.
@@ -233,7 +232,6 @@ struct GcHeader {
     value_size: usize,
     type_info: *const TypeInfo,
 }
-
 
 struct AllocPtr {
     ptr: *mut GcHeader,
@@ -588,7 +586,6 @@ where
     }
 }
 
-
 impl Gc {
     /// Constructs a new garbage collector
     pub fn new(generation: Generation, memory_limit: usize) -> Gc {
@@ -829,7 +826,6 @@ impl Gc {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -859,8 +855,6 @@ mod tests {
         }
     }
 
-
-
     fn object_count(gc: &Gc) -> usize {
         let mut header: &GcHeader = match gc.values {
             Some(ref x) => &**x,
@@ -878,7 +872,6 @@ mod tests {
         }
         count
     }
-
 
     #[derive(Copy, Clone)]
     struct Data_ {

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -144,7 +144,8 @@ pub struct Gc {
     collect_limit: usize,
     /// The maximum number of bytes this garbage collector may contain
     memory_limit: usize,
-    #[cfg_attr(feature = "serde_derive", serde(skip))] type_infos: FnvMap<TypeId, Box<TypeInfo>>,
+    #[cfg_attr(feature = "serde_derive", serde(skip))]
+    type_infos: FnvMap<TypeId, Box<TypeInfo>>,
     #[cfg_attr(feature = "serde_derive", serde(skip))]
     record_infos: FnvMap<Vec<InternedStr>, Box<TypeInfo>>,
     /// The generation of a gc determines what values it needs to copy and what values it can

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -99,12 +99,10 @@ impl Interner {
             Some(interned_str) => return Ok(*interned_str),
             None => (),
         }
-        let gc_str =
-            unsafe { InternedStr(GcStr::from_utf8_unchecked(gc.alloc(s.as_bytes())?)) };
+        let gc_str = unsafe { InternedStr(GcStr::from_utf8_unchecked(gc.alloc(s.as_bytes())?)) };
         // The key will live as long as the value it refers to and the static str never escapes
         // outside interner so this is safe
-        let key: &'static str =
-            unsafe { ::std::mem::transmute::<&str, &'static str>(&gc_str) };
+        let key: &'static str = unsafe { ::std::mem::transmute::<&str, &'static str>(&gc_str) };
         self.indexes.insert(key, gc_str);
         Ok(gc_str)
     }

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -19,6 +19,7 @@ extern crate mopa;
 extern crate pretty;
 #[macro_use]
 extern crate quick_error;
+#[cfg(feature = "tokio_core")]
 extern crate tokio_core;
 #[doc(hidden)]
 pub extern crate frunk_core;
@@ -147,7 +148,6 @@ quick_error! {
     }
 }
 
-
 pub type ExternLoader = fn(&Thread) -> Result<ExternModule>;
 
 pub struct ExternModule {
@@ -168,7 +168,6 @@ impl ExternModule {
         })
     }
 }
-
 
 /// Internal types and functions exposed to the main `gluon` crate
 pub mod internal {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -9,6 +9,8 @@ extern crate bitflags;
 extern crate collect_mac;
 #[cfg(test)]
 extern crate env_logger;
+#[doc(hidden)]
+pub extern crate frunk_core;
 #[macro_use]
 extern crate futures;
 extern crate itertools;
@@ -19,10 +21,8 @@ extern crate mopa;
 extern crate pretty;
 #[macro_use]
 extern crate quick_error;
-#[cfg(feature = "tokio_core")]
+#[cfg(not(target_arch = "wasm32"))]
 extern crate tokio_core;
-#[doc(hidden)]
-pub extern crate frunk_core;
 
 #[cfg(feature = "serde_derive")]
 #[macro_use]
@@ -59,12 +59,12 @@ pub mod primitives;
 pub mod reference;
 pub mod stack;
 pub mod types;
+pub mod vm;
 
 mod array;
 mod interner;
 mod source_map;
 mod value;
-mod vm;
 
 use std::marker::PhantomData;
 

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -111,7 +111,6 @@ impl<'a> MacroExpander<'a> {
     }
 }
 
-
 impl<'a> MutVisitor for MacroExpander<'a> {
     type Ident = Symbol;
 

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -54,7 +54,6 @@ impl AsMut<NodeMap> for DeSeed {
     }
 }
 
-
 pub struct SeSeed {
     node_to_id: ::base::serialization::SeSeed,
 }
@@ -204,7 +203,6 @@ pub mod gc {
         Record(#[serde(state_with = "::base::serialization::shared")] S),
         Data(VmTag),
     }
-
 
     impl SerializeState<SeSeed> for DataStruct {
         fn serialize_state<S>(&self, serializer: S, seed: &SeSeed) -> Result<S::Ok, S::Error>
@@ -610,7 +608,6 @@ where
         deserializer,
     )
 }
-
 
 struct DataDefSeed<T>(PhantomData<T>);
 

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -186,8 +186,10 @@ pub mod gc {
                                     + ::base::serialization::Shared,
                                S::Target: SerializeState<::serialization::SeSeed>"))]
     struct Data<F, S> {
-        #[serde(state)] tag: DataTag<S>,
-        #[serde(state)] fields: F,
+        #[serde(state)]
+        tag: DataTag<S>,
+        #[serde(state)]
+        fields: F,
     }
 
     #[derive(DeserializeState, SerializeState)]
@@ -580,8 +582,10 @@ pub mod closure {
 #[derive(DeserializeState)]
 #[cfg_attr(feature = "serde_derive", serde(deserialize_state = "DeSeed"))]
 struct PartialApplicationModel {
-    #[cfg_attr(feature = "serde_derive", serde(deserialize_state))] function: Callable,
-    #[cfg_attr(feature = "serde_derive", serde(deserialize_state))] args: Vec<Value>,
+    #[cfg_attr(feature = "serde_derive", serde(deserialize_state))]
+    function: Callable,
+    #[cfg_attr(feature = "serde_derive", serde(deserialize_state))]
+    args: Vec<Value>,
 }
 
 unsafe impl DataDef for PartialApplicationModel {

--- a/vm/src/source_map.rs
+++ b/vm/src/source_map.rs
@@ -72,7 +72,8 @@ pub struct Local {
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "::serialization::SeSeed"))]
 pub struct LocalMap {
     // Instruction indexes marking [start, end) where the local variable `Symbol` exists
-    #[cfg_attr(feature = "serde_derive", serde(state))] map: Vec<Local>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    map: Vec<Local>,
 }
 
 impl LocalMap {

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -154,11 +154,9 @@ impl Stack {
                         .debug_info
                         .source_map
                         .line(frame.instruction_index);
-                    Some(line.map(|line| {
-                        StacktraceFrame {
-                            name: closure.function.name.clone(),
-                            line: line,
-                        }
+                    Some(line.map(|line| StacktraceFrame {
+                        name: closure.function.name.clone(),
+                        line: line,
                     }))
                 }
                 State::Extern(ref ext) => Some(Some(StacktraceFrame {
@@ -475,7 +473,6 @@ impl fmt::Display for Stacktrace {
         Ok(())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -33,7 +33,8 @@ pub enum State {
 pub struct Frame {
     pub offset: VmIndex,
     pub instruction_index: usize,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub state: State,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub state: State,
     pub excess: bool,
 }
 
@@ -54,8 +55,10 @@ pub struct Lock(VmIndex);
 #[cfg_attr(feature = "serde_derive", serde(deserialize_state = "::serialization::DeSeed"))]
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "::serialization::SeSeed"))]
 pub struct Stack {
-    #[cfg_attr(feature = "serde_derive", serde(state))] values: Vec<Value>,
-    #[cfg_attr(feature = "serde_derive", serde(state))] frames: Vec<Frame>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    values: Vec<Value>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    frames: Vec<Frame>,
 }
 
 impl Traverseable for Stack {

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -28,7 +28,7 @@ use gc::{DataDef, Gc, GcPtr, Generation, Move};
 use source_map::LocalIter;
 use stack::{Frame, Lock, Stack, StackFrame, State};
 use types::*;
-use vm::{GlobalVmState, VmEnv};
+use vm::{GlobalVmState, GlobalVmStateBuilder, VmEnv};
 use value::{BytecodeFunction, Callable, ClosureData, ClosureDataDef, ClosureInitDef, Def,
             ExternFunction, GcStr, PartialApplicationDataDef, RecordDef, Userdata, Value};
 
@@ -392,11 +392,10 @@ impl Traverseable for RootedThread {
 impl RootedThread {
     /// Creates a new virtual machine with an empty global environment
     pub fn new() -> RootedThread {
-        RootedThread::with_event_loop(None)
+        RootedThread::with_global_state(GlobalVmStateBuilder::default().build())
     }
 
-    pub fn with_event_loop(event_loop: Option<::tokio_core::reactor::Remote>) -> RootedThread {
-        let mut global_state = GlobalVmState::new(event_loop);
+    pub fn with_global_state(mut global_state: GlobalVmState) -> RootedThread {
         let thread = Thread {
             parent: None,
             context: Mutex::new(Context::new(

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -280,17 +280,21 @@ pub struct Thread {
     global_state: Arc<GlobalVmState>,
     // The parent of this thread, if it exists must live at least as long as this thread as this
     // thread can refer to any value in the parent thread
-    #[cfg_attr(feature = "serde_derive", serde(state))] parent: Option<RootedThread>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    parent: Option<RootedThread>,
     #[cfg_attr(feature = "serde_derive", serde(skip))]
     roots: RwLock<Vec<GcPtr<Traverseable + Send + Sync>>>,
-    #[cfg_attr(feature = "serde_derive", serde(state))] rooted_values: RwLock<Vec<Value>>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    rooted_values: RwLock<Vec<Value>>,
     /// All threads which this thread have spawned in turn. Necessary as this thread needs to scan
     /// the roots of all its children as well since those may contain references to this threads
     /// garbage collected values
     #[cfg_attr(feature = "serde_derive", serde(state))]
     child_threads: RwLock<Vec<GcPtr<Thread>>>,
-    #[cfg_attr(feature = "serde_derive", serde(state))] context: Mutex<Context>,
-    #[cfg_attr(feature = "serde_derive", serde(skip))] interrupt: AtomicBool,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    context: Mutex<Context>,
+    #[cfg_attr(feature = "serde_derive", serde(skip))]
+    interrupt: AtomicBool,
 }
 
 impl fmt::Debug for Thread {
@@ -1028,9 +1032,12 @@ struct Hook {
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "::serialization::SeSeed"))]
 pub struct Context {
     // FIXME It is dangerous to write to gc and stack
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub stack: Stack,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub gc: Gc,
-    #[cfg_attr(feature = "serde_derive", serde(skip))] hook: Hook,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub stack: Stack,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub gc: Gc,
+    #[cfg_attr(feature = "serde_derive", serde(skip))]
+    hook: Hook,
     max_stack_size: VmIndex,
 
     /// Stack of polling functions used for extern functions returning futures

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -116,7 +116,6 @@ pub enum Instruction {
     FloatEQ,
 }
 
-
 impl Instruction {
     /// Returns by how much the stack is adjusted when executing the instruction `self`.
     pub fn adjust(&self) -> i32 {

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -142,7 +142,6 @@ impl PartialEq for DataStruct {
     }
 }
 
-
 impl DataStruct {
     pub fn record_bit() -> VmTag {
         1 << ((size_of::<VmTag>() * 8) - 1)
@@ -795,7 +794,6 @@ impl Traverseable for ExternFunction {
     fn traverse(&self, _: &mut Gc) {}
 }
 
-
 /// Representation of values which can be stored directly in an array
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Repr {
@@ -1093,9 +1091,9 @@ unsafe impl<'a> DataDef for &'a ValueArray {
         unsafe {
             let result = &mut *result.as_mut_ptr();
             result.repr = self.repr;
-            on_array!(self, |array: &Array<_>| {
-                result.unsafe_array_mut().initialize(array.iter().cloned())
-            });
+            on_array!(self, |array: &Array<_>| result
+                .unsafe_array_mut()
+                .initialize(array.iter().cloned()));
             result
         }
     }
@@ -1406,22 +1404,18 @@ mod tests {
 
         let nil = Value::Tag(1);
         assert_eq!(format!("{}", ValuePrinter::new(&env, &typ, nil)), "Nil");
-        let list1 = Value::Data(
-            gc.alloc(Def {
-                tag: 0,
-                elems: &[Value::Int(123), nil],
-            }).unwrap(),
-        );
+        let list1 = Value::Data(gc.alloc(Def {
+            tag: 0,
+            elems: &[Value::Int(123), nil],
+        }).unwrap());
         assert_eq!(
             format!("{}", ValuePrinter::new(&env, &typ, list1)),
             "Cons 123 Nil"
         );
-        let list2 = Value::Data(
-            gc.alloc(Def {
-                tag: 0,
-                elems: &[Value::Int(0), list1],
-            }).unwrap(),
-        );
+        let list2 = Value::Data(gc.alloc(Def {
+            tag: 0,
+            elems: &[Value::Int(0), list1],
+        }).unwrap());
         assert_eq!(
             format!("{}", ValuePrinter::new(&env, &typ, list2)),
             "Cons 0 (Cons 123 Nil)"

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -112,9 +112,12 @@ pub struct BytecodeFunction {
     pub instructions: Vec<Instruction>,
     #[cfg_attr(feature = "serde_derive", serde(state))]
     pub inner_functions: Vec<GcPtr<BytecodeFunction>>,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub strings: Vec<InternedStr>,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub records: Vec<Vec<InternedStr>>,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub debug_info: DebugInfo,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub strings: Vec<InternedStr>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub records: Vec<Vec<InternedStr>>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub debug_info: DebugInfo,
 }
 
 impl Traverseable for BytecodeFunction {
@@ -627,8 +630,10 @@ impl Traverseable for Callable {
 #[cfg_attr(feature = "serde_derive", derive(SerializeState))]
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "::serialization::SeSeed"))]
 pub struct PartialApplicationData {
-    #[cfg_attr(feature = "serde_derive", serde(serialize_state))] pub function: Callable,
-    #[cfg_attr(feature = "serde_derive", serde(serialize_state))] pub args: Array<Value>,
+    #[cfg_attr(feature = "serde_derive", serde(serialize_state))]
+    pub function: Callable,
+    #[cfg_attr(feature = "serde_derive", serde(serialize_state))]
+    pub args: Array<Value>,
 }
 
 impl PartialEq for PartialApplicationData {


### PR DESCRIPTION
Currently the `gluon_c-api` crate compiles down to ~3.5 MB (https://github.com/alexcrichton/wasm-gc does not make a dent) which may be a bit large but it could be interesting to make try_gluon run WASM instead of running the server side. If that change were made then it would be fairly simple to automatically provide errors as one writes code and things like that which would be cool! But it remains to be done at some later done.

Closes #424 