### PR TITLE
docs: Add an example on how to marshall map types

### DIFF
--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -2090,3 +2090,19 @@ impl<'vm, T: VmType> Pushable<'vm> for TypedBytecode<T> {
         Ok(())
     }
 }
+
+
+pub struct Map<K, V>(PhantomData<(K, V)>);
+
+impl<K: VmType, V: VmType> VmType for Map<K, V> where K::Type: Sized, V::Type: Sized {
+    type Type = Map<K::Type, V::Type>;
+
+    fn make_type(vm: &Thread) -> ArcType {
+        let map_alias = vm.find_type_info("std.map.Map")
+            .unwrap()
+            .clone()
+            .into_type();
+        Type::app(map_alias, collect![K::make_type(vm), V::make_type(vm)])
+    }
+}
+

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1762,10 +1762,15 @@ impl<'b> ExecuteContext<'b> {
                     let field = function.strings[i as usize];
                     match self.stack.pop().get_repr() {
                         Data(data) => {
-                            let v = data.get_field(field).expect("ICE: Field does not exist");
+                            let v = data.get_field(field).unwrap_or_else(|| {
+                                error!("{}", self.stack.stack.stacktrace(0));
+                                ice!("Field does not exist")
+                            });
                             self.stack.push(v);
                         }
-                        x => return Err(Error::Message(format!("GetField on {:?}", x))),
+                        x => {
+                            return Err(Error::Message(format!("GetField on {:?}", x)));
+                        }
                     }
                 }
                 TestTag(tag) => {


### PR DESCRIPTION
This is a rather hacky solution as it needs to go through the
`Array/slice` marshalling. Ideally we should be able to serialize maps
through from Rust into any `Map`-like type on gluon's side automatically
but that requires the Rust -> Gluon FFI to understand implicits.