### PR TITLE
Fix derive Getable for tuple structs

### DIFF
--- a/codegen/src/getable.rs
+++ b/codegen/src/getable.rs
@@ -90,7 +90,7 @@ fn gen_impl(ident: Ident, generics: Generics, cons_expr: TokenStream) -> TokenSt
 
     quote! {
         #[automatically_derived]
-        #[allow(unused_attributes)]
+        #[allow(unused_attributes, unused_variables)]
         impl #impl_generics ::gluon::vm::api::Getable<'__vm> for #ident #ty_generics
         #where_clause #(#getable_bounds,)* #(#lifetime_bounds),*
         {

--- a/codegen/src/getable.rs
+++ b/codegen/src/getable.rs
@@ -23,14 +23,22 @@ pub fn derive(input: TokenStream) -> TokenStream {
 }
 
 fn derive_struct(ast: DataStruct, ident: Ident, generics: Generics) -> TokenStream {
-    let fields = match ast.fields {
-        Fields::Named(FieldsNamed { named, .. }) => named,
-        _ => panic!("Struct fields always have names"),
+    let cons = match ast.fields {
+        Fields::Named(FieldsNamed { named, .. }) => gen_struct_cons(&ident, named),
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => gen_tuple_struct_cons(&ident, unnamed),
+        Fields::Unit => quote! { #ident },
     };
 
+    gen_impl(ident, generics, cons)
+}
+
+fn gen_struct_cons<I>(ident: &Ident, fields: I) -> TokenStream
+where
+    I: IntoIterator<Item = Field>,
+{
     // lookup each field by its name and then convert to its type using the Getable
     // impl of the fields type
-    let field_initializers = fields.iter().map(|field| {
+    let field_initializers = fields.into_iter().map(|field| {
         let field_ty = &field.ty;
         let ident = field
             .ident
@@ -47,13 +55,35 @@ fn derive_struct(ast: DataStruct, ident: Ident, generics: Generics) -> TokenStre
         }
     });
 
-    let cons = quote! {
+    quote! {
         #ident {
             #(#field_initializers,)*
         }
-    };
+    }
+}
 
-    gen_impl(ident, generics, cons)
+fn gen_tuple_struct_cons<I>(ident: &Ident, fields: I) -> TokenStream
+where
+    I: IntoIterator<Item = Field>,
+{
+    // do the lookup using the tag, because tuple structs don't have field names
+    let field_initializers = fields.into_iter().enumerate().map(|(tag, field)| {
+        let field_ty = &field.ty;
+
+        quote! {
+            if let Some(val) = data.get_variant(#tag) {
+                <#field_ty as ::gluon::vm::api::Getable<'__vm>>::from_value(vm, val)
+            } else {
+                panic!("Cannot find the field with tag '{}'. Do the type definitions match?", #tag);
+            }
+        }
+    });
+
+    quote! {
+        #ident (
+            #(#field_initializers,)*
+        )
+    }
 }
 
 fn derive_enum(ast: DataEnum, ident: Ident, generics: Generics) -> TokenStream {
@@ -119,14 +149,14 @@ fn gen_variant_match(ident: &Ident, tag: usize, variant: &Variant) -> TokenStrea
         // of the field to get the content from Data::get_variant;
         // the data variable was assigned in the function body above
         Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => {
-            let cons = gen_tuple_cons(unnamed);
+            let cons = gen_tuple_variant_cons(unnamed);
 
             quote! {
                 #tag => #ident::#variant_ident#cons
             }
         }
         Fields::Named(FieldsNamed { named, .. }) => {
-            let cons = gen_struct_cons(named);
+            let cons = gen_struct_variant_cons(named);
 
             quote! {
                 #tag => #ident::#variant_ident#cons
@@ -135,7 +165,7 @@ fn gen_variant_match(ident: &Ident, tag: usize, variant: &Variant) -> TokenStrea
     }
 }
 
-fn gen_tuple_cons<'a, I>(fields: I) -> TokenStream
+fn gen_tuple_variant_cons<'a, I>(fields: I) -> TokenStream
 where
     I: IntoIterator<Item = &'a Field>,
 {
@@ -156,7 +186,7 @@ where
     }
 }
 
-fn gen_struct_cons<'a, I>(fields: I) -> TokenStream
+fn gen_struct_variant_cons<'a, I>(fields: I) -> TokenStream
 where
     I: IntoIterator<Item = &'a Field>,
 {

--- a/codegen/src/pushable.rs
+++ b/codegen/src/pushable.rs
@@ -79,7 +79,7 @@ fn gen_impl(ident: &Ident, generics: Generics, push_impl: TokenStream) -> TokenS
 
     quote! {
         #[automatically_derived]
-        #[allow(unused_attributes)]
+        #[allow(unused_attributes, unused_variables)]
         impl #impl_generics ::gluon::vm::api::Pushable<'__vm> for #ident #ty_generics
         #where_clause #(#pushable_bounds),*
         {

--- a/codegen/src/userdata.rs
+++ b/codegen/src/userdata.rs
@@ -28,13 +28,19 @@ fn gen_impl(ident: Ident, generics: Generics) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = split_for_impl(&generics, &[]);
 
     quote! {
+        #[automatically_derived]
+        #[allow(unused_attributes, unused_variables)]
         impl #impl_generics ::gluon::vm::api::Userdata for #ident #ty_generics
         #where_clause #(#trait_bounds,)* #(#lifetime_bounds),*
         {
         }
 
+        #[automatically_derived]
+        #[allow(unused_attributes, unused_variables)]
         impl #impl_generics ::gluon::vm::gc::Traverseable for #ident #ty_generics {}
-
+        
+        #[automatically_derived]
+        #[allow(unused_attributes, unused_variables)]
         impl #impl_generics ::gluon::vm::api::VmType for #ident #ty_generics
         #where_clause #(#trait_bounds,)* #(#lifetime_bounds),*
         {

--- a/codegen/src/vm_type.rs
+++ b/codegen/src/vm_type.rs
@@ -78,6 +78,8 @@ fn gen_impl(ident: Ident, generics: Generics, gluon_type: &str) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = split_for_impl(&generics, &[]);
 
     quote! {
+        #[automatically_derived]
+        #[allow(unused_attributes, unused_variables)]
         impl #impl_generics ::gluon::vm::api::VmType for #ident #ty_generics
         #where_clause #(#trait_bounds,)* #(#lifetime_bounds),*
         {


### PR DESCRIPTION
When using the new derive macros, I noticed that tuple structs caused panics when deriving `Getable`, because that branch was not implemented. This fixes the problem and also adds `#[allow(unused_variables)]` to the generated code (occurs when using C-style enums, that do not use the `vm` parameter).