### PR TITLE
Update LALRPOP to 0.14

### DIFF
--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,19 +1,20 @@
 //! Code formatter.
 #![doc(html_root_url = "https://docs.rs/gluon_formatter/0.7.0")] // # GLUON
 
-extern crate itertools;
-extern crate pretty;
 #[macro_use]
 extern crate gluon_base as base;
 extern crate gluon_parser as parser;
+extern crate itertools;
+extern crate pretty;
+
+use base::ast::SpannedExpr;
+use base::source::Source;
+use base::symbol::{Symbol, Symbols};
+use base::types::TypeCache;
 
 mod pretty_print;
 
-pub fn format_expr(input: &str) -> Result<String, parser::ParseErrors> {
-    use base::source::Source;
-    use base::symbol::Symbols;
-    use base::types::TypeCache;
-
+pub fn pretty_expr(expr: &SpannedExpr<Symbol>, input: &str) -> String {
     let newline = match input.find(|c: char| c == '\n' || c == '\r') {
         Some(i) => {
             if input[i..].starts_with("\r\n") {
@@ -27,11 +28,15 @@ pub fn format_expr(input: &str) -> Result<String, parser::ParseErrors> {
         None => "\n",
     };
 
-    let type_cache = TypeCache::new();
-    let expr = parser::parse_expr(&mut Symbols::new(), &type_cache, input)?;
-
     let source = Source::new(input);
     let arena = pretty::Arena::new();
     let printer = pretty_print::Printer::new(&arena, &source);
-    Ok(printer.format(100, newline, &expr))
+    printer.format(100, newline, &expr)
+}
+
+pub fn format_expr(input: &str) -> Result<String, parser::ParseErrors> {
+    let type_cache = TypeCache::new();
+    let expr = parser::parse_expr(&mut Symbols::new(), &type_cache, input)?;
+
+    Ok(pretty_expr(&expr, input))
 }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -27,7 +27,7 @@ difference = "1.0"
 pretty_assertions = "0.4"
 
 [build-dependencies]
-lalrpop = "0.13.1"
+lalrpop = "0.14.0"
 
 [features]
 test = ["env_logger"]

--- a/parser/build.rs
+++ b/parser/build.rs
@@ -1,8 +1,6 @@
 extern crate lalrpop;
 
 fn main() {
-    ::std::env::set_var("LALRPOP_LANE_TABLE", "disabled");
-
     lalrpop::Configuration::new()
         .use_cargo_dir_conventions()
         .process_file("src/grammar.lalrpop")

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -377,7 +377,7 @@ Alternative: Alternative<Id> = {
             expr: super::shrink_hidden_spans(expr),
         }
     },
-    "|" <pat: Sp<NoErrorPattern>> <end: @L> <err: !> => {
+    "|" <pat: Sp<NoErrorPattern>> <err: !> <end: @R>  => {
         errors.push(err.error);
         let span = pos::Span::new(pat.span.end, end);
         Alternative {
@@ -385,7 +385,7 @@ Alternative: Alternative<Id> = {
             expr: pos::spanned(span, Expr::Error(None)),
         }
     },
-    "|" <start: @R> <end: @L> <err: !> => {
+    "|" <start: @R> <err: !> <end: @R>  => {
         errors.push(err.error);
         let span = pos::Span::new(start, end);
         Alternative {

--- a/parser/src/layout.rs
+++ b/parser/src/layout.rs
@@ -72,6 +72,10 @@ impl Contexts {
         self.stack.pop()
     }
 
+    fn is_empty(&self) -> bool {
+        self.stack.is_empty()
+    }
+
     fn push(&mut self, offside: Offside) -> Result<(), Spanned<Error, BytePos>> {
         self.check_unindentation_limit(offside)?;
         self.stack.push(offside);
@@ -208,6 +212,9 @@ where
         let mut token = self.next_token();
         if token.value == Token::EOF {
             token.span.start.column = Column::from(0);
+            if self.indent_levels.is_empty() {
+                return Ok(token);
+            }
         }
 
         loop {
@@ -219,7 +226,6 @@ where
                     let offside =
                         Offside::new(token.span.start, Context::Block { emit_semi: false });
                     self.indent_levels.push(offside)?;
-                    debug!("Default block {:?}", token);
                     return Ok(self.layout_token(token, Token::OpenBlock));
                 }
             };

--- a/parser/tests/error_handling.rs
+++ b/parser/tests/error_handling.rs
@@ -309,7 +309,10 @@ fn incomplete_let_binding_2() {
         let_("test", id("io"), no_loc(Expr::Error(None)))
     );
 
-    let errors = vec![no_loc(Error::UnexpectedToken("CloseBlock".into(), vec![]))];
+    let errors = vec![
+        no_loc(Error::UnexpectedToken("CloseBlock".into(), vec![])),
+        no_loc(Error::UnexpectedToken("CloseBlock".into(), vec![])),
+    ];
     assert_eq!(remove_expected(err), ParseErrors::from(errors));
 }
 


### PR DESCRIPTION
This finally takes advantage of LALRPOPs lane table parser as the bugs in error recovery has now been fixed! I found some small behaviour changes but nothing really strange.

I will take another look at the extra CloseBlock token error before merging as well to see if that is expected.