### PR TITLE
feat: Add user specified fixity specifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,9 +560,8 @@ version = "0.7.1"
 dependencies = [
  "difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gluon 0.7.1",
  "gluon_base 0.7.1",
- "gluon_check 0.7.1",
- "gluon_parser 0.7.1",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gluon_base 0.7.1",
+ "gluon_check 0.7.1",
  "gluon_parser 0.7.1",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/base/src/error.rs
+++ b/base/src/error.rs
@@ -52,6 +52,10 @@ impl<T> Errors<T> {
     pub fn pop(&mut self) -> Option<T> {
         self.errors.pop()
     }
+
+    pub fn iter(&self) -> slice::Iter<T> {
+        self.errors.iter()
+    }
 }
 
 impl<T> Extend<T> for Errors<T> {

--- a/base/src/metadata.rs
+++ b/base/src/metadata.rs
@@ -12,6 +12,12 @@ impl<'a, T: ?Sized + MetadataEnv> MetadataEnv for &'a T {
     }
 }
 
+impl MetadataEnv for () {
+    fn get_metadata(&self, _id: &SymbolRef) -> Option<&Metadata> {
+        None
+    }
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct Metadata {

--- a/base/src/metadata.rs
+++ b/base/src/metadata.rs
@@ -33,4 +33,40 @@ impl Metadata {
         }
         self
     }
+
+    pub fn get_attribute(&self, attribute: &str) -> Option<&str> {
+        self.attributes()
+            .find(|&(name, _)| name == attribute)
+            .map(|t| t.1.unwrap_or(""))
+    }
+
+    pub fn attributes(&self) -> Attributes {
+        attributes(self.comment.as_ref().map_or("", |s| s))
+    }
+}
+
+pub struct Attributes<'a> {
+    comment: ::std::str::Lines<'a>,
+}
+
+impl<'a> Iterator for Attributes<'a> {
+    type Item = (&'a str, Option<&'a str>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(line) = self.comment.next() {
+            if line.starts_with('@') {
+                let mut split = line[1..].splitn(2, ' ');
+                if let Some(x) = split.next().map(|key| (key, split.next())) {
+                    return Some(x);
+                }
+            }
+        }
+        None
+    }
+}
+
+pub fn attributes(comment: &str) -> Attributes {
+    Attributes {
+        comment: comment.lines(),
+    }
 }

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -4,6 +4,8 @@
 
 - [Syntax and semantics](./syntax-and-semantics.md)
 
+- [Metadata](./metadata.md)
+
 - [Modules](./modules.md)
 
 - [Embedding API](./embedding-api.md)

--- a/book/src/metadata.md
+++ b/book/src/metadata.md
@@ -1,0 +1,65 @@
+# Metadata
+
+Sometimes we need a way to associate some extra information to a specific named binding and have it be visible whenever we refer to that name. The most common reason for this is documentation comments. When we write some documentation for a binding we would like this documentation to be visible whenever someone uses that binding.
+
+For this reason gluon runs a "metadata" pass on all code in which "metadata" (such as documentation comments) gets statically propagated throughout the code.
+
+```f#
+/// Adds one to the argument `x`
+let add1 x = x + 1
+
+/// Adds two to the argument `x`
+let add2 x = x + 2
+
+add1 // Looking up the metadata of this variable yields the documentation of `add1`
+
+// It can't be statically determined which branch the `if` takes (since constant folding do not
+// take place). Thus `addN` do not get any metadta from either `add1` or `add2`
+let addN = if True then add1 else add2
+addN
+```
+
+
+## Attributes
+
+In addtion to documentation comments gluon also has a special notion of attributes that get propagated in the same manner. These are specified using the following syntax.
+
+```f#
+/// @<NAME> <VALUE?>
+```
+
+### @infix
+
+```f#
+/// @infix (left|right) <NON-NEGATIVE INTEGER>
+```
+
+The `@infix` attribute is used to specified the fixity and precedence of infix operators. This lets us specify that multiplication binds tighter that addition.
+
+```f#
+/// @infix left 6
+let (+) ?num : [num a] -> a -> a -> a = num.(+)
+/// @infix left 7
+let (*) ?num : [num a] -> a -> a -> a = num.(*)
+```
+
+
+### @implicit
+
+```f#
+/// @implicit
+```
+
+The `@implicit` attribute is used to mark value bindings or type bindings as usable for implicit resolution. If specified on a value binding then only that specific binding can be used on implicit resolution. If specified on a type binding then all bindings that has that type can be used in implicit resolution.
+
+```
+// Can be used as an implicit argument
+/// @implicit
+let binding : MyType = ..
+
+/// @implicit
+type Eq a = { (==) : a -> a -> Bool }
+
+// Can be used as an implicit argument
+let eq_Int : Eq Int = ..
+```

--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -7,32 +7,6 @@ use base::metadata::{Metadata, MetadataEnv};
 use base::symbol::{Name, Symbol};
 use base::types::row_iter;
 
-pub struct AttributesIter<'a> {
-    comment: ::std::str::Lines<'a>,
-}
-
-impl<'a> Iterator for AttributesIter<'a> {
-    type Item = (&'a str, Option<&'a str>);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some(line) = self.comment.next() {
-            if line.starts_with('@') {
-                let mut split = line[1..].splitn(2, ' ');
-                if let Some(x) = split.next().map(|key| (key, split.next())) {
-                    return Some(x);
-                }
-            }
-        }
-        None
-    }
-}
-
-pub fn attributes(comment: &str) -> AttributesIter {
-    AttributesIter {
-        comment: comment.lines(),
-    }
-}
-
 struct Environment<'b> {
     env: &'b MetadataEnv,
     stack: FnvMap<Symbol, Metadata>,

--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -208,6 +208,7 @@ pub fn metadata(
                         .cloned()
                         .unwrap_or_default()
                 }
+                Expr::MacroExpansion { ref replacement, .. } => self.metadata_expr(replacement),
                 _ => {
                     ast::walk_expr(self, expr);
                     Metadata::default()

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -33,11 +33,7 @@ pub fn rename(symbols: &mut SymbolModule, expr: &mut SpannedExpr<Symbol>) {
                             Some(ref mut pat) => self.new_pattern(pat),
                             None => {
                                 let id = field.name.value.clone();
-                                let pat = Pattern::Ident(TypedIdent {
-                                    name: self.stack_var(id, pattern.span),
-                                    typ: Type::hole(),
-                                });
-                                field.value = Some(pos::spanned(field.name.span, pat));
+                                field.name.value = self.stack_var(id, pattern.span);
                             }
                         }
                     }
@@ -84,9 +80,9 @@ pub fn rename(symbols: &mut SymbolModule, expr: &mut SpannedExpr<Symbol>) {
             }
             let new_id = self.symbols.symbol(new_name);
             debug!(
-                "Rename binding `{}` = `{}`",
-                self.symbols.string(&old_id),
-                self.symbols.string(&new_id),
+                "Rename binding `{:?}` = `{:?}`",
+                (&old_id),
+                (&new_id),
             );
             self.env.stack.insert(old_id, (new_id.clone(), span));
             new_id
@@ -127,13 +123,7 @@ pub fn rename(symbols: &mut SymbolModule, expr: &mut SpannedExpr<Symbol>) {
                             Some(ref mut expr) => self.visit_expr(expr),
                             None => if let Some(new_id) = self.rename(&expr_field.name.value) {
                                 debug!("Rename record field {} = {}", expr_field.name, new_id);
-                                expr_field.value = Some(pos::spanned(
-                                    expr_field.name.span,
-                                    Expr::Ident(TypedIdent {
-                                        name: new_id,
-                                        typ: Type::hole(),
-                                    }),
-                                ));
+                                expr_field.name.value = new_id;
                             },
                         }
                     }

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -333,6 +333,7 @@ impl<'a> Typecheck<'a> {
         symbols: &'a mut Symbols,
         environment: &'a (TypecheckEnv + 'a),
         type_cache: TypeCache<Symbol, ArcType>,
+        metadata: &'a mut FnvMap<Symbol, Metadata>,
     ) -> Typecheck<'a> {
         let symbols = SymbolModule::new(module, symbols);
         let kind_cache = KindCache::new();
@@ -350,7 +351,7 @@ impl<'a> Typecheck<'a> {
             type_variables: ScopedMap::new(),
             type_cache: type_cache,
             kind_cache: kind_cache,
-            implicit_resolver: ::implicits::ImplicitResolver::new(environment),
+            implicit_resolver: ::implicits::ImplicitResolver::new(environment, metadata),
         }
     }
 
@@ -599,9 +600,6 @@ impl<'a> Typecheck<'a> {
         info!("Typechecking {}", self.symbols.module());
         self.subs.clear();
         self.environment.stack.clear();
-
-        let _ = ::rename::rename(&mut self.symbols, expr);
-        self.implicit_resolver.metadata = ::metadata::metadata(&self.environment, expr).1;
 
         let temp = expected_type.and_then(|expected| self.create_unifiable_signature(expected));
         let expected_type = temp.as_ref().or(expected_type);

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -1111,6 +1111,7 @@ impl<'a> Typecheck<'a> {
 
                 Ok(TailCall::Type(ret))
             }
+            Expr::MacroExpansion { ref mut replacement, .. } => self.typecheck_(replacement, expected_type),
             Expr::Error(ref typ) => Ok(TailCall::Type(
                 typ.clone().unwrap_or_else(|| self.subs.new_var()),
             )),

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -10,7 +10,7 @@ use base::types::{self, Alias, ArcType, Generic, PrimitiveEnv, Type, TypeCache,
 
 use check::typecheck::{self, Typecheck};
 use check::{metadata, rename};
-use parser::{parse_partial_expr, ParseErrors};
+use parser::{parse_partial_expr, reparse_infix, ParseErrors};
 
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -203,7 +203,7 @@ pub fn typecheck_partial_expr(
         &mut expr,
     );
     let (_, mut metadata) = metadata::metadata(&env, &expr);
-    parser::reparse_infix(&metadata, &interner, &mut expr).unwrap_or_else(|err| panic!("{}", err));
+    reparse_infix(&metadata, &*interner, &mut expr).unwrap_or_else(|err| panic!("{}", err));
 
     let mut tc = Typecheck::new(
         "test".into(),

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -9,6 +9,7 @@ use base::types::{self, Alias, ArcType, Generic, PrimitiveEnv, Type, TypeCache,
                   TypeEnv};
 
 use check::typecheck::{self, Typecheck};
+use check::{metadata, rename};
 use parser::{parse_partial_expr, ParseErrors};
 
 use std::cell::RefCell;
@@ -151,7 +152,20 @@ pub fn typecheck_expr_expected(
     let env = MockEnv::new();
     let interner = get_local_interner();
     let mut interner = interner.borrow_mut();
-    let mut tc = Typecheck::new("test".into(), &mut interner, &env, TypeCache::new());
+
+    rename::rename(
+        &mut SymbolModule::new("test".into(), &mut interner),
+        &mut expr,
+    );
+    let (_, mut metadata) = metadata::metadata(&env, &expr);
+
+    let mut tc = Typecheck::new(
+        "test".into(),
+        &mut interner,
+        &env,
+        TypeCache::new(),
+        &mut metadata,
+    );
 
     let result = tc.typecheck_expr_expected(&mut expr, expected);
 
@@ -183,7 +197,21 @@ pub fn typecheck_partial_expr(
     let env = MockEnv::new();
     let interner = get_local_interner();
     let mut interner = interner.borrow_mut();
-    let mut tc = Typecheck::new("test".into(), &mut interner, &env, TypeCache::new());
+
+    rename::rename(
+        &mut SymbolModule::new("test".into(), &mut interner),
+        &mut expr,
+    );
+    let (_, mut metadata) = metadata::metadata(&env, &expr);
+    parser::reparse_infix(&metadata, &interner, &mut expr).unwrap_or_else(|err| panic!("{}", err));
+
+    let mut tc = Typecheck::new(
+        "test".into(),
+        &mut interner,
+        &env,
+        TypeCache::new(),
+        &mut metadata,
+    );
 
     let result = tc.typecheck_expr(&mut expr);
 

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -650,6 +650,7 @@ where
                     _ => unreachable!(),
                 }
             }
+            Expr::MacroExpansion { ref replacement, .. } => self.visit_expr(replacement),
             Expr::Error(..) => (),
         }
     }

--- a/completion/tests/support/mod.rs
+++ b/completion/tests/support/mod.rs
@@ -7,6 +7,7 @@ use base::metadata::{Metadata, MetadataEnv};
 use base::symbol::{Symbol, SymbolModule, SymbolRef, Symbols};
 use base::types::{self, Alias, ArcType, Generic, PrimitiveEnv, Type, TypeCache, TypeEnv};
 use check::typecheck::{self, Typecheck};
+use check::{metadata, rename};
 use parser::{parse_partial_expr, ParseErrors};
 
 use std::cell::RefCell;
@@ -111,7 +112,20 @@ pub fn typecheck_expr_expected(
     let env = MockEnv::new();
     let interner = get_local_interner();
     let mut interner = interner.borrow_mut();
-    let mut tc = Typecheck::new("test".into(), &mut interner, &env, TypeCache::new());
+
+    rename::rename(
+        &mut SymbolModule::new("test".into(), &mut interner),
+        &mut expr,
+    );
+    let (_, mut metadata) = metadata::metadata(&env, &expr);
+
+    let mut tc = Typecheck::new(
+        "test".into(),
+        &mut interner,
+        &env,
+        TypeCache::new(),
+        &mut metadata,
+    );
 
     let result = tc.typecheck_expr_expected(&mut expr, expected);
 
@@ -141,7 +155,21 @@ pub fn typecheck_partial_expr(
     let env = MockEnv::new();
     let interner = get_local_interner();
     let mut interner = interner.borrow_mut();
-    let mut tc = Typecheck::new("test".into(), &mut interner, &env, TypeCache::new());
+
+    rename::rename(
+        &mut SymbolModule::new("test".into(), &mut interner),
+        &mut expr,
+    );
+    let (_, mut metadata) = metadata::metadata(&env, &expr);
+    parser::reparse_infix(&metadata, &interner, &mut expr).unwrap_or_else(|err| panic!("{}", err));
+
+    let mut tc = Typecheck::new(
+        "test".into(),
+        &mut interner,
+        &env,
+        TypeCache::new(),
+        &mut metadata,
+    );
 
     let result = tc.typecheck_expr(&mut expr);
 

--- a/completion/tests/support/mod.rs
+++ b/completion/tests/support/mod.rs
@@ -8,7 +8,7 @@ use base::symbol::{Symbol, SymbolModule, SymbolRef, Symbols};
 use base::types::{self, Alias, ArcType, Generic, PrimitiveEnv, Type, TypeCache, TypeEnv};
 use check::typecheck::{self, Typecheck};
 use check::{metadata, rename};
-use parser::{parse_partial_expr, ParseErrors};
+use parser::{parse_partial_expr, reparse_infix, ParseErrors};
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -161,7 +161,7 @@ pub fn typecheck_partial_expr(
         &mut expr,
     );
     let (_, mut metadata) = metadata::metadata(&env, &expr);
-    parser::reparse_infix(&metadata, &interner, &mut expr).unwrap_or_else(|err| panic!("{}", err));
+    reparse_infix(&metadata, &*interner, &mut expr).unwrap_or_else(|err| panic!("{}", err));
 
     let mut tc = Typecheck::new(
         "test".into(),

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.7.0"
 
 gluon_base = { path = "../base", version = "0.7.1" } # GLUON
 gluon_parser = { path = "../parser", version = "0.7.1" } # GLUON
+gluon_check = { path = "../check", version = "0.7.1" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.5.0"

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -16,8 +16,7 @@ pretty = "0.3.2"
 itertools = "0.7.0"
 
 gluon_base = { path = "../base", version = "0.7.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.7.1" } # GLUON
-gluon_check = { path = "../check", version = "0.7.1" } # GLUON
+gluon = { path = "..", version = "0.7.1" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.5.0"

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -3,16 +3,27 @@
 
 #[macro_use]
 extern crate gluon_base as base;
-extern crate gluon_parser as parser;
+extern crate gluon;
 extern crate itertools;
 extern crate pretty;
 
-use base::ast::SpannedExpr;
+use gluon::{Compiler, Error, Thread, Result};
+use gluon::compiler_pipeline::*;
+
+use base::ast::{self, SpannedExpr};
+use base::pos::UNKNOWN_EXPANSION;
 use base::source::Source;
-use base::symbol::{Symbol, Symbols};
-use base::types::TypeCache;
+use base::symbol::Symbol;
 
 mod pretty_print;
+
+fn has_format_disabling_errors(file: &str, err: &Error) -> bool {
+    match *err {
+        Error::Multiple(ref errors) => errors.iter().any(|err| has_format_disabling_errors(file, err)),
+        Error::Parse(ref err) => err.source_name == file,
+        _ => false,
+    }
+}
 
 pub fn pretty_expr(input: &str, expr: &SpannedExpr<Symbol>) -> String {
     let newline = match input.find(|c: char| c == '\n' || c == '\r') {
@@ -34,18 +45,26 @@ pub fn pretty_expr(input: &str, expr: &SpannedExpr<Symbol>) -> String {
     printer.format(100, newline, &expr)
 }
 
-pub fn format_expr(input: &str) -> Result<String, parser::ParseErrors> {
-    let type_cache = TypeCache::new();
-    let mut symbols = Symbols::new();
+pub fn format_expr(compiler: &mut Compiler, thread: &Thread, file: &str, input: &str) -> Result<String> {
+    let expr = match input.reparse_infix(compiler, thread, file, input) {
+        Ok(expr) => expr.expr,
+        Err((Some(expr), err)) => {
+            if has_format_disabling_errors(file, &err) {
+                return Err(err);
+            }
+            expr.expr
+        }
+        Err((None, err)) => return Err(err),
+    };
 
-    let expr = parser::parse_expr(&mut symbols, &type_cache, input)?;
+    fn skip_implicit_prelude(l: &SpannedExpr<Symbol>) -> &SpannedExpr<Symbol> {
+        match l.value {
+            ast::Expr::LetBindings(_, ref e) if l.span.expansion_id == UNKNOWN_EXPANSION => {
+                skip_implicit_prelude(e)
+            }
+            _ => l,
+        }
+    }
 
-    rename::rename(
-        &mut SymbolModule::new("test".into(), &mut symbols),
-        &mut expr,
-    );
-    let (_, mut metadata) = metadata::metadata(&env, &expr);
-    parser::reparse_infix(&metadata, &symbols, &mut expr)?;
-
-    Ok(pretty_expr(input, &expr))
+    Ok(pretty_expr(input, skip_implicit_prelude(&expr)))
 }

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -36,7 +36,16 @@ pub fn pretty_expr(input: &str, expr: &SpannedExpr<Symbol>) -> String {
 
 pub fn format_expr(input: &str) -> Result<String, parser::ParseErrors> {
     let type_cache = TypeCache::new();
-    let expr = parser::parse_expr(&mut Symbols::new(), &type_cache, input)?;
+    let mut symbols = Symbols::new();
+
+    let expr = parser::parse_expr(&mut symbols, &type_cache, input)?;
+
+    rename::rename(
+        &mut SymbolModule::new("test".into(), &mut symbols),
+        &mut expr,
+    );
+    let (_, mut metadata) = metadata::metadata(&env, &expr);
+    parser::reparse_infix(&metadata, &symbols, &mut expr)?;
 
     Ok(pretty_expr(input, &expr))
 }

--- a/format/src/pretty_print.rs
+++ b/format/src/pretty_print.rs
@@ -30,14 +30,18 @@ macro_rules! rev_newlines_iter {
     }
 }
 
-pub(super) struct Printer<'a: 'e, 'e, I: 'a>(pretty_types::Printer<'a, 'e, I>);
+pub(super) struct Printer<'a: 'e, 'e, I: 'a> {
+    printer: pretty_types::Printer<'a, 'e, I>,
+}
 
 impl<'a: 'e, 'e, I> Printer<'a, 'e, I>
 where
     I: AsRef<str>,
 {
     pub(super) fn new(arena: &'a Arena<'a>, source: &'e source::Source<'a>) -> Self {
-        Printer(pretty_types::Printer::new(arena, source))
+        Printer {
+            printer: pretty_types::Printer::new(arena, source),
+        }
     }
 
     pub(super) fn format(
@@ -46,6 +50,7 @@ where
         newline: &'a str,
         expr: &'a SpannedExpr<I>,
     ) -> String {
+
         self.pretty_expr(expr)
             .1
             .pretty(width)
@@ -320,6 +325,7 @@ where
                         ].group(),
                         self.pretty_expr_(bound.span.end, body)
                     ],
+            Expr::MacroExpansion { ref original, .. } => return self.pretty_expr_(previous_end, original),
             Expr::Error(_) => arena.text("<error>"),
         };
         comments.append(doc)
@@ -717,7 +723,7 @@ impl<'a: 'e, 'e, I> ops::Deref for Printer<'a, 'e, I> {
     type Target = pretty_types::Printer<'a, 'e, I>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.printer
     }
 }
 

--- a/parser/src/infix.rs
+++ b/parser/src/infix.rs
@@ -9,6 +9,7 @@ use base::pos::{self, BytePos, Spanned};
 use std::cmp::Ordering;
 use std::error::Error as StdError;
 use std::fmt;
+use std::hash::Hash;
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::Index;
@@ -68,28 +69,31 @@ impl fmt::Display for OpMeta {
 }
 
 /// A table of operator metadata
-pub struct OpTable {
-    pub operators: FnvMap<String, OpMeta>,
+pub struct OpTable<Id> {
+    pub operators: FnvMap<Id, OpMeta>,
     pub default_meta: OpMeta,
 }
 
-impl OpTable {
-    fn new<I>(ops: I) -> OpTable
+impl<Id> OpTable<Id> {
+    pub fn new<I>(ops: I) -> OpTable<Id>
     where
-        I: IntoIterator<Item = (&'static str, OpMeta)>,
+        I: IntoIterator<Item = (Id, OpMeta)>,
+        Id: Eq + Hash,
     {
         OpTable {
-            operators: ops.into_iter()
-                .map(|(name, op)| (name.to_string(), op))
-                .collect(),
+            operators: ops.into_iter().collect(),
             default_meta: OpMeta::new(9, Fixity::Left),
         }
     }
 }
 
-impl Default for OpTable {
-    fn default() -> OpTable {
-        OpTable::new(vec![
+impl<Id> Default for OpTable<Id>
+where
+    Id: Eq + Hash,
+{
+    fn default() -> Self {
+        OpTable::new(vec![])
+        /*
             ("*", OpMeta::new(7, Fixity::Left)),
             ("/", OpMeta::new(7, Fixity::Left)),
             ("%", OpMeta::new(7, Fixity::Left)),
@@ -111,18 +115,119 @@ impl Default for OpTable {
             (">>", OpMeta::new(9, Fixity::Left)),
             ("<|", OpMeta::new(0, Fixity::Right)),
             ("|>", OpMeta::new(0, Fixity::Left)),
-        ])
+        ]*/
     }
 }
 
-impl<'a> Index<&'a str> for OpTable {
+impl<'a, Id> Index<&'a Id> for OpTable<Id>
+where
+    Id: Eq + Hash + AsRef<str>,
+{
     type Output = OpMeta;
 
-    fn index(&self, name: &'a str) -> &OpMeta {
+    fn index(&self, name: &'a Id) -> &OpMeta {
         self.operators.get(name).unwrap_or_else(|| {
-            if name.starts_with('#') {
-                &self[name[1..].trim_left_matches(char::is_alphanumeric)]
+            let name = name.as_ref();
+            if name.starts_with('#') || name == "&&" || name == "||" {
+                const OPS: &[(&str, OpMeta)] = &[
+                    (
+                        "*",
+                        OpMeta {
+                            precedence: 7,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "/",
+                        OpMeta {
+                            precedence: 7,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "+",
+                        OpMeta {
+                            precedence: 6,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "-",
+                        OpMeta {
+                            precedence: 6,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "==",
+                        OpMeta {
+                            precedence: 4,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "/=",
+                        OpMeta {
+                            precedence: 4,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "<",
+                        OpMeta {
+                            precedence: 4,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        ">",
+                        OpMeta {
+                            precedence: 4,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "<=",
+                        OpMeta {
+                            precedence: 4,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        ">=",
+                        OpMeta {
+                            precedence: 4,
+                            fixity: Fixity::Left,
+                        },
+                    ),
+                    (
+                        "&&",
+                        OpMeta {
+                            precedence: 3,
+                            fixity: Fixity::Right,
+                        },
+                    ),
+                    (
+                        "||",
+                        OpMeta {
+                            precedence: 2,
+                            fixity: Fixity::Right,
+                        },
+                    ),
+                ];
+
+                let op = name.trim_left_matches('#')
+                    .trim_left_matches(char::is_alphanumeric);
+
+                OPS.iter()
+                    .find(|t| t.0 == op)
+                    .map(|t| &t.1)
+                    .unwrap_or_else(|| {
+                        error!("Infix default: {}", name);
+                        &self.default_meta
+                    })
             } else {
+                error!("Infix default: {}", name);
                 &self.default_meta
             }
         })
@@ -130,14 +235,14 @@ impl<'a> Index<&'a str> for OpTable {
 }
 
 pub struct Reparser<'s, Id: 's> {
-    operators: OpTable,
+    operators: OpTable<Id>,
     symbols: &'s IdentEnv<Ident = Id>,
     errors: Errors<Spanned<Error, BytePos>>,
     _marker: PhantomData<Id>,
 }
 
 impl<'s, Id> Reparser<'s, Id> {
-    pub fn new(operators: OpTable, symbols: &'s IdentEnv<Ident = Id>) -> Reparser<'s, Id> {
+    pub fn new(operators: OpTable<Id>, symbols: &'s IdentEnv<Ident = Id>) -> Reparser<'s, Id> {
         Reparser {
             operators: operators,
             symbols: symbols,
@@ -149,7 +254,10 @@ impl<'s, Id> Reparser<'s, Id> {
     pub fn reparse(
         &mut self,
         expr: &mut SpannedExpr<Id>,
-    ) -> Result<(), Errors<Spanned<Error, BytePos>>> {
+    ) -> Result<(), Errors<Spanned<Error, BytePos>>>
+    where
+        Id: Eq + Hash + AsRef<str>,
+    {
         self.visit_expr(expr);
         if self.errors.has_errors() {
             Err(mem::replace(&mut self.errors, Errors::new()))
@@ -161,7 +269,7 @@ impl<'s, Id> Reparser<'s, Id> {
 
 impl<'a, 's, Id> MutVisitor<'a> for Reparser<'s, Id>
 where
-    Id: 'a,
+    Id: Eq + Hash + AsRef<str> + 'a,
 {
     type Ident = Id;
 
@@ -187,6 +295,8 @@ where
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
     ConflictingFixities((String, OpMeta), (String, OpMeta)),
+    InvalidFixity,
+    InvalidPrecedence,
 }
 
 impl fmt::Display for Error {
@@ -202,6 +312,11 @@ impl fmt::Display for Error {
                     lhs_meta, lhs_name, rhs_meta, rhs_name
                 )
             }
+            InvalidFixity => write!(
+                f,
+                "Only `left` or `right` is valid associativity specifications"
+            ),
+            InvalidPrecedence => write!(f, "Only positive integers are valid precedences"),
         }
     }
 }
@@ -221,8 +336,11 @@ impl StdError for Error {
 pub fn reparse<Id>(
     expr: SpannedExpr<Id>,
     symbols: &IdentEnv<Ident = Id>,
-    operators: &OpTable,
-) -> Result<SpannedExpr<Id>, Spanned<Error, BytePos>> {
+    operators: &OpTable<Id>,
+) -> Result<SpannedExpr<Id>, Spanned<Error, BytePos>>
+where
+    Id: Eq + Hash + AsRef<str>,
+{
     use self::Error::*;
     use base::pos;
 
@@ -255,8 +373,8 @@ pub fn reparse<Id>(
                     }
                 };
 
-                let next_op_meta = operators[symbols.string(&next_op.value.name)];
-                let stack_op_meta = operators[symbols.string(&stack_op.value.name)];
+                let next_op_meta = operators[&next_op.value.name];
+                let stack_op_meta = operators[&stack_op.value.name];
 
                 match i32::cmp(&next_op_meta.precedence, &stack_op_meta.precedence) {
                     // Reduce
@@ -494,8 +612,8 @@ mod tests {
     fn reparse_less_precedence() {
         let env = MockEnv::new();
         let ops = OpTable::new(vec![
-            ("*", OpMeta::new(7, Fixity::Left)),
-            ("+", OpMeta::new(6, Fixity::Left)),
+            ("*".to_string(), OpMeta::new(7, Fixity::Left)),
+            ("+".to_string(), OpMeta::new(6, Fixity::Left)),
         ]);
 
         // 1 + (2 * 8)
@@ -509,8 +627,8 @@ mod tests {
     fn reparse_greater_precedence() {
         let env = MockEnv::new();
         let ops = OpTable::new(vec![
-            ("*", OpMeta::new(7, Fixity::Left)),
-            ("+", OpMeta::new(6, Fixity::Left)),
+            ("*".to_string(), OpMeta::new(7, Fixity::Left)),
+            ("+".to_string(), OpMeta::new(6, Fixity::Left)),
         ]);
 
         // 1 * (2 + 8)
@@ -525,8 +643,8 @@ mod tests {
     fn reparse_equal_precedence_left_fixity() {
         let env = MockEnv::new();
         let ops = OpTable::new(vec![
-            ("-", OpMeta::new(6, Fixity::Left)),
-            ("+", OpMeta::new(6, Fixity::Left)),
+            ("-".to_string(), OpMeta::new(6, Fixity::Left)),
+            ("+".to_string(), OpMeta::new(6, Fixity::Left)),
         ]);
 
         // 1 + (2 - 8)
@@ -541,8 +659,8 @@ mod tests {
     fn reparse_equal_precedence_right_fixity() {
         let env = MockEnv::new();
         let ops = OpTable::new(vec![
-            ("-", OpMeta::new(6, Fixity::Right)),
-            ("+", OpMeta::new(6, Fixity::Right)),
+            ("-".to_string(), OpMeta::new(6, Fixity::Right)),
+            ("+".to_string(), OpMeta::new(6, Fixity::Right)),
         ]);
 
         // 1 + (2 - 8)
@@ -556,9 +674,9 @@ mod tests {
     fn reparse_mixed_precedences_mixed_fixities() {
         let env = MockEnv::new();
         let ops = OpTable::new(vec![
-            ("*", OpMeta::new(7, Fixity::Left)),
-            ("-", OpMeta::new(6, Fixity::Left)),
-            ("+", OpMeta::new(6, Fixity::Left)),
+            ("*".to_string(), OpMeta::new(7, Fixity::Left)),
+            ("-".to_string(), OpMeta::new(6, Fixity::Left)),
+            ("+".to_string(), OpMeta::new(6, Fixity::Left)),
         ]);
 
         //  1  + (2  * (6   -  8))
@@ -573,8 +691,8 @@ mod tests {
     fn reparse_equal_precedence_conflicting_fixities() {
         let env = MockEnv::new();
         let ops = OpTable::new(vec![
-            ("|>", OpMeta::new(5, Fixity::Left)),
-            ("<|", OpMeta::new(5, Fixity::Right)),
+            ("|>".to_string(), OpMeta::new(5, Fixity::Left)),
+            ("<|".to_string(), OpMeta::new(5, Fixity::Right)),
         ]);
 
         // 1 |> (2 <| 8)
@@ -592,8 +710,8 @@ mod tests {
     fn reparse_equal_precedence_conflicting_fixities_nested() {
         let env = MockEnv::new();
         let ops = OpTable::new(vec![
-            ("|>", OpMeta::new(5, Fixity::Left)),
-            ("<|", OpMeta::new(5, Fixity::Right)),
+            ("|>".to_string(), OpMeta::new(5, Fixity::Left)),
+            ("<|".to_string(), OpMeta::new(5, Fixity::Right)),
         ]);
 
         // 1 + (1 |> (2 <| 8))

--- a/parser/src/layout.rs
+++ b/parser/src/layout.rs
@@ -185,7 +185,7 @@ where
                 })
                 .map(|last_offside| last_offside.location.column)
             {
-                Some(last_column) if span.start.column <= last_column => {
+                | Some(last_column) if span.start.column <= last_column => {
                     debug!(
                         "Inserting empty block due to {:?} <= {:?}",
                         self.indent_levels.last(),

--- a/parser/src/layout.rs
+++ b/parser/src/layout.rs
@@ -185,7 +185,7 @@ where
                 })
                 .map(|last_offside| last_offside.location.column)
             {
-                | Some(last_column) if span.start.column <= last_column => {
+                Some(last_column) if span.start.column <= last_column => {
                     debug!(
                         "Inserting empty block due to {:?} <= {:?}",
                         self.indent_levels.last(),

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -16,17 +16,21 @@ extern crate quick_error;
 
 use std::cell::RefCell;
 use std::fmt;
+use std::hash::Hash;
 
 use base::ast::{Comment, Do, Expr, IdentEnv, SpannedExpr, SpannedPattern, TypedIdent, ValueBinding};
 use base::error::Errors;
+use base::fnv::FnvMap;
+use base::metadata::Metadata;
 use base::pos::{self, BytePos, Span, Spanned};
 use base::symbol::Symbol;
 use base::types::{ArcType, TypeCache};
 
+use infix::{Fixity, OpMeta, OpTable, Reparser};
 use layout::Layout;
 use token::{Token, Tokenizer};
 
-pub use infix::{Error as InfixError, OpTable, Reparser};
+pub use infix::Error as InfixError;
 pub use layout::Error as LayoutError;
 pub use token::Error as TokenizeError;
 
@@ -348,7 +352,7 @@ pub fn parse_partial_let_or_expr<Id>(
     input: &str,
 ) -> Result<LetOrExpr<Id>, (Option<LetOrExpr<Id>>, ParseErrors)>
 where
-    Id: Clone,
+    Id: Clone + Eq + Hash + AsRef<str>,
 {
     let result_ok_iter;
     let layout = layout!(result_ok_iter, input);
@@ -404,4 +408,60 @@ pub fn parse_string<'env, 'input>(
     input: &'input str,
 ) -> Result<SpannedExpr<String>, (Option<SpannedExpr<String>>, ParseErrors)> {
     parse_partial_expr(symbols, &TypeCache::new(), input)
+}
+
+pub fn reparse_infix<Id>(
+    metadata: &FnvMap<Id, Metadata>,
+    symbols: &IdentEnv<Ident = Id>,
+    expr: &mut SpannedExpr<Id>,
+) -> Result<(), ParseErrors>
+where
+    Id: Clone + Eq + Hash + AsRef<str>,
+{
+    let mut errors = Errors::new();
+    let op_table = OpTable::new(metadata.iter().filter_map(|(symbol, meta)| {
+        fn parse_infix(s: &str) -> Result<OpMeta, InfixError> {
+            let mut iter = s.splitn(2, " ");
+            let fixity = match iter.next().ok_or(InfixError::InvalidFixity)? {
+                "left" => Fixity::Left,
+                "right" => Fixity::Right,
+                _ => {
+                    return Err(InfixError::InvalidFixity);
+                }
+            };
+            let precedence = iter.next()
+                .and_then(|s| s.parse().ok())
+                .and_then(|precedence| {
+                    if precedence >= 0 {
+                        Some(precedence)
+                    } else {
+                        None
+                    }
+                })
+                .ok_or(InfixError::InvalidPrecedence)?;
+            Ok(OpMeta { fixity, precedence })
+        }
+        meta.get_attribute("infix")
+            .and_then(|s| match parse_infix(s) {
+                Ok(op_meta) => Some((symbol.clone(), op_meta)),
+                Err(err) => {
+                    errors.push(pos::spanned(Default::default(), err));
+                    None
+                }
+            })
+    }));
+
+    let mut reparser = Reparser::new(op_table, symbols);
+    match reparser.reparse(expr) {
+        Err(reparse_errors) => {
+            errors.extend(reparse_errors);
+        }
+        Ok(_) => {}
+    }
+
+    if errors.has_errors() {
+        Err(errors.into_iter().map(|err| err.map(Error::from)).collect())
+    } else {
+        Ok(())
+    }
 }

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -16,9 +16,9 @@ let { (<<) } = import! std.function
 let { Applicative, wrap, (*>) } = import! std.applicative
 let { flat_map, (>>=) } = import! std.monad
 
-let { append = (++) } = string.semigroup
 let ord_map @ { singleton, find, insert, ? } = map.make string.ord
 let { (<>) } = import! std.prelude
+let (++) = (<>)
 let { empty } = ord_map.monoid
 
 
@@ -80,26 +80,26 @@ let make_commands cpu_pool : CpuPool -> Commands =
             info = "Prints the type with an expression",
             action =
                 \arg ->
-                repl_prim.type_of_expr arg >>= print_result
+                (repl_prim.type_of_expr arg >>= print_result)
                     *> wrap Continue,
         },
         {
             name = "info",
             alias = "i",
             info = "Prints information about the given name",
-            action = \arg -> repl_prim.find_info arg >>= print_result *> wrap Continue,
+            action = \arg -> (repl_prim.find_info arg >>= print_result) *> wrap Continue,
         },
         {
             name = "kind",
             alias = "k",
             info = "Prints the kind with the given type",
-            action = \arg -> repl_prim.find_kind arg >>= print_result *> wrap Continue,
+            action = \arg -> (repl_prim.find_kind arg >>= print_result) *> wrap Continue,
         },
         {
             name = "load",
             alias = "l",
             info = "Loads the file at \'folder/module.ext\' and stores it at \'module\'",
-            action = \arg -> load_file cpu_pool arg >>= io.println *> wrap Continue,
+            action = \arg -> (load_file cpu_pool arg >>= io.println) *> wrap Continue,
         },
         {
             name = "script",
@@ -181,7 +181,7 @@ let loop repl : Repl -> IO () =
                 do eval_thread = thread.new_thread ()
                 let eval_action = repl_prim.eval_line line
                 repl_prim.finish_or_interrupt repl.cpu_pool eval_thread eval_action
-            io.catch action wrap >>= io.println
+            (io.catch action wrap >>= io.println)
                 *> wrap Continue
 
     do line_result = rustyline.readline repl.editor "> "

--- a/repl/tests/basic.rs
+++ b/repl/tests/basic.rs
@@ -19,6 +19,7 @@ fn fmt_repl() {
 
     let status = Command::new("../target/debug/gluon")
         .args(&["fmt", source])
+        .env("GLUON_PATH", "..")
         .spawn()
         .expect("Could not find gluon executable")
         .wait()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,10 @@ impl Compiler {
             &mut SymbolModule::new(file.into(), &mut self.symbols),
             type_cache,
             expr_str,
-        ).map_err(|(expr, err)| (expr, InFile::new(file, expr_str, err)))?)
+        ).map_err(|(expr, err)| {
+            info!("Parse error: {}", err);
+            (expr, InFile::new(file, expr_str, err))
+        })?)
     }
 
     /// Parse and typecheck `expr_str` returning the typechecked expression and type of the
@@ -288,6 +291,7 @@ impl Compiler {
             expr,
             typ: vm.global_env().type_cache().hole(),
             metadata: Default::default(),
+            metadata_map: Default::default(),
         }.compile(self, vm, filename, expr_str, ())
             .map(|result| result.module)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ impl Compiler {
         expr_str: &str,
         expected_type: Option<&ArcType>,
     ) -> Result<(SpannedExpr<Symbol>, ArcType)> {
-        let TypecheckValue { expr, typ } =
+        let TypecheckValue { expr, typ, .. } =
             expr_str.typecheck_expected(self, vm, file, expr_str, expected_type)?;
         Ok((expr, typ))
     }
@@ -285,8 +285,9 @@ impl Compiler {
         expr: &SpannedExpr<Symbol>,
     ) -> Result<CompiledModule> {
         TypecheckValue {
-            expr: expr,
+            expr,
             typ: vm.global_env().type_cache().hole(),
+            metadata: Default::default(),
         }.compile(self, vm, filename, expr_str, ())
             .map(|result| result.module)
     }

--- a/std/applicative.glu
+++ b/std/applicative.glu
@@ -27,8 +27,11 @@ type Applicative (f : Type -> Type) = {
 
 let wrap ?app : [Applicative f] -> a -> f a = app.wrap
 let apply ?app : [Applicative f] -> f (a -> b) -> f a -> f b = app.apply
+/// @infix left 4
 let (<*>) ?app : [Applicative f] -> f (a -> b) -> f a -> f b = app.apply
+/// @infix left 4
 let (<*) ?app l r : [Applicative f] -> f a -> f b -> f a = app.functor.map (\x _ -> x) l <*> r
+/// @infix left 4
 let (*>) ?app l r : [Applicative f] -> f a -> f b -> f b = app.functor.map (\_ x -> x) l <*> r
 
 let map2 ?app f a b : [Applicative f] -> (a -> b -> c)
@@ -48,6 +51,7 @@ type Alternative f = {
 
 let empty ?alt : [Alternative f] -> f a = alt.empty
 let or ?alt : [Alternative f] -> f a -> f a -> f a = alt.or
+/// @infix left 3
 let (<|>) ?alt : [Alternative f] -> f a -> f a -> f a = alt.or
 
 

--- a/std/cmp.glu
+++ b/std/cmp.glu
@@ -6,31 +6,37 @@ let { Bool, Ordering } = import! std.types
 /// @implicit
 type Eq a = { (==) : a -> a -> Bool }
 
+/// @infix left 4
 let (==) ?eq : [Eq a] -> a -> a -> Bool = eq.(==)
+/// @infix left 4
 let (/=) ?eq l r : [Eq a] -> a -> a -> Bool = if (eq.(==) l r) then False else True
 
 /// `Ord a` defines an ordering on `a`
 /// @implicit
 type Ord a = { eq : Eq a, compare : a -> a -> Ordering }
 
+/// @infix left 4
 let (<=) ?ord l r : [Ord a] -> a -> a -> Bool =
     match ord.compare l r with
     | LT -> True
     | EQ -> True
     | GT -> False
 
+/// @infix left 4
 let (<) ?ord l r : [Ord a] -> a -> a -> Bool =
     match ord.compare l r with
     | LT -> True
     | EQ -> False
     | GT -> False
 
+/// @infix left 4
 let (>) ?ord l r : [Ord a] -> a -> a -> Bool =
     match ord.compare l r with
     | LT -> False
     | EQ -> False
     | GT -> True
 
+/// @infix left 4
 let (>=) ?ord l r : [Ord a] -> a -> a -> Bool =
     match ord.compare l r with
     | LT -> False

--- a/std/function.glu
+++ b/std/function.glu
@@ -41,15 +41,19 @@ let const : a -> b -> a = applicative.wrap
 let flip f x y : (a -> b -> c) -> b -> a -> c = f y x
 
 /// Backward function application, where `f <| x == f x`
+/// @infix right 0
 let (<|) f x : (a -> b) -> a -> b = f x
 
 /// Forward function application, where `x |> f == f x`
+/// @infix left 0
 let (|>) x f : a -> (a -> b) -> b = f x
 
 /// Right-to-left function composition
+/// @infix right 9
 let (<<) : (b -> c) -> (a -> b) -> a -> c = category.compose
 
 /// Left-to-right function composition
+/// @infix left 9
 let (>>) : (a -> b) -> (b -> c) -> a -> c = flip category.compose
 
 {

--- a/std/list.glu
+++ b/std/list.glu
@@ -3,8 +3,8 @@ let { Semigroup, Monoid, Eq, Show } = prelude
 let { Functor, Applicative, Alternative, Monad, Traversable } = prelude
 let { Foldable } = import! std.foldable
 let { Bool } = import! std.bool
-let string @ { ? } = import! std.string
 let array @ { ? } = import! std.array
+let { (<>) } = import! std.semigroup
 
 let { map } = import! std.functor
 let { (<*>), wrap } = import! std.applicative
@@ -36,20 +36,18 @@ let semigroup : Semigroup (List a) =
 
     { append }
 
-let { (<>) } = import! std.prelude
-
 let monoid : Monoid (List a) = {
     semigroup = semigroup,
     empty = Nil,
 }
 
 let eq ?eq : [Eq a] -> Eq (List a) =
-    let (==) l r =
+    let list_eq l r =
         match (l, r) with
         | (Nil, Nil) -> True
-        | (Cons x xs, Cons y ys) -> eq.(==) x y && xs == ys
+        | (Cons x xs, Cons y ys) -> eq.(==) x y && list_eq xs ys
         | _ -> False
-    { (==) }
+    { (==) = list_eq }
 
 let functor : Functor List =
     let map f xs =
@@ -101,7 +99,6 @@ let monad : Monad List =
     { applicative = applicative, flat_map }
 
 let show ?d : [Show a] -> Show (List a) =
-    let (++) = string.semigroup.append
 
     {
         show = \xs ->
@@ -109,11 +106,11 @@ let show ?d : [Show a] -> Show (List a) =
                 match ys with
                 | Cons y ys2 ->
                     match ys2 with
-                    | Cons z zs -> d.show y ++ ", " ++ show_elems ys2
+                    | Cons z zs -> d.show y <> ", " <> show_elems ys2
                     | Nil -> d.show y
                 | Nil -> ""
 
-            "[" ++ show_elems xs ++ "]",
+            "[" <> show_elems xs <> "]",
     }
 
 let foldable : Foldable List =

--- a/std/monad.glu
+++ b/std/monad.glu
@@ -36,7 +36,9 @@ type Monad (m : Type -> Type) = {
 }
 
 let flat_map ?m : [Monad m] -> (a -> m b) -> m a -> m b = m.flat_map
+/// @infix right 1
 let (=<<) ?m : [Monad m] -> (a -> m b) -> m a -> m b = m.flat_map
+/// @infix left 1
 let (>>=) ?m x f : [Monad m] -> m a -> (a -> m b) -> m b = m.flat_map f x
 
 let join ?m mm : [Monad m] -> m (m a) -> m a = mm >>= (\x -> x)

--- a/std/option.glu
+++ b/std/option.glu
@@ -7,8 +7,10 @@ let { Functor, Monad, Traversable } = prelude
 let { Applicative, Alternative } = import! std.applicative
 let { Bool } = import! std.bool
 let { Option } = import! std.types
-let string = import! std.string
+let string @ { ? } = import! std.string
 let { Foldable } = import! std.foldable
+let { (<>) } = import! std.semigroup
+
 
 let unwrap opt : Option a -> a =
     match opt with
@@ -112,11 +114,9 @@ let monad : Monad Option = {
 }
 
 let show ?d : [Show a] -> Show (Option a) =
-    let (++) = string.append
-
     let show o =
         match o with
-        | Some x -> "Some (" ++ d.show x ++ ")"
+        | Some x -> "Some (" <> d.show x <> ")"
         | None -> "None"
 
     { show }

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -44,9 +44,13 @@ type Num a = {
     negate : a -> a
 }
 
+/// @infix left 6
 let (+) ?num : [Num a] -> a -> a -> a = num.(+)
+/// @infix left 6
 let (-) ?num : [Num a] -> a -> a -> a = num.(-)
+/// @infix left 7
 let (*) ?num : [Num a] -> a -> a -> a = num.(*)
+/// @infix left 7
 let (/) ?num : [Num a] -> a -> a -> a = num.(/)
 
 /// @implicit

--- a/std/result.glu
+++ b/std/result.glu
@@ -5,6 +5,7 @@ let { Result } = import! std.types
 let { Foldable } = import! std.foldable
 let { Bool } = import! std.bool
 let string = import! std.string
+let { (<>) } = import! std.semigroup
 
 let unwrap_ok res : Result e a -> a =
     match res with
@@ -80,12 +81,10 @@ let traversable : Traversable (Result e) = {
 }
 
 let show ?e ?t : [Show e] -> [Show t] -> Show (Result e t) =
-    let (++) = string.append
-
     let show o =
         match o with
-        | Ok x -> "Ok (" ++ t.show x ++ ")"
-        | Err x -> "Err (" ++ e.show x ++ ")"
+        | Ok x -> "Ok (" <> t.show x <> ")"
+        | Err x -> "Err (" <> e.show x <> ")"
 
     { show }
 

--- a/std/semigroup.glu
+++ b/std/semigroup.glu
@@ -13,6 +13,7 @@ type Semigroup a = {
 }
 
 let append ?s : [Semigroup a] -> a -> a -> a = s.append
+/// @infix left 4
 let (<>) ?s : [Semigroup a] -> a -> a -> a = s.append
 
 {

--- a/std/test.glu
+++ b/std/test.glu
@@ -1,5 +1,4 @@
 let string = import! std.string
-let { append = (++) } = string.semigroup
 let writer @ { Writer, ? } = import! std.writer
 let prelude @ { Semigroup } = import! std.prelude
 let float = import! std.float
@@ -7,6 +6,8 @@ let int = import! std.int
 let list @ { List, ? } = import! std.list
 let { Foldable, foldl } = import! std.foldable
 let { Option } = import! std.option
+let { (<>) } = import! std.semigroup
+
 
 type Test a = Writer (List String) a
 type TestCase a = | Test String (() -> Test a) | Group String (Array (TestCase a))
@@ -21,11 +22,11 @@ let assert x = if x then () else error "Assertion failed"
 let assert_eq l r : [Show a] -> [Eq a] -> a -> a -> Test () =
     if l == r
     then testWriter.applicative.wrap ()
-    else writer.tell (Cons ("Assertion failed: " ++ show l ++ " != " ++ show r) Nil)
+    else writer.tell (Cons ("Assertion failed: " <> show l <> " != " <> show r) Nil)
 
 let run test : Test a -> () =
     match test.writer with
-    | Cons _ _ -> error (foldl (\acc err -> acc ++ "\n" ++ err) "" test.writer)
+    | Cons _ _ -> error (foldl (\acc err -> acc <> "\n" <> err) "" test.writer)
     | Nil -> ()
 
 {

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -205,7 +205,7 @@ fn spawn_on_runexpr_in_catch() {
             do a = thread.spawn_on eval_thread f
             do result = a
             wrap result.value
-        io.catch action wrap >>= io.println *> wrap "123"
+        (io.catch action wrap >>= io.println) *> wrap "123"
     "#;
 
     let mut core = self::tokio_core::reactor::Core::new().unwrap();

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -39,6 +39,7 @@ in f(22)
 
 test_expr!{ add_operator,
 r"
+/// @infix left 6
 let (+) = \x y -> x #Int+ y in 1 + 2 + 3
 ",
 6i32
@@ -486,6 +487,8 @@ test_expr!{ prelude implicit_argument_selection2,
 r#"
 let string = import! std.string
 let { append = (++) } = string.semigroup
+/// @infix left 6
+let (++) = (++)
 
 let equality l r : [Eq a] -> a -> a -> String =
     if l == r then " == " else " != "

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -743,6 +743,7 @@ impl<'a, 'e> Translator<'a, 'e> {
                     ),
                 )
             }
+            ast::Expr::MacroExpansion { ref replacement, .. } => self.translate_(replacement),
             ast::Expr::Error(_) => ice!("ICE: Error expression found in the compiler"),
         }
     }


### PR DESCRIPTION
This is mostly there already but is softblocked on formatting now needing information from imported modules. Either it needs to depend on `gluon` to get the normal compiler pipeline and import semantics, or these parts need to be moved into `gluon_base` (see https://github.com/gluon-lang/gluon/issues/349).

Fixes #3