### PR TITLE
 refactor(vm): Make Value's internal strucuture private

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
  "gluon_base 0.7.1",
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -473,8 +473,8 @@ dependencies = [
  "gluon_check 0.7.1",
  "gluon_parser 0.7.1",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mopa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -568,29 +568,6 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-snap 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lalrpop"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -614,35 +591,8 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-intern"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lalrpop-intern"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lalrpop-snap"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lalrpop-snap"
@@ -665,11 +615,6 @@ dependencies = [
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lalrpop-util"
@@ -1550,13 +1495,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b07332223953b5051bceb67e8c4700aa65291535568e1f12408c43c4a42c0394"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lalrpop 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8ebe5a5c90d5edeecb7f62f6ebec0a3d0f6faf4759a052708348cda99fd311a0"
 "checksum lalrpop 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6fe7e84d1b798674f26dd7f2e7c0c92b5736f77866dadcf59c64b949ff40d00"
-"checksum lalrpop-intern 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05410c1e4aff497bdea1ccb274ac35536fda0ee858600df36966502d4f7acbe3"
 "checksum lalrpop-intern 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8af84a2fa97bb57e285c56b8303645cefa17c92ad115c4d711b3b4ba5bc5c197"
-"checksum lalrpop-snap 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f866ece35287f5223a1a022c5d86417c260cda2ca9c8a156af9959404ce5313"
 "checksum lalrpop-snap 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "395696fe1022abe294978648249b5edd854395a199b0e9e5579c7fab47b807d0"
-"checksum lalrpop-util 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7c7743f235fc17f5f50f3b1e64a8690ee154f17f86bd68cbb78787c5b37907f7"
 "checksum lalrpop-util 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c9d51721b6a49a70a02c02862e27c57069878fa6bf6689c20b755a45efc8c67"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ gluon_completion = { path = "completion", version = "0.7.1" } # GLUON
 default = ["regex", "rand"]
 serialization = ["serde", "serde_state", "serde_derive_state", "gluon_vm/serialization"]
 
+docs_rs = ["serialization"]
+
 test = ["serialization", "gluon_vm/test", "gluon_check/test", "gluon_parser/test"]
 nightly = ["compiletest_rs"]
 
@@ -138,3 +140,6 @@ name = "stack_overflow"
 name = "tutorial"
 [[test]]
 name = "vm"
+
+[package.metadata.docs.rs]
+features = ["docs_rs"]

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn glu_get_string(
     let mut context = vm.context();
     let stack = context.stack.current_frame();
     match stack
-        .get_variants(index)
+        .get_variant(index)
         .map(|value| <&str>::from_value(vm, value))
     {
         Some(value) => {
@@ -245,7 +245,7 @@ where
     let mut context = vm.context();
     let stack = context.stack.current_frame();
     match stack
-        .get_variants(index)
+        .get_variant(index)
         .map(|value| T::from_value(vm, value))
     {
         Some(value) => {

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -93,15 +93,15 @@ define_vmtype! { Method }
 impl<'vm> Pushable<'vm> for Wrap<Method> {
     fn push(self, _: &'vm Thread, context: &mut Context) -> VmResult<()> {
         use hyper::Method::*;
-        context.stack.push(Value::Tag(match self.0 {
+        context.stack.push(Value::tag(match self.0 {
             Get => 0,
             Post => 1,
             Delete => 2,
             _ => {
-                return Err(
-                    VmError::Message(format!("Method `{:?}` does not exist in gluon", self.0))
-                        .into(),
-                )
+                return Err(VmError::Message(format!(
+                    "Method `{:?}` does not exist in gluon",
+                    self.0
+                )).into())
             }
         }));
         Ok(())
@@ -260,8 +260,7 @@ fn listen(port: i32, value: WithVM<OpaqueValue<RootedThread, Handler<Response>>>
 
     // Retrieve the `handle` function from the http module which we use to evaluate values of type
     // `Handler Response`
-    type ListenFn = fn(OpaqueValue<RootedThread, Handler<Response>>, HttpState)
-        -> IO<Response>;
+    type ListenFn = fn(OpaqueValue<RootedThread, Handler<Response>>, HttpState) -> IO<Response>;
     let handle: Function<RootedThread, ListenFn> = thread
         .get_global("examples.http.handle")
         .unwrap_or_else(|err| panic!("{}", err));

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,7 +17,7 @@ collect-mac = "0.1.0"
 env_logger = { version = "0.3.4", optional = true }
 itertools = "0.6.0"
 quick-error = "1.0.0"
-lalrpop-util = "0.13.1"
+lalrpop-util = "0.14.0"
 log = "0.3.6"
 pretty = "0.3.2"
 gluon_base = { path = "../base", version = "0.7.1" } # GLUON

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -293,7 +293,7 @@ fn eval_line_(
         .map(move |ExecuteValue { value, typ, .. }| {
             let vm = value.vm();
             let env = vm.global_env().get_env();
-            ValuePrinter::new(&*env, &typ, *value)
+            ValuePrinter::new(&*env, &typ, value.get_variant())
                 .width(80)
                 .max_level(5)
                 .to_string()
@@ -313,7 +313,7 @@ fn set_globals(
                 Symbol::from(format!("@{}", id.name.declared_name())),
                 typ.clone(),
                 Default::default(),
-                **value,
+                value.get_value(),
             )?;
             Ok(())
         }
@@ -337,7 +337,7 @@ fn set_globals(
                         Symbol::from(format!("@{}", field.name.value.declared_name())),
                         field_type,
                         Default::default(),
-                        *field_value,
+                        field_value.get_value(),
                     )?,
                 }
             }
@@ -348,7 +348,7 @@ fn set_globals(
                 Symbol::from(format!("@{}", id.declared_name())),
                 typ.clone(),
                 Default::default(),
-                **value,
+                value.get_value(),
             )?;
             set_globals(vm, pattern, typ, value)
         }
@@ -382,7 +382,7 @@ fn finish_or_interrupt(
     });
 
     let mut action =
-        OwnedFunction::<fn() -> IO<Generic<A>>>::from_value(&thread, action.get_variants());
+        OwnedFunction::<fn() -> IO<Generic<A>>>::from_value(&thread, action.get_variant());
     let action_future = cpu_pool.0.spawn_fn(move || action.call_async());
 
     let ctrl_c_future = receiver

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -481,7 +481,12 @@ where
             })
             .and_then(move |mut value| {
                 let (metadata, _) = metadata::metadata(&*vm.get_env(), value.expr.borrow_mut());
-                try_future!(vm.set_global(value.id.clone(), value.typ, metadata, *value.value,));
+                try_future!(vm.set_global(
+                    value.id.clone(),
+                    value.typ,
+                    metadata,
+                    value.value.get_value(),
+                ));
                 info!("Loaded module `{}` filename", filename);
                 FutureValue::sync(Ok(()))
             })
@@ -639,7 +644,7 @@ where
         } = v;
 
         let vm1 = vm.clone();
-        execute(vm1, |vm| vm.execute_io(*value))
+        execute(vm1, |vm| vm.execute_io(value.get_value()))
             .map(move |(_, value)| {
                 // The type of the new value will be `a` instead of `IO a`
                 let actual = resolve::remove_aliases_cow(&*vm.get_env(), &typ);

--- a/src/import.rs
+++ b/src/import.rs
@@ -302,7 +302,7 @@ impl<I> Import<I> {
                 typ,
                 metadata,
             }) => {
-                vm.set_global(module_id.clone(), typ, metadata, *value)
+                vm.set_global(module_id.clone(), typ, metadata, value.get_value())
                     .map_err(|err| (None, err.into()))?;
             }
             UnloadedModule::Source(file_contents) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,7 +463,7 @@ impl Compiler {
             .run_expr(self, vm, name, expr_str, Some(&expected))
             .and_then(move |execute_value| unsafe {
                 FutureValue::sync(Ok((
-                    T::from_value(vm, Variants::new(&execute_value.value)),
+                    T::from_value(vm, Variants::new(&execute_value.value.get_value())),
                     execute_value.typ,
                 )))
             })

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -90,7 +90,6 @@ fn partial_record() {
     );
 }
 
-
 #[derive(Debug, PartialEq, Deserialize)]
 struct OptionalFieldRecord {
     test: Option<i32>,
@@ -123,7 +122,7 @@ fn optional_field() {
         .run_expr::<OpaqueValue<&Thread, Hole>>(&thread, "test", r#" { } "#)
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(
-        De::<OptionalFieldRecord>::from_value(&thread, value.get_variants()).0,
+        De::<OptionalFieldRecord>::from_value(&thread, value.get_variant()).0,
         OptionalFieldRecord { test: None }
     );
 
@@ -135,7 +134,7 @@ fn optional_field() {
         )
         .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(
-        De::<OptionalFieldRecord>::from_value(&thread, value.get_variants()).0,
+        De::<OptionalFieldRecord>::from_value(&thread, value.get_variant()).0,
         OptionalFieldRecord { test: Some(2) }
     );
 
@@ -154,7 +153,7 @@ fn optional_field() {
         Type::hole(),
     );
     assert_eq!(
-        de::from_value(&thread, value.get_variants(), &typ).ok(),
+        de::from_value(&thread, value.get_variant(), &typ).ok(),
         Some(OptionalFieldRecord { test: Some(1) })
     );
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -3,8 +3,7 @@ extern crate gluon;
 extern crate tokio_core;
 
 use gluon::{new_vm, Compiler, Thread};
-use gluon::vm::internal::Value;
-use gluon::vm::api::{Hole, OpaqueValue, IO};
+use gluon::vm::api::{Hole, OpaqueValue, ValueRef, IO};
 
 #[macro_use]
 mod support;
@@ -113,7 +112,7 @@ wrap 123
         .sync_or_error()
         .unwrap_or_else(|err| panic!("{}", err));
     assert!(
-        value.0.get_ref() != Value::Int(123),
+        value.0.get_ref() != ValueRef::Int(123),
         "Unexpected {:?}",
         value.0
     );

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,9 +1,9 @@
 #[allow(unused_extern_crates)]
 extern crate env_logger;
+pub extern crate futures;
 #[allow(unused_extern_crates)]
 extern crate gluon;
 extern crate tokio_core;
-pub extern crate futures;
 
 use gluon::vm::api::{Getable, VmType};
 use gluon::vm::thread::{RootedThread, Thread};

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -38,14 +38,14 @@ gluon_check = { path = "../check", version = "0.7.1" } # GLUON
 tokio-core = "0.1"
 
 [build-dependencies]
-lalrpop = { version = "0.13.1", optional = true }
+lalrpop = { version = "0.14.0", optional = true }
 
 [dev-dependencies]
 # HACK Trick crates.io into letting letting this be published with a dependency on gluon
 # (which requires gluon_vm to be published)
 gluon = { path = "..", version = "<0.9.0, >=0.7.0" } # GLUON
 
-lalrpop-util = "0.13.1"
+lalrpop-util = "0.14.0"
 regex = "0.2.0"
 serde_json = "1.0.0"
 

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -458,7 +458,7 @@ impl<'de, 't, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de, 't> {
                 ValueRef::Data(data) if data.tag() == 1 => visitor.visit_some(&mut Deserializer {
                     state: self.state.clone(),
                     typ: typ,
-                    input: data.get_variants(0).unwrap(),
+                    input: data.get_variant(0).unwrap(),
                 }),
                 _ => self.deserialize_any(visitor),
             },
@@ -505,7 +505,7 @@ impl<'de, 't, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de, 't> {
                 match row.row_iter().nth(data.tag() as usize) {
                     Some(field) => {
                         let iter = (0..data.len())
-                            .map(|i| data.get_variants(i).unwrap())
+                            .map(|i| data.get_variant(i).unwrap())
                             .zip(arg_iter(&field.typ));
                         visitor.visit_seq(SeqDeserializer::new(self.state.clone(), iter))
                     }
@@ -765,7 +765,7 @@ impl<'de, 'a, 't> VariantAccess<'de> for Enum<'a, 'de, 't> {
             (ValueRef::Data(data), &Type::Variant(ref row)) => {
                 match row.row_iter().nth(data.tag() as usize) {
                     Some(field) => seed.deserialize(&mut Deserializer {
-                        input: data.get_variants(0).ok_or_else(|| {
+                        input: data.get_variant(0).ok_or_else(|| {
                             VmError::Message("Expected variant to have a value argument".into())
                         })?,
                         typ: arg_iter(&field.typ).next().ok_or_else(|| {

--- a/vm/src/api/ser.rs
+++ b/vm/src/api/ser.rs
@@ -9,7 +9,7 @@ use api::{Pushable, VmType};
 use interner::InternedStr;
 use thread::{Context, Thread, ThreadInternal};
 use types::{VmIndex, VmTag};
-use value::{Def, RecordDef, Value};
+use value::{Def, RecordDef, ValueRepr};
 use serde::ser::{self, Serialize};
 
 /**
@@ -178,7 +178,7 @@ impl<'t> Serializer<'t> {
         for _ in 0..values {
             self.context.stack.pop();
         }
-        self.context.stack.push(Value::Data(value));
+        self.context.stack.push(ValueRepr::Data(value));
         Ok(())
     }
 
@@ -190,7 +190,7 @@ impl<'t> Serializer<'t> {
         for _ in 0..values {
             self.context.stack.pop();
         }
-        self.context.stack.push(Value::Data(value));
+        self.context.stack.push(ValueRepr::Data(value));
         Ok(())
     }
 }
@@ -327,7 +327,7 @@ impl<'a, 'vm> ser::Serializer for &'a mut Serializer<'vm> {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
-        self.context.stack.push(Value::Tag(0));
+        self.context.stack.push(ValueRepr::Tag(0));
         Ok(())
     }
 
@@ -341,7 +341,7 @@ impl<'a, 'vm> ser::Serializer for &'a mut Serializer<'vm> {
         variant_index: u32,
         _variant: &'static str,
     ) -> Result<Self::Ok> {
-        self.context.stack.push(Value::Tag(variant_index));
+        self.context.stack.push(ValueRepr::Tag(variant_index));
         Ok(())
     }
 
@@ -559,6 +559,7 @@ impl<'a, 'vm> ser::SerializeStructVariant for RecordSerializer<'a, 'vm> {
 mod tests {
     use super::*;
     use thread::{RootedThread, ThreadInternal};
+    use value::Value;
 
     fn to_value<T>(thread: &Thread, value: &T) -> Result<Value>
     where
@@ -572,6 +573,6 @@ mod tests {
     #[test]
     fn bool() {
         let thread = RootedThread::new();
-        assert_eq!(to_value(&thread, &true).unwrap(), Value::Tag(1));
+        assert_eq!(to_value(&thread, &true).unwrap(), Value::tag(1));
     }
 }

--- a/vm/src/array.rs
+++ b/vm/src/array.rs
@@ -14,45 +14,45 @@ mod internal {
 /// Abstract array type which have their length store inline with the elements.
 /// Fills the same role as Box<[T]> but takes only 8 bytes on the stack instead of 16
 #[repr(C)]
-pub struct Array<T: Copy> {
+pub struct Array<T> {
     len: usize,
     array_start: [T; 0],
     _marker: self::internal::CantConstruct,
 }
 
-impl<T: Copy> AsRef<[T]> for Array<T> {
+impl<T> AsRef<[T]> for Array<T> {
     fn as_ref(&self) -> &[T] {
         self
     }
 }
 
-impl<T: Copy> AsMut<[T]> for Array<T> {
+impl<T> AsMut<[T]> for Array<T> {
     fn as_mut(&mut self) -> &mut [T] {
         self
     }
 }
 
-impl<T: Copy + PartialEq> PartialEq for Array<T> {
+impl<T: PartialEq> PartialEq for Array<T> {
     fn eq(&self, other: &Array<T>) -> bool {
         &**self == other.as_ref()
     }
 }
 
-impl<T: Copy + Eq> Eq for Array<T> {}
+impl<T: Eq> Eq for Array<T> {}
 
-impl<T: Copy + PartialOrd> PartialOrd for Array<T> {
+impl<T: PartialOrd> PartialOrd for Array<T> {
     fn partial_cmp(&self, other: &Array<T>) -> Option<Ordering> {
         (&**self).partial_cmp(other.as_ref())
     }
 }
 
-impl<T: Copy + Ord> Ord for Array<T> {
+impl<T: Ord> Ord for Array<T> {
     fn cmp(&self, other: &Array<T>) -> Ordering {
         (&**self).cmp(other)
     }
 }
 
-impl<T: Copy + Hash> Hash for Array<T> {
+impl<T: Hash> Hash for Array<T> {
     fn hash<H>(&self, hasher: &mut H)
     where
         H: Hasher,
@@ -61,19 +61,19 @@ impl<T: Copy + Hash> Hash for Array<T> {
     }
 }
 
-impl<T: Copy + fmt::Debug> fmt::Debug for Array<T> {
+impl<T: fmt::Debug> fmt::Debug for Array<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", &**self)
     }
 }
 
-impl<T: Copy + Traverseable> Traverseable for Array<T> {
+impl<T: Traverseable> Traverseable for Array<T> {
     fn traverse(&self, gc: &mut Gc) {
         (**self).traverse(gc)
     }
 }
 
-impl<T: Copy> Array<T> {
+impl<T> Array<T> {
     pub fn size_of(len: usize) -> usize {
         mem::size_of::<usize>() + mem::size_of::<T>() * len
     }
@@ -99,20 +99,20 @@ impl<T: Copy> Array<T> {
     }
 }
 
-impl<T: Copy> Deref for Array<T> {
+impl<T> Deref for Array<T> {
     type Target = [T];
     fn deref(&self) -> &[T] {
         unsafe { slice::from_raw_parts(self.array_start.as_ptr(), self.len) }
     }
 }
 
-impl<T: Copy> DerefMut for Array<T> {
+impl<T> DerefMut for Array<T> {
     fn deref_mut(&mut self) -> &mut [T] {
         unsafe { slice::from_raw_parts_mut(self.array_start.as_mut_ptr(), self.len) }
     }
 }
 
-impl<'a, T: Copy + 'a> IntoIterator for &'a Array<T> {
+impl<'a, T: 'a> IntoIterator for &'a Array<T> {
     type Item = &'a T;
     type IntoIter = <&'a [T] as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {
@@ -120,7 +120,7 @@ impl<'a, T: Copy + 'a> IntoIterator for &'a Array<T> {
     }
 }
 
-impl<'a, T: Copy + 'a> IntoIterator for &'a mut Array<T> {
+impl<'a, T: 'a> IntoIterator for &'a mut Array<T> {
     type Item = &'a mut T;
     type IntoIter = <&'a mut [T] as IntoIterator>::IntoIter;
     fn into_iter(self) -> Self::IntoIter {

--- a/vm/src/debug.rs
+++ b/vm/src/debug.rs
@@ -4,7 +4,7 @@ use thread::Thread;
 use {ExternModule, Result};
 
 fn trace(a: Generic<A>) {
-    println!("{:?}", a.0);
+    println!("{:?}", a);
 }
 
 mod std {

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -105,20 +105,6 @@ impl<'a> Variants<'a> {
     }
 }
 
-impl<'a> ::serde::ser::SerializeState<::serialization::SeSeed> for Variants<'a> {
-    #[inline]
-    fn serialize_state<S>(
-        &self,
-        serializer: S,
-        seed: &::serialization::SeSeed,
-    ) -> ::std::result::Result<S::Ok, S::Error>
-    where
-        S: ::serde::ser::Serializer,
-    {
-        self.0.serialize_state(serializer, seed)
-    }
-}
-
 /// Type returned from vm functions which may fail
 pub type Result<T> = ::std::result::Result<T, Error>;
 

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -14,6 +14,7 @@ use base::serialization::{NodeMap, NodeToId};
 use base::symbol::{Symbol, Symbols};
 use base::types::ArcType;
 
+use Variants;
 use array::Array;
 use gc::{DataDef, GcPtr, WriteOnly};
 use thread::{RootedThread, Thread, ThreadInternal};
@@ -738,6 +739,20 @@ where
 {
     use serde::ser::Error;
     Err(S::Error::custom("Userdata cannot be serialized"))
+}
+
+impl<'a> ::serde::ser::SerializeState<::serialization::SeSeed> for Variants<'a> {
+    #[inline]
+    fn serialize_state<S>(
+        &self,
+        serializer: S,
+        seed: &::serialization::SeSeed,
+    ) -> ::std::result::Result<S::Ok, S::Error>
+    where
+        S: ::serde::ser::Serializer,
+    {
+        self.0.serialize_state(serializer, seed)
+    }
 }
 
 #[cfg(test)]

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -348,7 +348,7 @@ pub(crate) enum ValueRepr {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(feature = "serde_derive", serde(deserialize_state = "::serialization::DeSeed"))]
 #[cfg_attr(feature = "serde_derive", serde(serialize_state = "::serialization::SeSeed"))]
-pub struct Value(#[serde(state)] ValueRepr);
+pub struct Value(#[cfg_attr(feature = "serde_derive", serde(state))] ValueRepr);
 
 impl From<ValueRepr> for Value {
     #[inline]


### PR DESCRIPTION
Start of #16 and #303. By restricting how `Value` can be used we have a
start towards making the vm actually memory safe. As a first step, this
prevents code outside of `gluon_vm` from accessing the `GcPtr`s inside
`Value`.