### PR TITLE
fix(check): Don't overwrite implicit variables in renaming

### DIFF
--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -127,6 +127,10 @@ impl<Id> AstType<Id> {
         self._typ.1.value
     }
 
+    pub fn as_mut(&mut self) -> &mut SpannedAstType<Id> {
+        &mut self._typ.1
+    }
+
     pub fn params_mut(&mut self) -> &mut [Generic<Id>] {
         match self._typ.1.value {
             Type::Forall(ref mut params, _, _) => params,

--- a/base/src/types/mod.rs
+++ b/base/src/types/mod.rs
@@ -1051,6 +1051,17 @@ pub fn type_field_iter<T>(typ: &T) -> TypeFieldIterator<T> {
     TypeFieldIterator { typ, current: 0 }
 }
 
+pub fn remove_forall<'a, Id, T>(typ: &'a T) -> &'a T
+where
+    T: Deref<Target = Type<Id, T>>,
+    Id: 'a,
+{
+    match **typ {
+        Type::Forall(_, ref typ, _) => remove_forall(typ),
+        _ => typ,
+    }
+}
+
 impl<Id> ArcType<Id> {
     pub fn new(typ: Type<Id, ArcType<Id>>) -> ArcType<Id> {
         ArcType { typ: Arc::new(typ) }
@@ -1080,10 +1091,7 @@ impl<Id> ArcType<Id> {
     }
 
     pub fn remove_forall(&self) -> &ArcType<Id> {
-        match **self {
-            Type::Forall(_, ref typ, _) => typ.remove_forall(),
-            _ => self,
-        }
+        remove_forall(self)
     }
 
     pub fn skolemize(&self, named_variables: &mut FnvMap<Id, ArcType<Id>>) -> ArcType<Id>

--- a/check/tests/forall.rs
+++ b/check/tests/forall.rs
@@ -62,28 +62,21 @@ in f "123"
     );
 }
 
-/// Test that overload resolution selects the closest implementation that matches even if another
-/// overload has a better match. If this wasn't the case it would be possible to get diffferent
-/// selection depending on the order that types are infered.
 #[test]
-fn overloaded_with_equal_aliases() {
+fn shadowed_binding() {
     let _ = env_logger::try_init();
 
     let text = r"
-type Test = Int
 let test x: Int -> Int = 1
-let test x: Test -> Test = 0
+let test x: Int -> Int = 0
 test 1
 ";
     let (expr, result) = support::typecheck_expr(text);
 
     assert!(result.is_ok());
     let (bind, call) = match expr.value {
-        Expr::TypeBindings(_, ref body) => match body.value {
-            Expr::LetBindings(_, ref body) => match body.value {
-                Expr::LetBindings(ref binds, ref body) => (&binds[0], body),
-                _ => panic!(),
-            },
+        Expr::LetBindings(_, ref body) => match body.value {
+            Expr::LetBindings(ref binds, ref body) => (&binds[0], body),
             _ => panic!(),
         },
         _ => panic!(),

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -162,7 +162,7 @@ impl<E: TypeEnv> OnFound for Suggest<E> {
                 }
                 for field in field_ids {
                     match field.value {
-                        Some(_) => (),
+                        Some(ref value) => self.on_pattern(value),
                         None => {
                             let name = field.name.value.clone();
                             let typ = unaliased.row_iter()

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -471,7 +471,7 @@ r#"
 true
 }
 
-test_expr!{ implicit_argument_selection,
+test_expr!{ implicit_argument_selection1,
 r#"
 /// @implicit
 type Test = | Test ()
@@ -480,6 +480,22 @@ let i = Test ()
 f (Test ())
 "#,
 ()
+}
+
+test_expr!{ prelude implicit_argument_selection2,
+r#"
+let string = import! std.string
+let { append = (++) } = string.semigroup
+
+let equality l r : [Eq a] -> a -> a -> String =
+    if l == r then " == " else " != "
+
+let cmp l r : [Show a] -> [Eq a] -> a -> a -> String =
+    (show l) ++ (equality l r) ++ (show r)
+
+cmp 5 6
+"#,
+String::from("5 != 6")
 }
 
 #[test]


### PR DESCRIPTION
Moves the renaming pass before metadata and typechecking so that typechecking can freely create symbols without worrying about renaming bulldozing it afterwards.