### PR TITLE
fix(vm): Align garbage collected allocations correctly on 32-bit systems 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   - rust: nightly-2017-12-18
   - rust: beta
   - rust: stable
+    env: ARCH=i686
+  - rust: stable
     env:
       - DEPLOY=1
       - TARGET=x86_64-unknown-linux-gnu

--- a/vm/src/array.rs
+++ b/vm/src/array.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
@@ -74,10 +73,6 @@ impl<T: Traverseable> Traverseable for Array<T> {
 }
 
 impl<T> Array<T> {
-    pub fn size_of(len: usize) -> usize {
-        mem::size_of::<usize>() + mem::size_of::<T>() * len
-    }
-
     pub unsafe fn set_len(&mut self, len: usize) {
         self.len = len;
     }

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -433,8 +433,7 @@ unsafe impl DataDef for ClosureDataModel {
 
     fn size(&self) -> usize {
         use std::mem::size_of;
-        use array::Array;
-        size_of::<GcPtr<BytecodeFunction>>() + Array::<Value>::size_of(self.upvars)
+        size_of::<ClosureData>() + size_of::<Value>() * self.upvars
     }
 
     fn initialize<'w>(self, mut result: WriteOnly<'w, Self::Value>) -> &'w mut Self::Value {


### PR DESCRIPTION
Working on getting WASM properly working and it appears that WASM acts as a 32-bit system. Since we never ran any tests on 32-bit that had been broken since forever.