### PR TITLE
fix(repl): Don't panic on solo array literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ before_deploy:
 - >
     if [[ $CURRENT_TAG != "" ]]; then
         export GIT_HASH=$(git rev-parse HEAD)
-        travis_wait sh scripts/before_deploy.sh
+        sh scripts/before_deploy.sh
     fi
 deploy:
   - provider: pages

--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -916,8 +916,8 @@ impl<'a> Typecheck<'a> {
             Expr::Array(ref mut array) => {
                 let mut expected_element_type = self.subs.new_var();
 
+                array.typ = self.type_cache.array(expected_element_type.clone());
                 if let Some(expected_type) = expected_type.take() {
-                    array.typ = self.type_cache.array(expected_element_type.clone());
                     self.unify_span(expr.span, &expected_type, array.typ.clone());
                 }
 

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -919,3 +919,16 @@ Test ""
 
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
+
+#[test]
+fn array_expr_gets_type_assigned_without_expected_type_issue_555() {
+    let _ = env_logger::try_init();
+
+    let text = r#"
+[1]
+"#;
+    let (expr, result) = support::typecheck_expr(text);
+
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+    assert_eq!(expr.env_type_of(&MockEnv::new()).to_string(), "Array Int");
+}


### PR DESCRIPTION
As the repl invokes the typechecker without an expected type any array
in the tail expression would not get a type assigned to them.

Fixes #555