### PR TITLE
Use assert_eq with implicit arguments in the test module

### DIFF
--- a/std/test.glu
+++ b/std/test.glu
@@ -14,11 +14,6 @@ let testWriter = writer.make list.monoid
 
 let assert x = if x then () else error "Assertion failed"
 
-let old_assert_eq show eq = \x y ->
-    if eq.(==) x y
-    then testWriter.applicative.wrap ()
-    else writer.tell (Cons ("Assertion failed: " ++ show.show x ++ " != " ++ show.show y) Nil)
-
 let assert_eq l r : [Show a] -> [Eq a] -> a -> a -> Test () =
     if l == r
     then testWriter.applicative.wrap ()
@@ -37,6 +32,5 @@ let run test : Test a -> () =
     monad = testWriter.monad,
     assert,
     assert_eq,
-    old_assert_eq,
     run,
 }

--- a/std/test.glu
+++ b/std/test.glu
@@ -13,14 +13,16 @@ type Test a = Writer (List String) a
 let testWriter = writer.make list.monoid
 
 let assert x = if x then () else error "Assertion failed"
-let assert_eq show eq = \x y ->
+
+let old_assert_eq show eq = \x y ->
     if eq.(==) x y
     then testWriter.applicative.wrap ()
     else writer.tell (Cons ("Assertion failed: " ++ show.show x ++ " != " ++ show.show y) Nil)
 
-let assert_ieq = assert_eq int.show int.eq
-let assert_feq = assert_eq float.show float.eq
-let assert_seq = assert_eq string.show string.eq
+let assert_eq l r : [Show a] -> [Eq a] -> a -> a -> Test () =
+    if l == r
+    then testWriter.applicative.wrap ()
+    else writer.tell (Cons ("Assertion failed: " ++ show l ++ " != " ++ show r) Nil)
 
 let run test : Test a -> () =
     match test.writer with
@@ -35,8 +37,6 @@ let run test : Test a -> () =
     monad = testWriter.monad,
     assert,
     assert_eq,
-    assert_ieq,
-    assert_feq,
-    assert_seq,
+    old_assert_eq,
     run,
 }

--- a/tests/pass/alternative.glu
+++ b/tests/pass/alternative.glu
@@ -1,4 +1,4 @@
-let { run, writer, old_assert_eq, ? } = import! std.test
+let { run, Test, assert_eq, ? } = import! std.test
 let prelude @ { Alternative } = import! std.prelude
 let { Applicative, (*>) } = import! std.applicative
 let int = import! std.int
@@ -9,10 +9,14 @@ let test_alt ?alt show eq : [Alternative f] -> Show (f Int) -> Eq (f Int) -> _ =
     let { (<|>), or, empty } = import! std.prelude
     let { wrap } = alt.applicative
 
-    let assert = old_assert_eq show eq
+    let assert = assert_eq ?show ?eq
 
     assert empty empty *> assert (empty <|> wrap 1) (wrap 1) *> assert (empty <|> empty) empty
         *> assert (empty <|> empty <|> wrap 10) (wrap 10)
 
-test_alt option.show option.eq
-    *> test_alt list.show list.eq
+let tests: Test () =
+    test_alt option.show option.eq
+        *> test_alt list.show list.eq
+
+run tests
+

--- a/tests/pass/alternative.glu
+++ b/tests/pass/alternative.glu
@@ -1,4 +1,4 @@
-let { run, writer, assert_eq, ? } = import! std.test
+let { run, writer, old_assert_eq, ? } = import! std.test
 let prelude @ { Alternative } = import! std.prelude
 let { Applicative, (*>) } = import! std.applicative
 let int = import! std.int
@@ -9,7 +9,7 @@ let test_alt ?alt show eq : [Alternative f] -> Show (f Int) -> Eq (f Int) -> _ =
     let { (<|>), or, empty } = import! std.prelude
     let { wrap } = alt.applicative
 
-    let assert = assert_eq show eq
+    let assert = old_assert_eq show eq
 
     assert empty empty *> assert (empty <|> wrap 1) (wrap 1) *> assert (empty <|> empty) empty
         *> assert (empty <|> empty <|> wrap 10) (wrap 10)

--- a/tests/pass/arithmetic.glu
+++ b/tests/pass/arithmetic.glu
@@ -1,17 +1,20 @@
-let { run, writer, assert, assert_ieq, assert_feq, ? }  = import! std.test
+let { run, Test, assert_eq, ? }  = import! std.test
 let prelude  = import! std.prelude
-let { Applicative, (*>) } = import! std.applicative
+let { Applicative, (*>), ? } = import! std.applicative
 let int = import! std.int
 let float = import! std.float
 
 let int_tests =
     let { (+), (-), (*) } = int.num
-    assert_ieq 2 2
-        *> assert_ieq 12 (10 + 2)
-        *> assert_ieq 123 (50 * 2 + 9 * 3 - 4)
+    assert_eq 2 2
+        *> assert_eq 12 (10 + 2)
+        *> assert_eq 123 (50 * 2 + 9 * 3 - 4)
 
 let float_tests =
     let { (+), (-), (*) } = float.num
-    assert_feq 91.0 (50.0 * 2.0 - 3.0 * 3.0)
+    assert_eq 91.0 (50.0 * 2.0 - 3.0 * 3.0)
 
-int_tests *> float_tests
+let tests : Test () =
+    int_tests *> float_tests
+
+run tests

--- a/tests/pass/channel.glu
+++ b/tests/pass/channel.glu
@@ -1,13 +1,10 @@
 let { Test, run, writer, assert_eq, ? }  = import! std.test
 let prelude  = import! std.prelude
-let { Applicative, (*>) } = import! std.applicative
+let { Applicative, (*>), ? } = import! std.applicative
 let int = import! std.int
-let result @ { Result } = import! std.result
+let result @ { Result, ? } = import! std.result
 let unit @ { ? } = import! std.unit
 let { send, recv, channel } = import! std.channel
-
-let assert : Result () Int -> Result () Int -> Test _ =
-    assert_eq result.show result.eq
 
 let { sender, receiver } = channel 0
 
@@ -15,9 +12,9 @@ send sender 0
 send sender 1
 send sender 2
 
-let tests =
-    assert (recv receiver) (Ok 0)
-        *> assert (recv receiver) (Ok 1)
-        *> assert (recv receiver) (Ok 2)
+let tests : Test () =
+    assert_eq (recv receiver) (Ok 0)
+        *> assert_eq (recv receiver) (Ok 1)
+        *> assert_eq (recv receiver) (Ok 2)
 
 run tests

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -1,4 +1,4 @@
-let { run, writer, assert, assert_ieq, assert_feq } = import! std.test
+let { run, writer, assert, ? } = import! std.test
 let prelude = import! std.prelude
 let { (*>) } = import! std.applicative
 let { Result } = import! std.result

--- a/tests/pass/lazy.glu
+++ b/tests/pass/lazy.glu
@@ -1,4 +1,4 @@
-let { run, writer, assert_ieq, ? } = import! std.test
+let { run, Test, assert_eq, ? } = import! std.test
 let prelude = import! std.prelude
 let { Applicative, (*>), wrap } = import! std.applicative
 let int = import! std.int
@@ -7,5 +7,8 @@ let { lazy, force } = import! std.lazy
 
 let l = lazy (\_ -> 123 + 57)
 
-assert_ieq (force (lazy (\_ -> 2))) 2 *> wrap ()
-    *> assert_ieq 180 (force l)
+let tests : Test () =
+    assert_eq (force (lazy (\_ -> 2))) 2 *> wrap ()
+        *> assert_eq 180 (force l)
+
+run tests

--- a/tests/pass/lisp.glu
+++ b/tests/pass/lisp.glu
@@ -1,6 +1,6 @@
 let prelude = import! std.prelude
-let { Test, run, writer, assert_eq, assert_seq, assert_ieq, ? } = import! std.test
-let { Applicative, (*>) } = import! std.applicative
+let { Test, run, writer, assert_eq, ? } = import! std.test
+let { Applicative, (*>), ? } = import! std.applicative
 let list @ { List, ? } = import! std.list
 
 let result @ { Result, ? } = import! std.result
@@ -9,52 +9,50 @@ let parser = import! std.parser
 
 let lisp @ { Expr, ? } = import! "examples/lisp/lisp.glu"
 
-let assert_leq : Result String Expr -> Result String Expr -> _ =
-    assert_eq result.show result.eq
-
 let parser_tests =
-    assert_leq (parser.parse lisp.expr "test") (Ok (Atom "test"))
-        *> assert_leq (parser.parse lisp.expr "()") (Ok (List Nil))
-        *> assert_leq
+    assert_eq (parser.parse lisp.expr "test") (Ok (Atom "test"))
+        *> assert_eq (parser.parse lisp.expr "()") (Ok (List Nil))
+        *> assert_eq
             (parser.parse lisp.expr "(test abc)")
             (Ok (List (Cons (Atom "test") (Cons (Atom "abc") Nil))))
-        *> assert_leq
+        *> assert_eq
             (parser.parse lisp.expr " ( test abc ) ")
             (Ok (List (Cons (Atom "test") (Cons (Atom "abc") Nil))))
-        *> assert_leq
+        *> assert_eq
             (parser.parse lisp.expr "(test (abc) d)")
             (Ok
                 (List
                     (Cons
                         (Atom "test")
                         (Cons (List (Cons (Atom "abc") Nil)) (Cons (Atom "d") Nil)))))
-        *> assert_leq
+        *> assert_eq
             (parser.parse lisp.expr "(test 123)")
             (Ok (List (Cons (Atom "test") (Cons (Int 123) Nil))))
-        *> assert_leq (parser.parse lisp.expr "123.45") (Ok (Float 123.45))
+        *> assert_eq (parser.parse lisp.expr "123.45") (Ok (Float 123.45))
 
 let { (>>=) } = import! std.prelude
 let eval_string s = parser.parse lisp.expr s >>= lisp.eval
 let eval_string_seq s = parser.parse (parser.many lisp.expr) s >>= lisp.eval_seq
 
 let eval_tests =
-    assert_leq (lisp.eval (Int 123)) (Ok (Int 123))
-        *> assert_leq
+    assert_eq (lisp.eval (Int 123)) (Ok (Int 123))
+        *> assert_eq
             (lisp.eval (List (Cons (Atom "+") (Cons (Int 1) (Cons (Int 2) Nil)))))
             (Ok (Int 3))
-        *> assert_leq (eval_string "()") (Ok (List Nil))
-        *> assert_leq (eval_string "(+ 1 2 3 4)") (Ok (Int (1 + 2 + 3 + 4)))
-        *> assert_leq (eval_string "(+ 1.0 2.5 3.14)") (Ok (Float (1.0 + 2.5 + 3.14)))
-        *> assert_leq (eval_string "(+ 1.0 (+ 2.5 3.14))") (Ok (Float (1.0 + 2.5 + 3.14)))
-        *> assert_leq (eval_string "(+ (+ 1 2) (+ 3 4))") (Ok (Int (1 + 2 + 3 + 4)))
-        *> assert_leq (eval_string "(- (* 2 3) (/ 2 2))") (Ok (Int ((2 * 3) - (2 / 2))))
+        *> assert_eq (eval_string "()") (Ok (List Nil))
+        *> assert_eq (eval_string "(+ 1 2 3 4)") (Ok (Int (1 + 2 + 3 + 4)))
+        *> assert_eq (eval_string "(+ 1.0 2.5 3.14)") (Ok (Float (1.0 + 2.5 + 3.14)))
+        *> assert_eq (eval_string "(+ 1.0 (+ 2.5 3.14))") (Ok (Float (1.0 + 2.5 + 3.14)))
+        *> assert_eq (eval_string "(+ (+ 1 2) (+ 3 4))") (Ok (Int (1 + 2 + 3 + 4)))
+        *> assert_eq (eval_string "(- (* 2 3) (/ 2 2))") (Ok (Int ((2 * 3) - (2 / 2))))
 
 let define_tests =
-    assert_leq (eval_string "(define x 3)") (Ok (Int 3))
-        *> assert_leq (eval_string_seq "(define y 3) y") (Ok (Int 3))
-        *> assert_leq (eval_string_seq "(define (id x) x) (id 4)") (Ok (Int 4))
-        *> assert_leq (eval_string_seq "(define (succ x) (+ x 1)) (succ 4)") (Ok (Int 5))
+    assert_eq (eval_string "(define x 3)") (Ok (Int 3))
+        *> assert_eq (eval_string_seq "(define y 3) y") (Ok (Int 3))
+        *> assert_eq (eval_string_seq "(define (id x) x) (id 4)") (Ok (Int 4))
+        *> assert_eq (eval_string_seq "(define (succ x) (+ x 1)) (succ 4)") (Ok (Int 5))
 
-let tests = parser_tests *> eval_tests *> define_tests
+let tests : Test () =
+    parser_tests *> eval_tests *> define_tests
 
 run tests

--- a/tests/pass/list.glu
+++ b/tests/pass/list.glu
@@ -1,14 +1,12 @@
-let prelude  = import! std.prelude
-let { Test, run, writer, assert, assert_eq, ? }  = import! std.test
-let { Applicative, (*>) } = import! std.applicative
-let int @ { ? } = import! std.int
-let list @ { List } = import! std.list
+let { Test, run, assert_eq, ? }  = import! std.test
+let { Applicative, (*>), ? } = import! std.applicative
+let list @ { List, ? } = import! std.list
 
-let assert_list show eq : Show a -> Eq a -> List a -> List a -> _ = assert_eq list.show list.eq
-let assert_int_list = assert_list int.show int.eq
+let empty_list : List Int =
+    Nil
 
-let test_list =
-    assert_int_list (list.of []) Nil *>
-        assert_int_list (list.of [1, 2, 3]) (Cons 1 (Cons 2 (Cons 3 Nil)))
+let test_list : Test () =
+    assert_eq (list.of []) empty_list *>
+        assert_eq (list.of [1, 2, 3]) (Cons 1 (Cons 2 (Cons 3 Nil)))
 
 run test_list

--- a/tests/pass/map.glu
+++ b/tests/pass/map.glu
@@ -3,7 +3,7 @@ let int = import! std.int
 let option @ { Option } = import! std.option
 let string = import! std.string
 let { (<>) } = import! std.prelude
-let { Test, run, writer, assert, old_assert_eq, ? }  = import! std.test
+let { Test, run, assert, assert_eq, ? }  = import! std.test
 let map @ { ? } = import! std.map
 let { Applicative, (*>) } = import! std.applicative
 let list @ { List } = import! std.list
@@ -16,10 +16,10 @@ let eq_Entry : Eq { key : String, value : Int } = {
     (==) = \l r -> l.key == r.key && l.value == r.value
 }
 
-let assert_entries = old_assert_eq (list.show ?show_Entry) (list.eq ?eq_Entry)
-let assert_keys = old_assert_eq (list.show ?string.show) (list.eq ?string.eq)
-let assert_values = old_assert_eq (list.show ?int.show) (list.eq ?int.eq)
-let assert_opt = old_assert_eq (option.show ?int.show) (option.eq ?int.eq)
+let assert_entries = assert_eq ?(list.show ?show_Entry) ?(list.eq ?eq_Entry)
+let assert_keys = assert_eq ?(list.show ?string.show) ?(list.eq ?string.eq)
+let assert_values = assert_eq ?(list.show ?int.show) ?(list.eq ?int.eq)
+let assert_opt = assert_eq ?(option.show ?int.show) ?(option.eq ?int.eq)
 
 let ord_map = map.make string.ord
 let { singleton, find, insert, to_list, keys, values, ? } = ord_map
@@ -47,4 +47,7 @@ let append_tests =
     assert_opt (find "b" test_map1) (Some 2)
         *> assert_opt (find "*" test_map2) (Some 3)
 
-run (basic_tests *> append_tests)
+let tests: Test () =
+    basic_tests *> append_tests
+
+run tests

--- a/tests/pass/map.glu
+++ b/tests/pass/map.glu
@@ -3,7 +3,7 @@ let int = import! std.int
 let option @ { Option } = import! std.option
 let string = import! std.string
 let { (<>) } = import! std.prelude
-let { Test, run, writer, assert, assert_eq, ? }  = import! std.test
+let { Test, run, writer, assert, old_assert_eq, ? }  = import! std.test
 let map @ { ? } = import! std.map
 let { Applicative, (*>) } = import! std.applicative
 let list @ { List } = import! std.list
@@ -16,10 +16,10 @@ let eq_Entry : Eq { key : String, value : Int } = {
     (==) = \l r -> l.key == r.key && l.value == r.value
 }
 
-let assert_entries = assert_eq (list.show ?show_Entry) (list.eq ?eq_Entry)
-let assert_keys = assert_eq (list.show ?string.show) (list.eq ?string.eq)
-let assert_values = assert_eq (list.show ?int.show) (list.eq ?int.eq)
-let assert_opt = assert_eq (option.show ?int.show) (option.eq ?int.eq)
+let assert_entries = old_assert_eq (list.show ?show_Entry) (list.eq ?eq_Entry)
+let assert_keys = old_assert_eq (list.show ?string.show) (list.eq ?string.eq)
+let assert_values = old_assert_eq (list.show ?int.show) (list.eq ?int.eq)
+let assert_opt = old_assert_eq (option.show ?int.show) (option.eq ?int.eq)
 
 let ord_map = map.make string.ord
 let { singleton, find, insert, to_list, keys, values, ? } = ord_map

--- a/tests/pass/match_literal.glu
+++ b/tests/pass/match_literal.glu
@@ -1,9 +1,6 @@
 let prelude = import! std.prelude
-let { run, writer, assert_eq, ? } = import! std.test
-let int = import! std.int
-let { (*>) } = import! std.applicative
-
-let assert_ieq = assert_eq int.show int.eq
+let { run, Test, assert_eq, ? } = import! std.test
+let { (*>), ? } = import! std.applicative
 
 let ints input =
     match input with
@@ -52,39 +49,39 @@ let test_m input =
     | _ -> 23
 
 let match_ns =
-    assert_ieq (ns (A 1)) 7
-        *> assert_ieq (ns (A 2)) 8
-        *> assert_ieq (ns B) 9
-        *> assert_ieq (ns (A 3)) 10
+    assert_eq (ns (A 1)) 7
+        *> assert_eq (ns (A 2)) 8
+        *> assert_eq (ns B) 9
+        *> assert_eq (ns (A 3)) 10
 
 let match_ints =
-    assert_ieq (ints 0) 1
-        *> assert_ieq (ints 1) 2
-        *> assert_ieq (ints 2) 3
-        *> assert_ieq (ints 3) 3
+    assert_eq (ints 0) 1
+        *> assert_eq (ints 1) 2
+        *> assert_eq (ints 2) 3
+        *> assert_eq (ints 3) 3
 
 let match_strings =
-    assert_ieq (strings "A") 4
-        *> assert_ieq (strings "B") 5
-        *> assert_ieq (strings "") 6
+    assert_eq (strings "A") 4
+        *> assert_eq (strings "B") 5
+        *> assert_eq (strings "") 6
 
 let match_r1 =
-    assert_ieq (r1 { x = 2 }) 11
-        *> assert_ieq (r1 { x = 3 }) 12
-        *> assert_ieq (r1 { x = 4 }) 13
+    assert_eq (r1 { x = 2 }) 11
+        *> assert_eq (r1 { x = 3 }) 12
+        *> assert_eq (r1 { x = 4 }) 13
 
 let match_r2 =
-    assert_ieq (r2 { x = 2, y = 3 }) 14
-        *> assert_ieq (r2 { x = 3, y = 4 }) 15
-        *> assert_ieq (r2 { x = 4, y = 4 }) 16
+    assert_eq (r2 { x = 2, y = 3 }) 14
+        *> assert_eq (r2 { x = 3, y = 4 }) 15
+        *> assert_eq (r2 { x = 4, y = 4 }) 16
 
 let match_test_m =
-    assert_ieq (test_m (TestM 1 "hello")) 20
-        *> assert_ieq (test_m (TestM 2 "world")) 21
-        *> assert_ieq (test_m (TestM 2 "hello")) 22
-        *> assert_ieq (test_m (TestM 3 "")) 23
+    assert_eq (test_m (TestM 1 "hello")) 20
+        *> assert_eq (test_m (TestM 2 "world")) 21
+        *> assert_eq (test_m (TestM 2 "hello")) 22
+        *> assert_eq (test_m (TestM 3 "")) 23
 
-let tests =
+let tests : Test () =
     match_ints *> match_strings *> match_ns *> match_r1 *> match_r2 *> match_test_m
 
 run tests

--- a/tests/pass/parser.glu
+++ b/tests/pass/parser.glu
@@ -1,20 +1,12 @@
 let prelude = import! std.prelude
-let char = import! std.char
-let string = import! std.string
-let result @ { Result } = import! std.result
-let { Test, run, writer, assert, assert_eq } = import! std.test
-let { Writer } = import! std.writer
-
+let result @ { Result, ? } = import! std.result
+let { Test, run, writer, assert_eq } = import! std.test
+let { ? } = import! std.char
 let { Parser, applicative, functor, alternative, monad, any, parse } = import! std.parser
-let { Applicative, (*>), wrap } = import! std.applicative
+let { Applicative, (*>), ? } = import! std.applicative
 let { (<|>) } = import! std.prelude
 
-let assert_parse show eq : Show a -> Eq a -> Result String a -> Result String a -> _ =
-    assert_eq
-        result.show
-        result.eq
-
-let tests =
-    assert_parse char.show char.eq (parse any "abc") (Ok 'a')
+let tests : Test () =
+    assert_eq (parse any "abc") (Ok 'a')
 
 run tests

--- a/tests/pass/state.glu
+++ b/tests/pass/state.glu
@@ -1,13 +1,13 @@
 let prelude = import! std.prelude
-let { Test, run, writer, assert, assert_ieq, assert_feq, assert_seq, ? } = import! std.test
+let { Test, run, writer, assert, assert_eq, ? } = import! std.test
 let int = import! std.int
 let state @ { State, put, get, modify, runState, evalState, execState, ? } = import! std.state
-let { Applicative, (*>) } = import! std.applicative
+let { Applicative, (*>), ? } = import! std.applicative
 
 let tests =
-    assert_ieq (execState (modify (\x -> x + 2) *> modify (\x -> x * 4)) 0) 8
-        *> assert_ieq (evalState (modify (\x -> x + 2) *> get) 0) 2
-        *> assert_seq (evalState (put "hello" *> get) "") "hello"
-        *> assert_seq (runState (put "hello" *> get) "").value "hello"
+    assert_eq (execState (modify (\x -> x + 2) *> modify (\x -> x * 4)) 0) 8
+        *> assert_eq (evalState (modify (\x -> x + 2) *> get) 0) 2
+        *> assert_eq (evalState (put "hello" *> get) "") "hello"
+        *> assert_eq (runState (put "hello" *> get) "").value "hello"
 
 run tests

--- a/tests/pass/stream.glu
+++ b/tests/pass/stream.glu
@@ -1,5 +1,5 @@
 let prelude = import! std.prelude
-let { run, writer, assert_eq, assert_ieq, ? } = import! std.test
+let { run, Test, assert_eq, ? } = import! std.test
 let { Applicative, (*>) } = import! std.applicative
 let int = import! std.int
 let stream @ { Stream } = import! std.stream
@@ -10,12 +10,13 @@ let s = stream.from (\i -> if i < 5 then Some i else None)
 
 let assert_leq s a : Stream Int -> Array Int -> _ =
     assert_eq
-        list.show
-        list.eq
         (stream.to_list s)
         (list.of a)
 
-assert_ieq (stream.fold (+) 0 s) 10
-    *> assert_leq s [4, 3, 2, 1, 0]
-    *> assert_leq (stream.functor.map (\x -> x + x) s) [8, 6, 4, 2, 0]
-    *> assert_leq (stream.zip_with (+) s s) [8, 6, 4, 2, 0]
+let tests : Test () =
+    assert_eq (stream.fold (+) 0 s) 10
+        *> assert_leq s [4, 3, 2, 1, 0]
+        *> assert_leq (stream.functor.map (\x -> x + x) s) [8, 6, 4, 2, 0]
+        *> assert_leq (stream.zip_with (+) s s) [8, 6, 4, 2, 0]
+
+run tests

--- a/tests/pass/string.glu
+++ b/tests/pass/string.glu
@@ -1,58 +1,54 @@
-let prelude = import! std.prelude
-let { run, writer, assert_eq, assert_seq, assert_ieq, ? } = import! std.test
-let int = import! std.int
-let { Applicative, (*>) } = import! std.applicative
+let { run, Test, assert_eq, ? } = import! std.test
+let { Applicative, (*>), ? } = import! std.applicative
 
-let bool @ { Bool, ? } = import! std.bool
-let option @ { Option, ? } = import! std.option
 let string = import! std.string
-let result @ { Result, ? } = import! std.result
-let unit @ { ? } = import! std.unit
-
-let assert_oieq : Option Int -> Option Int -> _ = assert_eq option.show option.eq
-let assert_beq : Bool -> Bool -> _ = assert_eq bool.show bool.eq
-let assert_req : Result () String -> Result () String -> _ = assert_eq result.show result.eq
+let { Result, ? } = import! std.result
+let { ? } = import! std.unit
 
 let slice_tests =
-    assert_seq (string.slice "ab" 0 1) "a" *> assert_seq (string.slice "ab" 1 2) "b"
-        *> assert_seq (string.slice "abcd" 2 4) "cd"
+    assert_eq (string.slice "ab" 0 1) "a" *> assert_eq (string.slice "ab" 1 2) "b"
+        *> assert_eq (string.slice "abcd" 2 4) "cd"
 
 let append_tests =
     let { (<>) } = import! std.prelude
-    assert_seq ("ab" <> "cd") "abcd" *> assert_seq ("ab" <> "") "ab" *> assert_seq ("" <> "cd") "cd"
-        *> assert_seq ("" <> "") ""
+    assert_eq ("ab" <> "cd") "abcd" *> assert_eq ("ab" <> "") "ab" *> assert_eq ("" <> "cd") "cd"
+        *> assert_eq ("" <> "") ""
 
 let find_tests =
-    assert_oieq (string.find "abcd1234" "ab") (Some 0)
-        *> assert_oieq (string.find "abcd1234" "b") (Some 1)
-        *> assert_oieq (string.find "abcd1234" "4") (Some 7)
-        *> assert_oieq (string.find "abcd1234" "xyz") None
-        *> assert_oieq (string.rfind "abcdabcd" "b") (Some 5)
-        *> assert_oieq (string.rfind "abcdabcd" "d") (Some 7)
-        *> assert_oieq (string.rfind "abcd1234" "xyz") None
+    assert_eq (string.find "abcd1234" "ab") (Some 0)
+        *> assert_eq (string.find "abcd1234" "b") (Some 1)
+        *> assert_eq (string.find "abcd1234" "4") (Some 7)
+        *> assert_eq (string.find "abcd1234" "xyz") None
+        *> assert_eq (string.rfind "abcdabcd" "b") (Some 5)
+        *> assert_eq (string.rfind "abcdabcd" "d") (Some 7)
+        *> assert_eq (string.rfind "abcd1234" "xyz") None
 
 let starts_ends_tests =
-    assert_beq (string.starts_with "abcd1234" "ab") True
-        *> assert_beq (string.starts_with "abcd1234" "b") False
-        *> assert_beq (string.ends_with "abcd1234" "1234") True
-        *> assert_beq (string.ends_with "abcd1234" "4") True
-        *> assert_beq (string.ends_with "abcd1234" "ab") False
+    assert_eq (string.starts_with "abcd1234" "ab") True
+        *> assert_eq (string.starts_with "abcd1234" "b") False
+        *> assert_eq (string.ends_with "abcd1234" "1234") True
+        *> assert_eq (string.ends_with "abcd1234" "4") True
+        *> assert_eq (string.ends_with "abcd1234" "ab") False
 
 let trim_tests =
-    assert_seq (string.trim "ab") "ab" *> assert_seq (string.trim " ab ") "ab"
-        *> assert_seq (string.trim "ab \t") "ab"
-        *> assert_seq (string.trim "\t ab") "ab"
-        *> assert_seq (string.trim_left " ab ") "ab "
-        *> assert_seq (string.trim_right " ab ") " ab"
+    assert_eq (string.trim "ab") "ab" *> assert_eq (string.trim " ab ") "ab"
+        *> assert_eq (string.trim "ab \t") "ab"
+        *> assert_eq (string.trim "\t ab") "ab"
+        *> assert_eq (string.trim_left " ab ") "ab "
+        *> assert_eq (string.trim_right " ab ") " ab"
 
 let from_utf8_tests =
-    assert_req (string.from_utf8 []) (Ok "") *> assert_req (string.from_utf8 [32b]) (Ok " ")
-        *> assert_req (string.from_utf8 [195b, 165b, 195b, 164b, 195b, 182b]) (Ok "åäö")
-        *> assert_req (string.from_utf8 [195b, 165b, 195b, 164b, 195b]) (Err ())
-        *> assert_req (string.from_utf8 [195b, 165b, 195b, 195b, 182b]) (Err ())
+    assert_eq (string.from_utf8 []) (Ok "") *> assert_eq (string.from_utf8 [32b]) (Ok " ")
+        *> assert_eq (string.from_utf8 [195b, 165b, 195b, 164b, 195b, 182b]) (Ok "åäö")
+        *> assert_eq (string.from_utf8 [195b, 165b, 195b, 164b, 195b]) (Err ())
+        *> assert_eq (string.from_utf8 [195b, 165b, 195b, 195b, 182b]) (Err ())
 
 let tests =
-    slice_tests *> append_tests *> find_tests
+    slice_tests 
+        *> append_tests
+        *> find_tests
+        *> starts_ends_tests
+        *> trim_tests
         *> from_utf8_tests
 
 run tests

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -1,20 +1,18 @@
-let { run, writer, old_assert_eq, ? }  = import! std.test
+let { run, Test, assert_eq, ? }  = import! std.test
 let prelude  = import! std.prelude
 let { Bool } = import! std.bool
 let int = import! std.int
-let result @ { Result } = import! std.result
+let result @ { Result, ? } = import! std.result
 let string = import! std.string
-let unit = import! std.unit
+let unit @ { ? } = import! std.unit
 let { Applicative, (*>) } = import! std.applicative
 let { flat_map } = import! std.prelude
 let { send, recv, channel } = import! std.channel
 let { spawn, yield, resume } = import! std.thread
 
-let assert =
-    old_assert_eq (result.show ?unit.show ?int.show) (result.eq ?unit.eq ?int.eq)
 let assert_any_err =
-    old_assert_eq (result.show ?string.show ?unit.show)
-              (result.eq ?{ (==) = \x y -> True } ?unit.eq)
+    assert_eq ?(result.show ?string.show ?unit.show)
+              ?(result.eq ?{ (==) = \x y -> True } ?unit.eq)
 
 let { sender, receiver } = channel 0
 
@@ -26,13 +24,13 @@ let thread = spawn (\_ ->
     )
 resume thread
 
-let tests =
-    assert (recv receiver) (Ok 0) *> (
-            do _ = assert (recv receiver) (Err ())
+let tests : Test () =
+    assert_eq (recv receiver) (Ok 0) *> (
+            do _ = assert_eq (recv receiver) (Err ())
             resume thread
-            assert (recv receiver) (Ok 1)
+            assert_eq (recv receiver) (Ok 1)
         ) *> (
-            do _ = assert (recv receiver) (Err ())
+            do _ = assert_eq (recv receiver) (Err ())
             assert_any_err (resume thread) (Err "Any error message here")
         )
 

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -1,4 +1,4 @@
-let { run, writer, assert_eq, ? }  = import! std.test
+let { run, writer, old_assert_eq, ? }  = import! std.test
 let prelude  = import! std.prelude
 let { Bool } = import! std.bool
 let int = import! std.int
@@ -11,9 +11,9 @@ let { send, recv, channel } = import! std.channel
 let { spawn, yield, resume } = import! std.thread
 
 let assert =
-    assert_eq (result.show ?unit.show ?int.show) (result.eq ?unit.eq ?int.eq)
+    old_assert_eq (result.show ?unit.show ?int.show) (result.eq ?unit.eq ?int.eq)
 let assert_any_err =
-    assert_eq (result.show ?string.show ?unit.show)
+    old_assert_eq (result.show ?string.show ?unit.show)
               (result.eq ?{ (==) = \x y -> True } ?unit.eq)
 
 let { sender, receiver } = channel 0

--- a/tests/pass/unwrap.glu
+++ b/tests/pass/unwrap.glu
@@ -1,13 +1,13 @@
 let { (|>) } = import! std.function
 let option @ { Option } = import! std.option
 let result @ { Result } = import! std.result
-let { assert_ieq }  = import! std.test
+let { assert_eq }  = import! std.test
 
 let one = Some 1 |> option.unwrap
-assert_ieq one 1
+assert_eq one 1
 
 let two = Ok 2 |> result.unwrap_ok
-assert_ieq two 2
+assert_eq two 2
 
 let three = Err 3 |> result.unwrap_err
-assert_ieq three 3
+assert_eq three 3

--- a/tests/pass/writer.glu
+++ b/tests/pass/writer.glu
@@ -1,14 +1,14 @@
 let prelude = import! std.prelude
 let list @ { ? } = import! std.list
 let { Writer, ? }  = import! std.writer
-let test @ { Test, run, writer, assert, assert_ieq, assert_feq, ? }  = import! std.test
-let { Applicative, (*>) } = import! std.applicative
+let { Test, run, assert, assert_eq, ? }  = import! std.test
+let { Applicative, (*>), ? } = import! std.applicative
 let { count } = import! std.prelude
 
 let tests =
-    assert_ieq 1 1
-        *> assert_ieq 1 2
-        *> assert_ieq 1 1
-        *> assert_feq 1.0 10.0
+    assert_eq 1 1
+        *> assert_eq 1 2
+        *> assert_eq 1 1
+        *> assert_eq 1.0 10.0
 
 assert (count tests.writer == 2)


### PR DESCRIPTION
Closes #459

Wasn't able to convert `tests/pass/alternative.glu`, `tests/pass/map.glu`, `tests/pass/thread.glu`, so still use `old_assert_eq`

@Marwes here are my observations:
- errors need more love. I see you've already created #457. For example, it wasn't clear to me that I need to add `?` to import when using `*>` from `std.applicative`
- added some types to help the compiler; in particular in `tests` definitions, but it seems that to import `Test` from `std.test` is enough