### PR TITLE
Wrap repl tests in interface.

### DIFF
--- a/repl/tests/rexpect.rs
+++ b/repl/tests/rexpect.rs
@@ -66,7 +66,6 @@ impl REPL {
 fn prompt() {
     test!({
         let mut repl = REPL::new()?;
-        repl.test(repl.prompt, None)?;
     });
 }
 

--- a/repl/tests/rexpect.rs
+++ b/repl/tests/rexpect.rs
@@ -6,30 +6,27 @@ use rexpect::spawn;
 use rexpect::session::PtySession;
 use rexpect::errors::*;
 
-macro_rules! test {
-    ($b: block) => {
-        if ::std::env::var("GLUON_PATH").is_err() {
-            ::std::env::set_var("GLUON_PATH", "..");
-        }
-
-        || -> Result<()> {
-            $b
-            Ok(())
-        }().unwrap_or_else(|err| panic!("{}", err));
-    };
-}
-
 struct REPL {
     session: PtySession,
     prompt: &'static str,
 }
 
 impl REPL {
+    fn new() -> REPL {
+        let repl = REPL::new_().unwrap_or_else(|err| panic!("{}", err));
+        repl
+    }
+
     /// Defines the command, timeout, and prompt settings.
     /// Wraps a rexpect::session::PtySession. expecting the prompt after launch.
-    fn new() -> Result<REPL> {
+    fn new_() -> Result<REPL> {
+        if ::std::env::var("GLUON_PATH").is_err() {
+            ::std::env::set_var("GLUON_PATH", "..");
+        }
+
         let command = "../target/debug/gluon -i";
         let timeout: u64 = 10_000;
+
         let prompt: &'static str = "> ";
 
         let mut session = spawn(command, Some(timeout))?;
@@ -38,10 +35,15 @@ impl REPL {
         Ok(REPL { session, prompt })
     }
 
+    fn test(&mut self, send: &str, expect: Option<&str>) {
+        self.test_(send, expect)
+            .unwrap_or_else(|err| panic!("{}", err));
+    }
+
     /// Ensures certain lines are expected to reduce race conditions.
     /// If no ouput is expected or desired to be tested, pass it an Option::None,
     /// causing rexpect to wait for the next prompt.
-    fn test(&mut self, send: &str, expect: Option<&str>) -> Result<()> {
+    fn test_(&mut self, send: &str, expect: Option<&str>) -> Result<()> {
         self.session.send_line(send)?;
         self.session.exp_string(send)?;
 
@@ -53,7 +55,11 @@ impl REPL {
         Ok(())
     }
 
-    fn quit(&mut self) -> Result<()> {
+    fn quit(&mut self) {
+        self.quit_().unwrap_or_else(|err| panic!("{}", err));
+    }
+
+    fn quit_(&mut self) -> Result<()> {
         let line: &'static str = ":q";
         self.session.send_line(line)?;
         self.session.exp_string(line)?;
@@ -64,92 +70,74 @@ impl REPL {
 
 #[test]
 fn prompt() {
-    test!({
-        let mut repl = REPL::new()?;
-    });
+    let _repl = REPL::new();
 }
 
 #[test]
 fn quit() {
-    test!({
-        let mut repl = REPL::new()?;
-        repl.quit()?;
-    });
+    let mut repl = REPL::new();
+    repl.quit();
 }
 
 #[test]
 fn hello_world() {
-    test!({
-        let mut repl = REPL::new()?;
+    let mut repl = REPL::new();
 
-        repl.test("let io = import! std.io", None)?;
-        repl.test("io.println \"Hello world\"", Some("Hello world"))?;
-    });
+    repl.test("let io = import! std.io", None);
+    repl.test("io.println \"Hello world\"", Some("Hello world"));
 }
 
 #[test]
 fn expression_types() {
-    test!({
-        let mut repl = REPL::new()?;
+    let mut repl = REPL::new();
 
-        repl.test(":t 5", Some("Int"))?;
-        // repl.test(":t 5 + 5", Some("Int -> Int"))?;
-        repl.test(":t \"gluon\"", Some("String"))?;
-    });
+    repl.test(":t 5", Some("Int"));
+    // repl.test(":t 5 + 5", Some("Int -> Int"));
+    repl.test(":t \"gluon\"", Some("String"));
 }
 
 #[test]
 fn names() {
-    test!({
-        let mut repl = REPL::new()?;
+    let mut repl = REPL::new();
 
-        repl.test(
-            ":i std.prelude.show",
-            Some("std.prelude.show: forall a . [std.prelude.Show a] -> a -> String"),
-        )?;
-    });
+    repl.test(
+        ":i std.prelude.show",
+        Some("std.prelude.show: forall a . [std.prelude.Show a] -> a -> String"),
+    );
 }
 
 #[test]
 fn comments() {
-    test!({
-        let mut repl = REPL::new()?;
+    let mut repl = REPL::new();
 
-        repl.test("1 + 2 // Calls the + function on 1 and 2", Some("3"))?;
-        repl.test("1 + 2 /* Calls the + function on 1 and 2 */", Some("3"))?;
-    });
+    repl.test("1 + 2 // Calls the + function on 1 and 2", Some("3"));
+    repl.test("1 + 2 /* Calls the + function on 1 and 2 */", Some("3"));
 }
 
 #[test]
 fn if_expressions() {
-    test!({
-        let mut repl = REPL::new()?;
+    let mut repl = REPL::new();
 
-        repl.test("if True then 1 else 0", Some("1"))?;
-        repl.test("if False then 1 else 0", Some("0"))?;
-    });
+    repl.test("if True then 1 else 0", Some("1"));
+    repl.test("if False then 1 else 0", Some("0"));
 }
 
 #[test]
 fn records() {
-    test!({
-        let mut repl = REPL::new()?;
+    let mut repl = REPL::new();
 
-        repl.test("let record = { pi = 3.14, add1 = (+) 1.0 }", None)?;
-        repl.test("record.pi", Some("3.14"))?;
+    repl.test("let record = { pi = 3.14, add1 = (+) 1.0 }", None);
+    repl.test("record.pi", Some("3.14"));
 
-        repl.test("let record_2 = {x = 1 .. record }", None)?;
-        repl.test("record_2.x", Some("1"))?;
-        repl.test("record_2.pi", Some("3.14"))?;
-    });
+    repl.test("let record_2 = {x = 1 .. record }", None);
+    repl.test("record_2.x", Some("1"));
+    repl.test("record_2.pi", Some("3.14"));
 }
 
 #[test]
 fn arrays() {
-    test!({
-        let mut repl = REPL::new()?;
+    let mut repl = REPL::new();
 
-        repl.test("let array = import! std.array", None)?;
-        repl.test("array.len [1, 2, 3]", Some("3"))?;
-    });
+    repl.test("let array = import! std.array", None);
+    repl.test("array.len [1, 2, 3]", Some("3"));
 }

--- a/repl/tests/rexpect.rs
+++ b/repl/tests/rexpect.rs
@@ -27,9 +27,9 @@ impl REPL {
         let command = "../target/debug/gluon -i";
         let timeout: u64 = 10_000;
 
-        let prompt: &'static str = "> ";
-
         let mut session = spawn(command, Some(timeout))?;
+
+        let prompt: &'static str = "> ";
         session.exp_string(prompt)?;
 
         Ok(REPL { session, prompt })

--- a/repl/tests/rexpect.rs
+++ b/repl/tests/rexpect.rs
@@ -70,7 +70,7 @@ fn prompt() {
 }
 
 #[test]
-fn exit() {
+fn quit() {
     test!({
         let mut repl = REPL::new()?;
         repl.quit()?;


### PR DESCRIPTION
A simple interface to ensure various lines are not forgetten to improve reliability of repl tests. Let's see how these fair, especially so more tests can be written!