### PR TITLE
Document required serialization feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,9 +152,11 @@ name = "ui"
 name = "24"
 [[example]]
 name = "marshalling"
+required-features = ["serialization"]
 [[example]]
 name = "http"
 path = "examples/http/main.rs"
+required-features = ["serialization"]
 [[example]]
 name = "lisp"
 path = "examples/lisp/main.rs"

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -1,4 +1,6 @@
 //! Gluon -> Rust value conversion via the `serde::Deserialize` trait
+//! 
+//! _This module requires Gluon to be built with the `serde` feature._
 
 use std::cell::RefCell;
 use std::fmt;

--- a/vm/src/api/ser.rs
+++ b/vm/src/api/ser.rs
@@ -1,4 +1,6 @@
 //! Rust -> Gluon value conversion via the `serde::Serialize` trait
+//! 
+//! _This module requires Gluon to be built with the `serde` feature._
 
 use std::fmt;
 use std::ops::{Deref, DerefMut};

--- a/vm/src/api/typ.rs
+++ b/vm/src/api/typ.rs
@@ -1,4 +1,6 @@
 //! Rust type to gluon type conversion
+//! 
+//! _This module requires Gluon to be built with the `serde` feature._
 
 use base::symbol::{Symbol, Symbols};
 use base::types::{ArcType, Field, Type, TypeCache};


### PR DESCRIPTION
This makes clear which modules and examples require the `serialization` or `serde` feature flags, fixing non-obvious build errors (see #573). 

Closes #573