### PR TITLE
Fix all clippy warnings in completion module

### DIFF
--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -727,12 +727,12 @@ impl Extract for IdentAt {
             Match::Expr(&Spanned {
                 value: Expr::Ident(ref id),
                 ..
-            }) => id.name.clone(),
-            Match::Ident(_, id, _) => id.clone(),
-            Match::Pattern(&Spanned {
+            })
+            | Match::Pattern(&Spanned {
                 value: Pattern::Ident(ref id),
                 ..
             }) => id.name.clone(),
+            Match::Ident(_, id, _) => id.clone(),
             Match::Pattern(&Spanned {
                 value: Pattern::As(ref id, _),
                 ..

--- a/completion/tests/suggest.rs
+++ b/completion/tests/suggest.rs
@@ -24,10 +24,10 @@ mod support;
 use support::MockEnv;
 
 fn suggest_types(s: &str, pos: BytePos) -> Result<Vec<Suggestion>, ()> {
-    suggest_query(SuggestionQuery::new(), s, pos)
+    suggest_query(&SuggestionQuery::new(), s, pos)
 }
 
-fn suggest_query(query: SuggestionQuery, s: &str, pos: BytePos) -> Result<Vec<Suggestion>, ()> {
+fn suggest_query(query: &SuggestionQuery, s: &str, pos: BytePos) -> Result<Vec<Suggestion>, ()> {
     let env = MockEnv::new();
 
     struct ReplaceImport;
@@ -76,7 +76,7 @@ fn suggest_loc(s: &str, row: usize, column: usize) -> Result<Vec<String>, ()> {
     )
 }
 fn suggest_query_loc(
-    query: SuggestionQuery,
+    query: &SuggestionQuery,
     s: &str,
     row: usize,
     column: usize,
@@ -427,7 +427,7 @@ import! st
         paths: vec![find_gluon_root()],
         ..SuggestionQuery::default()
     };
-    let result = suggest_query_loc(query, text, 1, 10);
+    let result = suggest_query_loc(&query, text, 1, 10);
     let expected = Ok(vec!["std".into()]);
 
     assert_eq!(result, expected);
@@ -444,7 +444,7 @@ import! std.p
         paths: vec![find_gluon_root()],
         ..SuggestionQuery::default()
     };
-    let result = suggest_query_loc(query, text, 1, 12);
+    let result = suggest_query_loc(&query, text, 1, 12);
     let expected = Ok(vec!["parser".into(), "prelude".into()]);
 
     assert_eq!(result, expected);
@@ -461,7 +461,7 @@ import! std.
         paths: vec![find_gluon_root()],
         ..SuggestionQuery::default()
     };
-    let result = suggest_query_loc(query, text, 1, 12);
+    let result = suggest_query_loc(&query, text, 1, 12);
     assert!(result.is_ok());
 
     let suggestions = result.unwrap();
@@ -484,7 +484,7 @@ import! std.prelud
         ..SuggestionQuery::default()
     };
     let result = suggest_query(
-        query,
+        &query,
         text,
         Source::new(text)
             .lines()
@@ -515,7 +515,7 @@ import! example.
         modules: vec!["example.test".into()],
         ..SuggestionQuery::default()
     };
-    let result = suggest_query_loc(query, text, 1, 16);
+    let result = suggest_query_loc(&query, text, 1, 16);
     let expected = Ok(vec!["test".into()]);
 
     assert_eq!(result, expected);
@@ -533,7 +533,7 @@ import! example.
         modules: vec!["example.test.inner".into()],
         ..SuggestionQuery::default()
     };
-    let result = suggest_query_loc(query, text, 1, 16);
+    let result = suggest_query_loc(&query, text, 1, 16);
     let expected = Ok(vec!["test".into()]);
 
     assert_eq!(result, expected);
@@ -551,7 +551,7 @@ import! example.test.inn
         modules: vec!["example.test.inner".into()],
         ..SuggestionQuery::default()
     };
-    let result = suggest_query_loc(query, text, 1, 24);
+    let result = suggest_query_loc(&query, text, 1, 24);
     let expected = Ok(vec!["inner".into()]);
 
     assert_eq!(result, expected);

--- a/completion/tests/suggest.rs
+++ b/completion/tests/suggest.rs
@@ -61,7 +61,7 @@ fn suggest_query(query: SuggestionQuery, s: &str, pos: BytePos) -> Result<Vec<Su
 
     ReplaceImport.visit_expr(&mut expr);
 
-    let mut vec = query.suggest(&env, &mut expr, pos);
+    let mut vec = query.suggest(&env, &expr, pos);
     vec.sort_by(|l, r| l.name.cmp(&r.name));
     Ok(vec)
 }
@@ -703,7 +703,7 @@ match Abc 1 with
 
     let (mut expr, _result) = support::typecheck_partial_expr(text);
     expr.span.expansion_id = pos::UNKNOWN_EXPANSION;
-    let result: Vec<_> = completion::suggest(&env, &mut expr, 42.into())
+    let result: Vec<_> = completion::suggest(&env, &expr, 42.into())
         .into_iter()
         .map(|s| s.name)
         .collect();
@@ -727,7 +727,7 @@ match Abc 1 with
 
     let (mut expr, _result) = support::typecheck_partial_expr(text);
     expr.span.expansion_id = pos::UNKNOWN_EXPANSION;
-    let result: Vec<_> = completion::suggest(&env, &mut expr, 74.into())
+    let result: Vec<_> = completion::suggest(&env, &expr, 74.into())
         .into_iter()
         .map(|s| s.name)
         .collect();

--- a/completion/tests/support/mod.rs
+++ b/completion/tests/support/mod.rs
@@ -38,7 +38,7 @@ pub fn parse_new(
     let symbols = get_local_interner();
     let mut symbols = symbols.borrow_mut();
     let mut module = SymbolModule::new("test".into(), &mut symbols);
-    parse_partial_expr(&mut module, &TypeCache::new(), &s)
+    parse_partial_expr(&mut module, &TypeCache::new(), s)
 }
 
 pub struct MockEnv {
@@ -73,7 +73,7 @@ impl KindEnv for MockEnv {
 impl TypeEnv for MockEnv {
     fn find_type(&self, id: &SymbolRef) -> Option<&ArcType> {
         match id.definition_name() {
-            "False" | "True" => Some(&self.bool.as_type()),
+            "False" | "True" => Some(self.bool.as_type()),
             // Just need a dummy type that is not `Type::hole` to verify that lookups work
             "std.prelude" => Some(&self.int),
             _ => None,
@@ -98,7 +98,7 @@ impl TypeEnv for MockEnv {
 
 impl PrimitiveEnv for MockEnv {
     fn get_bool(&self) -> &ArcType {
-        &self.bool.as_type()
+        self.bool.as_type()
     }
 }
 
@@ -143,8 +143,7 @@ pub fn typecheck_partial_expr(
     Result<ArcType, InFile<typecheck::HelpError<Symbol>>>,
 ) {
     let mut expr = match parse_new(text) {
-        Ok(e) => e,
-        Err((Some(e), _)) => e,
+        Ok(e) | Err((Some(e), _)) => e,
         Err((None, err)) => panic!("{}", err),
     };
 
@@ -159,7 +158,7 @@ pub fn typecheck_partial_expr(
 }
 
 pub fn typ(s: &str) -> ArcType {
-    assert!(s.len() != 0);
+    assert!(!s.is_empty());
     typ_a(s, Vec::new())
 }
 
@@ -167,14 +166,14 @@ pub fn typ_a<T>(s: &str, args: Vec<T>) -> T
 where
     T: From<Type<Symbol, T>>,
 {
-    assert!(s.len() != 0);
+    assert!(!s.is_empty());
 
     match s.parse() {
         Ok(b) => Type::builtin(b),
         Err(()) if s.starts_with(char::is_lowercase) => {
             Type::generic(Generic::new(intern(s), Kind::typ()))
         }
-        Err(()) => if args.len() == 0 {
+        Err(()) => if args.is_empty() {
             Type::ident(intern(s))
         } else {
             Type::app(Type::ident(intern(s)), args.into_iter().collect())


### PR DESCRIPTION
There are some left that I'm not ready to do now:
```
warning: consider using `Option<T>` instead of `Option<Option<T>>` or a custom enum if you need to distinguish all 3 cases
   --> completion/src/lib.rs:208:12
    |
208 |     found: Option<Option<Match<'a>>>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(option_option)] on by default
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.184/index.html#option_option

warning: this `match` has identical arm bodies
   --> completion/src/lib.rs:735:19
    |
735 |             }) => id.name.clone(),
    |                   ^^^^^^^^^^^^^^^
    |
    = note: #[warn(match_same_arms)] on by default
note: same as this
   --> completion/src/lib.rs:730:19
    |
730 |             }) => id.name.clone(),
    |                   ^^^^^^^^^^^^^^^
note: consider refactoring into `Match::Expr(&Spanned {
                value: Expr::Ident(ref id),
                ..
            }) | Match::Pattern(&Spanned {
                value: Pattern::Ident(ref id),
                ..
            })`
   --> completion/src/lib.rs:730:19
    |
730 |             }) => id.name.clone(),
    |                   ^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.184/index.html#match_same_arms

warning: this argument is passed by value, but not consumed in the function body
  --> completion/tests/suggest.rs:30:25
   |
30 | fn suggest_query(query: SuggestionQuery, s: &str, pos: BytePos) -> Result<Vec<Suggestion>, ()> {
   |                         ^^^^^^^^^^^^^^^ help: consider taking a reference instead: `&SuggestionQuery`
   |
   = note: #[warn(needless_pass_by_value)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.184/index.html#needless_pass_by_value
```