### PR TITLE
chore: Disable tests for tagged build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
     # Run benchmark and a no-default-features check in a separate
   - rust: stable
     env:
-      - DEPLOY=1
       - NO_NORMAL_TEST=1
       - BENCH_DEFAULT_FEATURES_CHECK=1
       - TARGET=x86_64-unknown-linux-gnu
@@ -70,7 +69,9 @@ env:
     - RUST_BACKTRACE=1
 script:
 - >
-    if [ ! -z $DISABLE_TESTS ]; then
+    if [ ! -z $TRAVIS_TAG ]; then
+        echo "Disabling tests for tagged builds as they timeout otherwise"
+    elif [ ! -z $DISABLE_TESTS ]; then
         return
     elif [[ -z ${WASM+set} ]]; then
         ./scripts/travis.sh
@@ -78,7 +79,7 @@ script:
         rustup target add wasm32-unknown-unknown
         cargo check --target wasm32-unknown-unknown -p gluon_c-api
     fi
-- (cd book && mdbook build)
+- mdbook build book
 
 notifications:
   webhooks:


### PR DESCRIPTION
If we run tests and build release artifacts we run into travis's 50
minutes timeout. So instead we only build release artifacts and trust
that they have already been run on the branch build