### PR TITLE
perf(check): Partition the implicit bindings to reduce the search space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rpds 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rpds 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "union-find 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "rpds"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2066,7 +2066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rexpect 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9f223820adfca83e60e8b577346a0f7122e313eade41d46794766d953029a9c"
-"checksum rpds 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "428720c0fe5ca53b63d4cad25c3920b52e69ae634cd07fc7c0ea7e78626f81b9"
+"checksum rpds 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d41235ae795ad106da2c4f3dbdd09537062b14a15ee4754d4c9f4eeb69b4ad8b"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
 "checksum rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00b06ac9c8e8e3e83b33d175d39a9f7b6c2c930c82990593719c8e48788ae2d9"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -17,7 +17,7 @@ itertools = "0.7.0"
 union-find = "0.3.1"
 pretty = "0.3.0"
 smallvec = "0.2.1"
-rpds = "0.3"
+rpds = "0.5"
 
 codespan = "0.1"
 codespan-reporting = "0.1"

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -1708,31 +1708,10 @@ impl<'a> Typecheck<'a> {
             }
 
             // Update the implicit bindings with the generalized types we just created
-            let mut bindings = self.implicit_resolver
-                .implicit_bindings
-                .last()
-                .unwrap()
-                .clone();
-            for i in 0..bindings.len() {
-                let opt = {
-                    let bind = bindings.get(i).unwrap();
-                    if bind.0.len() == 1 {
-                        let typ = self.environment
-                            .stack
-                            .get(&bind.0[0].name)
-                            .unwrap()
-                            .typ
-                            .clone();
-                        Some((bind.0.clone(), typ))
-                    } else {
-                        None
-                    }
-                };
-                if let Some(new) = opt {
-                    bindings = bindings.set(i, new).unwrap();
-                }
-            }
-            *self.implicit_resolver.implicit_bindings.last_mut().unwrap() = bindings;
+            let bindings = self.implicit_resolver.implicit_bindings.last_mut().unwrap();
+
+            let stack = &self.environment.stack;
+            bindings.update(|name| Some(stack.get(name).unwrap().typ.clone()));
         }
 
         debug!("Typecheck `in`");

--- a/check/tests/implicits.rs
+++ b/check/tests/implicits.rs
@@ -33,7 +33,7 @@ f 42
 "#;
     let (expr, result) = support::typecheck_expr(text);
 
-    assert_eq!(result, Ok(Type::int()));
+    assert_req!(result, Ok(Type::int()));
 
     // Verify that the insert implicit argument have the renamed symbol
     match expr.value {

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -828,7 +828,6 @@ fn expected_type_do_not_override_actual_type_for_returned_type_array() {
     assert_req!(result.map(|t| t.to_string()), Ok("Array Int"));
 }
 
-
 #[test]
 fn dont_guess_record_type() {
     let _ = env_logger::try_init();
@@ -859,5 +858,8 @@ a
 "#;
     let result = support::typecheck(text);
 
-    assert_req!(result.map(|t| t.to_string()), Ok("Array { f : String -> String }"));
+    assert_req!(
+        result.map(|t| t.to_string()),
+        Ok("Array { f : String -> String }")
+    );
 }


### PR DESCRIPTION
Cuts the time of `cargo test --features test --test main` in about half.

This might cause some implicit bindings to fail to resolve if it the implicit type is hidden behind an alias, however that is not a huge problem + once type sealing gets added that will be semantically closer to this behaviour as well (but the issue with aliases should still be fixed).