### PR TITLE
Fix typo in TUTORIAL.md

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -451,7 +451,7 @@ So in simple case, `forall` is no different from declaring type parameters to a 
 
 ```f#
 let module =
-    let id = x
+    let id x = x
 
     { id }
 


### PR DESCRIPTION
I noticed this when reading through the tutorial. It looks like this definition of the id function dropped an x.