### PR TITLE
Use error_on_line_overflow option instead of error_on_line_overflow_comments

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 newline_style = "Native"
 use_try_shorthand = true
-error_on_line_overflow_comments = false
+error_on_line_overflow = false


### PR DESCRIPTION
I'm using `rustfmt 0.3.6-nightly (e0e3e22 2018-01-18)` and it emits a warning:
`Warning: Unknown configuration option error_on_line_overflow_comments`

I'm not sure what version you use, so feel free to close this as you see fit.