### PR TITLE
feat: Filter out unrelated fields in some type errors 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "pretty 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "union-find 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1169,6 +1170,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "structopt"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum socket2 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a76b792959eba82f021c9028c8ecb6396f085268d6d46af2ed96a829cc758d7c"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "783cb22d520b177a3772e520d04a3c7970d51c3b647ba80739f99be01131b54f"
 "checksum structopt-derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4da119c9a7a1eccb7c6de0c1eb3f7ed1c11138624d092b3687222aeed8f1375c"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"

--- a/base/src/types/mod.rs
+++ b/base/src/types/mod.rs
@@ -25,6 +25,7 @@ use serde::de::DeserializeState;
 use serde::ser::SerializeState;
 
 use self::pretty_print::Printer;
+pub use self::pretty_print::TypeFormatter;
 
 pub mod pretty_print;
 
@@ -127,11 +128,9 @@ where
         let fields: Vec<_> = elems
             .into_iter()
             .enumerate()
-            .map(|(i, typ)| {
-                Field {
-                    name: symbols.from_str(&format!("_{}", i)),
-                    typ: typ,
-                }
+            .map(|(i, typ)| Field {
+                name: symbols.from_str(&format!("_{}", i)),
+                typ: typ,
             })
             .collect();
         if fields.is_empty() {
@@ -229,7 +228,8 @@ impl BuiltinType {
 #[cfg_attr(feature = "serde_derive", serde(deserialize_state = "Seed<Id, T>"))]
 #[cfg_attr(feature = "serde_derive", serde(de_parameters = "Id, T"))]
 pub struct TypeVariable {
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub kind: ArcKind,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub kind: ArcKind,
     pub id: u32,
 }
 
@@ -243,9 +243,11 @@ pub struct TypeVariable {
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "SeSeed"))]
 #[cfg_attr(feature = "serde_derive", serde(bound(serialize = "Id: SerializeState<SeSeed>")))]
 pub struct Skolem<Id> {
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub name: Id,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub name: Id,
     pub id: u32,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub kind: ArcKind,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub kind: ArcKind,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -258,8 +260,10 @@ pub struct Skolem<Id> {
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "SeSeed"))]
 #[cfg_attr(feature = "serde_derive", serde(bound(serialize = "Id: SerializeState<SeSeed>")))]
 pub struct Generic<Id> {
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub id: Id,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub kind: ArcKind,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub id: Id,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub kind: ArcKind,
 }
 
 impl<Id> Generic<Id> {
@@ -280,8 +284,10 @@ impl<Id> Generic<Id> {
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "SeSeed"))]
 #[cfg_attr(feature = "serde_derive", serde(bound(serialize = "T: SerializeState<SeSeed>")))]
 pub struct Alias<Id, T> {
-    #[cfg_attr(feature = "serde_derive", serde(state))] _typ: T,
-    #[cfg_attr(feature = "serde_derive", serde(skip))] _marker: PhantomData<Id>,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    _typ: T,
+    #[cfg_attr(feature = "serde_derive", serde(skip))]
+    _marker: PhantomData<Id>,
 }
 
 impl<Id, T> Deref for Alias<Id, T>
@@ -330,14 +336,12 @@ where
     pub fn group(group: Vec<AliasData<Id, T>>) -> Vec<Alias<Id, T>> {
         let group = Arc::new(group);
         (0..group.len())
-            .map(|index| {
-                Alias {
-                    _typ: T::from(Type::Alias(AliasRef {
-                        index: index,
-                        group: group.clone(),
-                    })),
-                    _marker: PhantomData,
-                }
+            .map(|index| Alias {
+                _typ: T::from(Type::Alias(AliasRef {
+                    index: index,
+                    group: group.clone(),
+                })),
+                _marker: PhantomData,
             })
             .collect()
     }
@@ -445,7 +449,8 @@ where
 #[cfg_attr(feature = "serde_derive",
            serde(bound(serialize = "T: SerializeState<SeSeed>, Id: SerializeState<SeSeed>")))]
 pub struct AliasData<Id, T> {
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub name: Id,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub name: Id,
     /// The type that is being aliased
     #[cfg_attr(feature = "serde_derive", serde(state))]
     typ: T,
@@ -510,8 +515,10 @@ impl<Id, T> Deref for AliasRef<Id, T> {
 #[cfg_attr(feature = "serde_derive",
            serde(bound(serialize = "T: SerializeState<SeSeed>, Id: SerializeState<SeSeed>")))]
 pub struct Field<Id, T = ArcType<Id>> {
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub name: Id,
-    #[cfg_attr(feature = "serde_derive", serde(state))] pub typ: T,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub name: Id,
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    pub typ: T,
 }
 
 /// `SmallVec` used in the `Type::App` constructor to avoid allocating a `Vec` for every applied
@@ -685,11 +692,9 @@ where
             elems
                 .into_iter()
                 .enumerate()
-                .map(|(i, typ)| {
-                    Field {
-                        name: symbols.from_str(&format!("_{}", i)),
-                        typ: typ,
-                    }
+                .map(|(i, typ)| Field {
+                    name: symbols.from_str(&format!("_{}", i)),
+                    typ: typ,
                 })
                 .collect(),
             Type::empty_row(),
@@ -1406,7 +1411,6 @@ where
     }
 }
 
-
 pub struct ArgIterator<'a, T: 'a> {
     /// The current type being iterated over. After `None` has been returned this is the return
     /// type.
@@ -1510,7 +1514,6 @@ impl Prec {
     }
 }
 
-
 fn dt<'a, T>(prec: Prec, typ: &'a T) -> DisplayType<'a, T> {
     DisplayType {
         prec: prec,
@@ -1522,59 +1525,9 @@ fn top<'a, T>(typ: &'a T) -> DisplayType<'a, T> {
     dt(Prec::Top, typ)
 }
 
-pub fn display_type<'a, T>(typ: &'a T) -> TypeFormatter<'a, T> {
-    TypeFormatter {
-        width: 80,
-        typ: typ,
-    }
-}
-
 pub struct DisplayType<'a, T: 'a> {
     prec: Prec,
     typ: &'a T,
-}
-
-pub struct TypeFormatter<'a, T>
-where
-    T: 'a,
-{
-    width: usize,
-    typ: &'a T,
-}
-
-impl<'a, T> TypeFormatter<'a, T> {
-    pub fn new(typ: &'a T) -> Self {
-        TypeFormatter {
-            width: 80,
-            typ: typ,
-        }
-    }
-}
-
-impl<'a, T> TypeFormatter<'a, T> {
-    pub fn width(mut self, width: usize) -> Self {
-        self.width = width;
-        self
-    }
-}
-
-impl<'a, I, T> fmt::Display for TypeFormatter<'a, T>
-where
-    T: Deref<Target = Type<I, T>> + HasSpan + Commented + 'a,
-    I: AsRef<str>,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let arena = Arena::new();
-        let source = Source::new("");
-        let printer = Printer::new(&arena, &source);
-        let mut s = Vec::new();
-        pretty_print(&printer, self.typ)
-            .group()
-            .1
-            .render(self.width, &mut s)
-            .map_err(|_| fmt::Error)?;
-        write!(f, "{}", ::std::str::from_utf8(&s).expect("utf-8"))
-    }
 }
 
 pub trait ToDoc<'a, A, E> {
@@ -1597,7 +1550,7 @@ where
     I: AsRef<str>,
 {
     fn to_doc(&'a self, arena: &'a Arena<'a>, source: &'e Source<'a>) -> DocBuilder<'a, Arena<'a>> {
-        let printer = Printer { arena, source };
+        let printer = Printer::new(arena, source);
         dt(Prec::Top, self).pretty(&printer)
     }
 }
@@ -1616,9 +1569,8 @@ macro_rules! chain {
 impl<'a, I, T> DisplayType<'a, T>
 where
     T: Deref<Target = Type<I, T>> + HasSpan + Commented + 'a,
-    I: 'a,
 {
-    pub fn pretty<'e>(&self, printer: &Printer<'a, 'e>) -> DocBuilder<'a, Arena<'a>>
+    pub fn pretty<'e>(&self, printer: &Printer<'a, 'e, I>) -> DocBuilder<'a, Arena<'a>>
     where
         I: AsRef<str>,
     {
@@ -1743,6 +1695,7 @@ where
                 } else {
                     arena.space()
                 };
+                let mut filtered = false;
 
                 while let Type::ExtendRow {
                     ref types,
@@ -1750,7 +1703,17 @@ where
                     ..
                 } = **typ
                 {
-                    for (i, field) in types.iter().enumerate() {
+                    for (i, field) in types
+                        .iter()
+                        .filter(|field| {
+                            let x = printer.filter(&field.name);
+                            if !x {
+                                filtered = true;
+                            }
+                            x
+                        })
+                        .enumerate()
+                    {
                         let f = chain![arena;
                             field.name.as_ref(),
                             arena.space(),
@@ -1776,7 +1739,17 @@ where
                     ..
                 } = **typ
                 {
-                    for (i, field) in fields.iter().enumerate() {
+                    for (i, field) in fields
+                        .iter()
+                        .filter(|field| {
+                            let x = printer.filter(&field.name);
+                            if !x {
+                                filtered = true;
+                            }
+                            x
+                        })
+                        .enumerate()
+                    {
                         let mut rhs = top(&field.typ).pretty(printer);
                         match *field.typ {
                             // Records handle nesting on their own
@@ -1794,14 +1767,25 @@ where
                                 arena.nil()
                             }].group();
                         doc = doc.append(newline.clone()).append(f);
-                        typ = rest;
                     }
+                    typ = rest;
                 }
-                match **typ {
+                let row_doc = match **typ {
                     Type::EmptyRow => doc,
                     _ => doc.append(arena.space())
                         .append("| ")
                         .append(top(typ).pretty(printer)),
+                };
+                if filtered {
+                    chain![arena;
+                        newline.clone(),
+                        "...,",
+                        row_doc,
+                        newline.clone(),
+                        "..."
+                    ]
+                } else {
+                    row_doc
                 }
             }
             // This should not be displayed normally as it should only exist in `ExtendRow`
@@ -1819,7 +1803,7 @@ where
         }
     }
 
-    fn pretty_function<'e>(&self, printer: &Printer<'a, 'e>) -> DocBuilder<'a, Arena<'a>>
+    fn pretty_function<'e>(&self, printer: &Printer<'a, 'e, I>) -> DocBuilder<'a, Arena<'a>>
     where
         I: AsRef<str>,
     {
@@ -1842,7 +1826,7 @@ where
 }
 
 pub fn pretty_print<'a, 'e, I, T>(
-    printer: &Printer<'a, 'e>,
+    printer: &Printer<'a, 'e, I>,
     typ: &'a T,
 ) -> DocBuilder<'a, Arena<'a>>
 where
@@ -2032,7 +2016,6 @@ where
     }
 }
 
-
 /// Walks through a type calling `f` on each inner type. If `f` return `Some` the type is replaced.
 pub fn walk_move_type<F: ?Sized, I, T>(typ: T, f: &mut F) -> T
 where
@@ -2190,20 +2173,16 @@ where
         } => Type::extend_row(
             types
                 .iter()
-                .map(|field| {
-                    Field {
-                        name: field.name.clone(),
-                        typ: Alias::from(translate_alias(&field.typ, &mut translate)),
-                    }
+                .map(|field| Field {
+                    name: field.name.clone(),
+                    typ: Alias::from(translate_alias(&field.typ, &mut translate)),
                 })
                 .collect(),
             fields
                 .iter()
-                .map(|field| {
-                    Field {
-                        name: field.name.clone(),
-                        typ: translate(&field.typ),
-                    }
+                .map(|field| Field {
+                    name: field.name.clone(),
+                    typ: translate(&field.typ),
                 })
                 .collect(),
             translate_type(cache, rest),

--- a/base/src/types/mod.rs
+++ b/base/src/types/mod.rs
@@ -1695,6 +1695,11 @@ where
                 } else {
                     arena.space()
                 };
+
+                let print_any_field = fields
+                    .iter()
+                    .any(|field| printer.filter(&field.name) != Filter::Drop);
+
                 let mut filtered = false;
 
                 while let Type::ExtendRow {
@@ -1719,7 +1724,7 @@ where
                             } else {
                                  top(&field.typ.typ).pretty(printer)
                             },
-                            if i + 1 != types.len() || !fields.is_empty() {
+                            if i + 1 != types.len() || print_any_field {
                                 arena.text(",")
                             } else {
                                 arena.nil()
@@ -1783,6 +1788,11 @@ where
                             newline.clone(),
                             "...,",
                             doc,
+                            if newline.1 == arena.space().1 {
+                                arena.text(",")
+                            } else {
+                                arena.nil()
+                            },
                             newline.clone(),
                             "..."
                         ]

--- a/base/src/types/mod.rs
+++ b/base/src/types/mod.rs
@@ -1777,13 +1777,20 @@ where
                         .append(top(typ).pretty(printer)),
                 };
                 if filtered {
-                    chain![arena;
-                        newline.clone(),
-                        "...,",
-                        row_doc,
-                        newline.clone(),
-                        "..."
-                    ]
+                    if row_doc.1 == arena.nil().1 {
+                        chain![arena;
+                            newline.clone(),
+                            "..."
+                        ]
+                    } else {
+                        chain![arena;
+                            newline.clone(),
+                            "...,",
+                            row_doc,
+                            newline.clone(),
+                            "..."
+                        ]
+                    }
                 } else {
                     row_doc
                 }

--- a/base/src/types/pretty_print.rs
+++ b/base/src/types/pretty_print.rs
@@ -91,6 +91,19 @@ impl<'a, I, T> TypeFormatter<'a, I, T> {
         self
     }
 
+    pub fn pretty(&self, arena: &'a Arena<'a>) -> DocBuilder<'a, Arena<'a>>
+    where
+        T: Deref<Target = Type<I, T>> + HasSpan + Commented + 'a,
+        I: AsRef<str>,
+    {
+        use super::top;
+        top(self.typ).pretty(&Printer {
+            arena,
+            source: &Source::new(""),
+            filter: self.filter,
+        })
+    }
+
     pub fn build<'e>(&self, arena: &'a Arena<'a>, source: &'e Source<'a>) -> Printer<'a, 'e, I> {
         Printer {
             arena,

--- a/base/src/types/pretty_print.rs
+++ b/base/src/types/pretty_print.rs
@@ -65,6 +65,16 @@ pub enum Filter {
     Retain,
 }
 
+impl From<bool> for Filter {
+    fn from(b: bool) -> Filter {
+        if b {
+            Filter::Retain
+        } else {
+            Filter::Drop
+        }
+    }
+}
+
 pub struct TypeFormatter<'a, I, T>
 where
     I: 'a,

--- a/base/src/types/pretty_print.rs
+++ b/base/src/types/pretty_print.rs
@@ -58,6 +58,13 @@ pub fn doc_comment<'a>(
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum Filter {
+    Drop,
+    RetainKey,
+    Retain,
+}
+
 pub struct TypeFormatter<'a, I, T>
 where
     I: 'a,
@@ -65,7 +72,7 @@ where
 {
     width: usize,
     typ: &'a T,
-    filter: &'a Fn(&I) -> bool,
+    filter: &'a Fn(&I) -> Filter,
     _marker: PhantomData<I>,
 }
 
@@ -74,7 +81,7 @@ impl<'a, I, T> TypeFormatter<'a, I, T> {
         TypeFormatter {
             width: 80,
             typ: typ,
-            filter: &|_| true,
+            filter: &|_| Filter::Retain,
             _marker: PhantomData,
         }
     }
@@ -86,7 +93,7 @@ impl<'a, I, T> TypeFormatter<'a, I, T> {
         self
     }
 
-    pub fn filter(mut self, filter: &'a Fn(&I) -> bool) -> Self {
+    pub fn filter(mut self, filter: &'a Fn(&I) -> Filter) -> Self {
         self.filter = filter;
         self
     }
@@ -136,7 +143,7 @@ where
 pub struct Printer<'a: 'e, 'e, I: 'a> {
     pub arena: &'a Arena<'a>,
     pub source: &'e Source<'a>,
-    filter: &'a Fn(&I) -> bool,
+    filter: &'a Fn(&I) -> Filter,
 }
 
 impl<'a: 'e, 'e, I> Printer<'a, 'e, I> {
@@ -144,11 +151,11 @@ impl<'a: 'e, 'e, I> Printer<'a, 'e, I> {
         Printer {
             arena,
             source,
-            filter: &|_| true,
+            filter: &|_| Filter::Retain,
         }
     }
 
-    pub fn filter(&self, field: &I) -> bool {
+    pub fn filter(&self, field: &I) -> Filter {
         (self.filter)(field)
     }
 

--- a/base/src/types/pretty_print.rs
+++ b/base/src/types/pretty_print.rs
@@ -1,10 +1,15 @@
 use std::borrow::Cow;
+use std::fmt;
+use std::marker::PhantomData;
+use std::ops::Deref;
 
 use pretty::{Arena, DocAllocator, DocBuilder};
 
-use ast::{is_operator_char, Comment, CommentType};
-use pos::{BytePos, Span};
+use ast::{is_operator_char, Comment, CommentType, Commented};
+use pos::{BytePos, HasSpan, Span};
 use source::Source;
+
+use types::{pretty_print, Type};
 
 pub fn ident<'b, S>(arena: &'b Arena<'b>, name: S) -> DocBuilder<'b, Arena<'b>>
 where
@@ -53,14 +58,85 @@ pub fn doc_comment<'a>(
     }
 }
 
-pub struct Printer<'a: 'e, 'e> {
-    pub arena: &'a Arena<'a>,
-    pub source: &'e Source<'a>,
+pub struct TypeFormatter<'a, I, T>
+where
+    I: 'a,
+    T: 'a,
+{
+    width: usize,
+    typ: &'a T,
+    filter: &'a Fn(&I) -> bool,
+    _marker: PhantomData<I>,
 }
 
-impl<'a: 'e, 'e> Printer<'a, 'e> {
-    pub fn new(arena: &'a Arena<'a>, source: &'e Source<'a>) -> Printer<'a, 'e> {
-        Printer { arena, source }
+impl<'a, I, T> TypeFormatter<'a, I, T> {
+    pub fn new(typ: &'a T) -> Self {
+        TypeFormatter {
+            width: 80,
+            typ: typ,
+            filter: &|_| true,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, I, T> TypeFormatter<'a, I, T> {
+    pub fn width(mut self, width: usize) -> Self {
+        self.width = width;
+        self
+    }
+
+    pub fn filter(mut self, filter: &'a Fn(&I) -> bool) -> Self {
+        self.filter = filter;
+        self
+    }
+
+    pub fn build<'e>(&self, arena: &'a Arena<'a>, source: &'e Source<'a>) -> Printer<'a, 'e, I> {
+        Printer {
+            arena,
+            source,
+            filter: self.filter,
+        }
+    }
+}
+
+impl<'a, I, T> fmt::Display for TypeFormatter<'a, I, T>
+where
+    T: Deref<Target = Type<I, T>> + HasSpan + Commented + 'a,
+    I: AsRef<str>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let arena = Arena::new();
+        let source = Source::new("");
+        let printer = self.build(&arena, &source);
+        let mut s = Vec::new();
+
+        pretty_print(&printer, self.typ)
+            .group()
+            .1
+            .render(self.width, &mut s)
+            .map_err(|_| fmt::Error)?;
+        write!(f, "{}", ::std::str::from_utf8(&s).expect("utf-8"))
+    }
+}
+
+pub struct Printer<'a: 'e, 'e, I: 'a> {
+    pub arena: &'a Arena<'a>,
+    pub source: &'e Source<'a>,
+    filter: &'a Fn(&I) -> bool,
+}
+
+impl<'a: 'e, 'e, I> Printer<'a, 'e, I> {
+    pub fn new(arena: &'a Arena<'a>, source: &'e Source<'a>) -> Printer<'a, 'e, I> {
+        Printer {
+            arena,
+            source,
+            filter: &|_| true,
+        }
+    }
+
+    pub fn filter(&self, field: &I) -> bool {
+        (self.filter)(field)
     }
 
     pub fn space_before(&self, pos: BytePos) -> DocBuilder<'a, Arena<'a>> {

--- a/base/tests/types.rs
+++ b/base/tests/types.rs
@@ -144,6 +144,56 @@ fn show_record_multiline() {
 }
 
 #[test]
+fn show_record_filtered() {
+    let data = |s, a| ArcType::from(type_con(s, a));
+    let test = data("Test", vec![data("a", vec![])]);
+    let record = Type::record(
+        vec![Field::new("Test", Alias::new("Test", Type::int()))],
+        vec![
+            Field::new("x", Type::int()),
+            Field::new("y", Type::int()),
+            Field::new("test", test.clone()),
+            Field::new(
+                "+",
+                Type::function(vec![Type::int(), Type::int()], Type::int()),
+            ),
+        ],
+    );
+
+    assert_eq_display!(
+        format!(
+            "{}",
+            TypeFormatter::new(&record).filter(&|field| *field == "Test")
+        ),
+        r#"{ ..., Test = Int, ... }"#
+    );
+
+    assert_eq_display!(
+        format!(
+            "{}",
+            TypeFormatter::new(&record).filter(&|field| *field != "x")
+        ),
+        r#"{ ..., Test = Int, y : Int, test : Test a, (+) : Int -> Int -> Int, ... }"#
+    );
+    assert_eq_display!(
+        format!(
+            "{}",
+            TypeFormatter::new(&record)
+                .filter(&|field| *field != "x")
+                .width(50)
+        ),
+        r#"{
+    ...,
+    Test = Int,
+    y : Int,
+    test : Test a,
+    (+) : Int -> Int -> Int,
+    ...
+}"#
+    );
+}
+
+#[test]
 fn show_record_multi_line_nested() {
     let data = |s, a| ArcType::from(type_con(s, a));
     let fun = Type::function(vec![data("a", vec![])], Type::string());

--- a/base/tests/types.rs
+++ b/base/tests/types.rs
@@ -163,7 +163,7 @@ fn show_record_filtered() {
     assert_eq_display!(
         format!(
             "{}",
-            TypeFormatter::new(&record).filter(&|field| *field == "Test")
+            TypeFormatter::new(&record).filter(&|field| (*field == "Test").into())
         ),
         r#"{ ..., Test = Int, ... }"#
     );
@@ -171,7 +171,7 @@ fn show_record_filtered() {
     assert_eq_display!(
         format!(
             "{}",
-            TypeFormatter::new(&record).filter(&|field| *field != "x")
+            TypeFormatter::new(&record).filter(&|field| (*field != "x").into())
         ),
         r#"{ ..., Test = Int, y : Int, test : Test a, (+) : Int -> Int -> Int, ... }"#
     );
@@ -179,7 +179,7 @@ fn show_record_filtered() {
         format!(
             "{}",
             TypeFormatter::new(&record)
-                .filter(&|field| *field != "x")
+                .filter(&|field| (*field != "x").into())
                 .width(50)
         ),
         r#"{

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -18,6 +18,8 @@ union-find = "0.3.1"
 pretty = "0.3.0"
 smallvec = "0.2.1"
 
+strsim = "0.7.0"
+
 gluon_base = { path = "../base", version = "0.7.1" } # GLUON
 gluon_parser = { path = "../parser", version = "0.7.1", optional = true } # GLUON
 

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -11,6 +11,7 @@ extern crate itertools;
 #[macro_use]
 extern crate log;
 extern crate pretty;
+extern crate strsim;
 extern crate union_find;
 
 #[macro_use]

--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -81,10 +81,10 @@ pub fn metadata(
                     self.stack_var(id.clone(), metadata.clone());
                     self.new_pattern(metadata, pat);
                 }
-                Pattern::Tuple { .. } |
-                Pattern::Constructor(..) |
-                Pattern::Literal(_) |
-                Pattern::Error => (),
+                Pattern::Tuple { .. }
+                | Pattern::Constructor(..)
+                | Pattern::Literal(_)
+                | Pattern::Error => (),
             }
         }
 

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -174,8 +174,12 @@ where
                     })
                     .collect::<Vec<_>>();
                 field_similarity.sort_by_key(|t| ::std::cmp::Reverse(t.1));
+
                 Box::new(move |field: &I| {
-                    if field_similarity
+                    // Keep the fields that were missing as-is (with full types)
+                    if fields.iter().any(|f| f.as_ref() == field.as_ref()) {
+                        Filter::Retain
+                    } else if field_similarity
                         .iter()
                         .take(3)
                         .any(|t| t.0.as_ref() == field.as_ref())

--- a/check/src/unify_type.rs
+++ b/check/src/unify_type.rs
@@ -5,7 +5,8 @@ use base::error::Errors;
 use base::fnv::FnvMap;
 use base::merge;
 use base::kind::ArcKind;
-use base::types::{self, AppVec, ArcType, Field, Generic, Skolem, Type, TypeEnv, TypeVariable};
+use base::types::{self, AppVec, ArcType, Field, Generic, Skolem, Type, TypeEnv, TypeFormatter,
+                  TypeVariable};
 use base::symbol::{Symbol, SymbolRef};
 use base::resolve::{self, Error as ResolveError};
 use base::scoped_map::ScopedMap;
@@ -133,6 +134,53 @@ where
     I: fmt::Display + AsRef<str>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let filter = self.make_filter();
+        self.filter_fmt(&*filter, f)
+    }
+}
+
+impl<I> TypeError<I>
+where
+    I: fmt::Display + AsRef<str>,
+{
+    pub fn make_filter<'a>(&'a self) -> Box<Fn(&I) -> bool + 'a> {
+        match *self {
+            TypeError::FieldMismatch(ref l, ref r) => {
+                Box::new(move |field| [l, r].iter().any(|f| f.as_ref() == field.as_ref()))
+            }
+            TypeError::UndefinedType(_) => Box::new(|_| true),
+            TypeError::SelfRecursive(_) => Box::new(|_| true),
+            TypeError::UnableToGeneralize(_) => Box::new(|_| true),
+            TypeError::MissingFields(ref typ, ref fields) => {
+                let mut field_similarity = typ.type_field_iter()
+                    .map(|field| &field.name)
+                    .chain(typ.row_iter().map(|field| &field.name))
+                    .map(|field_in_type| {
+                        let similarity = fields
+                            .iter()
+                            .map(|missing_field| {
+                                ::strsim::jaro_winkler(
+                                    missing_field.as_ref(),
+                                    field_in_type.as_ref(),
+                                )
+                            })
+                            .max_by(|l, r| l.partial_cmp(&r).unwrap())
+                            .expect("At least one missing field");
+                        (field_in_type, (similarity * 1000000.) as i32)
+                    })
+                    .collect::<Vec<_>>();
+                field_similarity.sort_by_key(|t| ::std::cmp::Reverse(t.1));
+                Box::new(move |field: &I| {
+                    field_similarity
+                        .iter()
+                        .take(3)
+                        .any(|t| t.0.as_ref() == field.as_ref())
+                })
+            }
+        }
+    }
+
+    pub fn filter_fmt(&self, filter: &Fn(&I) -> bool, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             TypeError::FieldMismatch(ref l, ref r) => write!(
                 f,
@@ -152,7 +200,11 @@ where
                 id
             ),
             TypeError::MissingFields(ref typ, ref fields) => {
-                write!(f, "The type `{}` lacks the following fields: ", typ)?;
+                write!(
+                    f,
+                    "The type `{}` lacks the following fields: ",
+                    TypeFormatter::new(typ).filter(filter)
+                )?;
                 for (i, field) in fields.iter().enumerate() {
                     let sep = match i {
                         0 => "",

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -334,7 +334,7 @@ fn set_globals(
                         set_globals(vm, field_pattern, &field_type, &field_value)?
                     }
                     None => vm.set_global(
-                        field.name.value.clone(),
+                        Symbol::from(format!("@{}", field.name.value.declared_name())),
                         field_type,
                         Default::default(),
                         *field_value,


### PR DESCRIPTION
Instead of writing out the entire prelude record we will now get the below output. We could definitely still do better however (and the filtering is a bit imprecise right now since it applies to the entire type regardless of the nesting).

```
gluon (:h for help, :q to quit)
> let { Se = x } = import! std.prelude in x
<line>:Line: 1, Column: 5: Expected the following types to be equal
Expected:
    {
        ...,
        Semigroup = forall a . { ... },
        Show = forall a . { ... },
        make_Semigroup : forall a . std.prelude.Semigroup a -> { ... },
        ...
    }
Found:
    {
        ...,
        Semigroup = forall a . { ... },
        Show = forall a . { ... },
        make_Semigroup : forall a . std.prelude.Semigroup a -> { ... },
        | a
        ...
    }
1 errors were found during unification:
The type `{
    ...,
    Semigroup = forall a . { ... },
    Show = forall a . { ... },
    make_Semigroup : forall a . std.prelude.Semigroup a -> { ... },
    ...
}` lacks the following fields: Se
let { Se = x } = import! std.prelude in x
```