### PR TITLE
feat: Add seq expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ do digits =
     wrap [a, b, c, d]
 
 let print_digits = for digits (\d ->
-        do _ = io.print " "
+        do io.print " "
         io.print (show d))
-do _ = io.print "Four digits:" *> print_digits *> io.println ""
+do io.print "Four digits:" *> print_digits *> io.println ""
 
 let guess_loop _ =
     do line = io.read_line

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ do digits =
     wrap [a, b, c, d]
 
 let print_digits = for digits (\d ->
-        do io.print " "
+        seq io.print " "
         io.print (show d))
-do io.print "Four digits:" *> print_digits *> io.println ""
+seq io.print "Four digits:" *> print_digits *> io.println ""
 
 let guess_loop _ =
     do line = io.read_line

--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -274,7 +274,7 @@ pub struct ExprField<Id, E> {
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Do<Id> {
-    pub id: SpannedIdent<Id>,
+    pub id: Option<SpannedPattern<Id>>,
     pub bound: Box<SpannedExpr<Id>>,
     pub body: Box<SpannedExpr<Id>>,
     pub flat_map_id: Option<Box<SpannedExpr<Id>>>,
@@ -685,7 +685,9 @@ pub fn walk_expr<'a, V: ?Sized + $trait_name<'a>>(v: &mut V, e: &'a $($mut)* Spa
             ref $($mut)* body,
             ref $($mut)* flat_map_id,
         }) => {
-            v.visit_spanned_typed_ident(id);
+            if let Some(id) = id {
+                v.visit_pattern(id);
+            }
             v.visit_expr(bound);
             v.visit_expr(body);
             if let Some(ref $($mut)* flat_map_id) = *flat_map_id {

--- a/book/src/syntax-and-semantics.md
+++ b/book/src/syntax-and-semantics.md
@@ -323,6 +323,21 @@ flat_map (\x -> Some (x + 2)) (Some 1)
 
 do x = Some 1
 Some (x + 2)
+
+// The binding can also be a (irrefutable) pattern
+do { y } = Some { y = "" }
+Some y
+```
+
+### Seq expressions
+
+`seq` expressions work just like `do` expressions, only they do not have a binding.
+
+```f#,rust
+let io @ { ? } = import! std.io
+seq io.print "Hello"
+seq io.print " "
+io.println "world!"
 ```
 
 ### Indentation

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -744,6 +744,21 @@ test (x #Int+ 2)
     assert_req!(result.map(support::close_record), expected);
 }
 
+test_check! {
+do_expression_bind_scope,
+r#"
+type Test a = { x : a }
+let flat_map f x : (a -> Test b) -> Test a -> Test b = f x.x
+let test x : a -> Test a = { x }
+
+let f y : () -> Test Int =
+    do y = test 1
+    test (y #Int+ 2)
+f
+"#,
+"() -> test.Test Int"
+}
+
 #[test]
 fn eq_unresolved_constraint_bug() {
     let _ = env_logger::try_init();

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -678,18 +678,16 @@ where
                 }
             }
             Expr::Do(ref do_expr) => {
-                let iter = once(Either::Left(&do_expr.id))
+                let iter = do_expr
+                    .id
+                    .as_ref()
+                    .map(Either::Left)
+                    .into_iter()
                     .chain(once(Either::Right(&do_expr.bound)))
                     .chain(once(Either::Right(&do_expr.body)));
                 match self.select_spanned(iter, |x| x.either(|i| i.span, |e| e.span)) {
                     (_, Some(either)) => match either {
-                        Either::Left(ident) => {
-                            self.found = MatchState::Found(Match::Ident(
-                                ident.span,
-                                &ident.value.name,
-                                ident.value.typ.clone(),
-                            ));
-                        }
+                        Either::Left(ident) => self.visit_pattern(ident),
                         Either::Right(expr) => self.visit_expr(expr),
                     },
                     _ => unreachable!(),

--- a/examples/24.glu
+++ b/examples/24.glu
@@ -135,9 +135,9 @@ do digits =
     wrap [a, b, c, d]
 
 let print_digits = for digits (\d ->
-        do _ = io.print " "
+        do io.print " "
         io.print (show d))
-do _ = io.print "Four digits:" *> print_digits *> io.println ""
+do io.print "Four digits:" *> print_digits *> io.println ""
 
 let guess_loop _ =
     do line = io.read_line

--- a/examples/24.glu
+++ b/examples/24.glu
@@ -135,9 +135,9 @@ do digits =
     wrap [a, b, c, d]
 
 let print_digits = for digits (\d ->
-        do io.print " "
+        seq io.print " "
         io.print (show d))
-do io.print "Four digits:" *> print_digits *> io.println ""
+seq io.print "Four digits:" *> print_digits *> io.println ""
 
 let guess_loop _ =
     do line = io.read_line

--- a/examples/http/server.glu
+++ b/examples/http/server.glu
@@ -60,17 +60,17 @@ let sum : Eff (HttpEffect r) Response =
     do body = get_request >>= array_body
     match string.from_utf8 body with
     | Err _ ->
-        do _ = write_response (string.as_bytes "Request contained invalid UTF-8")
+        seq write_response (string.as_bytes "Request contained invalid UTF-8")
         wrap { status = status.bad_request, .. http.response }
     | Ok string_body ->
         match de.deserialize de.deserializer string_body with
         | Ok int_array ->
             let int_array : Array Int = int_array
             let s = foldl (+) 0 int_array 
-            do _ = write_response (string.as_bytes (show s))
+            do write_response (string.as_bytes (show s))
             wrap { status = status.ok, .. http.response }
         | Err err ->
-            do _ = write_response (string.as_bytes err)
+            seq write_response (string.as_bytes err)
             wrap { status = status.bad_request, .. http.response }
 
 

--- a/examples/http/server.glu
+++ b/examples/http/server.glu
@@ -67,7 +67,7 @@ let sum : Eff (HttpEffect r) Response =
         | Ok int_array ->
             let int_array : Array Int = int_array
             let s = foldl (+) 0 int_array 
-            do write_response (string.as_bytes (show s))
+            seq write_response (string.as_bytes (show s))
             wrap { status = status.ok, .. http.response }
         | Err err ->
             seq write_response (string.as_bytes err)

--- a/examples/lisp/lisp.glu
+++ b/examples/lisp/lisp.glu
@@ -73,7 +73,7 @@ let { fold_m } = import! std.foldable
 let scope_state run : Eff (LispEffect r) a -> Eff (LispEffect r) a =
     do original = get
     do x = run
-    do _ = put original
+    seq put original
     wrap x
 
 let primitive name f : String -> _ -> Map String Expr = std_map.singleton name (Primitive f)
@@ -112,7 +112,7 @@ let define xs =
     | Cons (Atom name) (Cons value Nil) ->
         do state = get
         let new_state = std_map.insert name value state
-        do _ = put new_state
+        seq put new_state
         wrap value
     | Cons (List (Cons (Atom name) params)) body ->
         do closure = get
@@ -125,7 +125,7 @@ let define xs =
                 }
         let new_state = std_map.insert name function closure
 
-        do _ = put new_state
+        seq put new_state
 
         wrap function
     | _ -> throw "Unexpected parameters to define `define`"
@@ -141,7 +141,7 @@ let apply f xs : forall r . Expr -> List Expr -> Eff (LispEffect r) Expr =
     let add_args names values : List String -> _ =
         match (names, values) with
         | (Cons name names, Cons value values) ->
-            do _ = modify (\state -> std_map.insert name value state)
+            seq modify (\state -> std_map.insert name value state)
             add_args names values
         | (Nil, _) -> wrap ()
         | _ -> throw "Not enough arguments to function"
@@ -150,7 +150,7 @@ let apply f xs : forall r . Expr -> List Expr -> Eff (LispEffect r) Expr =
     | Primitive primitive -> primitive xs
     | Function function ->
         scope_state (
-            do _ = add_args function.params xs
+            seq add_args function.params xs
             eval_exprs function.body)
     | _ -> throw ("Can\'t call value: " <> show f)
 

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -198,7 +198,7 @@ fn marshal_generic() -> Result<()> {
         let either: forall r . Either String r = Left "hello rust!"
 
         // we can pass the generic Either to the Rust function without an issue
-        do 
+        seq 
             match flip either with
             | Left _ -> error "unreachable!"
             | Right val -> io.println ("Right is: " <> val)

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -198,7 +198,7 @@ fn marshal_generic() -> Result<()> {
         let either: forall r . Either String r = Left "hello rust!"
 
         // we can pass the generic Either to the Rust function without an issue
-        do _ = 
+        do 
             match flip either with
             | Left _ -> error "unreachable!"
             | Right val -> io.println ("Right is: " <> val)

--- a/format/src/pretty_print.rs
+++ b/format/src/pretty_print.rs
@@ -473,11 +473,16 @@ where
                 ..
             }) => chain![arena;
                 chain![arena;
-                    "do",
-                    self.space_before(id.span.start()),
-                    id.value.name.as_ref(),
-                    self.space_after(id.span.end()),
-                    "=",
+                    match id {
+                        Some(pattern) => chain![arena;
+                            "do",
+                            self.space_before(pattern.span.start()),
+                            self.pretty_pattern(pattern),
+                            self.space_after(pattern.span.end()),
+                            "="
+                        ],
+                        None => arena.text("seq"),
+                    },
                     self.hang(arena.nil(), bound).group()
                 ].group(),
                 self.pretty_expr_(bound.span.end(), body)

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -2,7 +2,7 @@ use crate::itertools::{Either, Itertools};
 
 use crate::base::{
     ast::{Alternative, Argument, Array, AstType, Do, Expr, ExprField, Lambda, Literal, Pattern,
-    PatternField, SpannedExpr, SpannedIdent, TypeBinding, TypedIdent, ValueBinding, ValueBindings},
+    PatternField, SpannedExpr, SpannedIdent, SpannedPattern, TypeBinding, TypedIdent, ValueBinding, ValueBindings},
     kind::{ArcKind, Kind},
     pos::{self, BytePos, Spanned},
     types::{Alias, AliasData, ArcType, ArgType, BuiltinType, Field, Generic, Type, TypeCache},
@@ -42,6 +42,7 @@ extern {
         "in" => Token::In,
         "let" => Token::Let,
         "do" => Token::Do,
+        "seq" => Token::Seq,
         "match" => Token::Match,
         "then" => Token::Then,
         "type" => Token::Type,
@@ -753,8 +754,12 @@ Expr: Expr<Id> = {
         Expr::TypeBindings(bindings, Box::new(body))
     },
 
-    "do" <id: SpannedIdent> "=" <bound: SpExpr> <body: InExpr> => {
-        Expr::Do(Do { id, bound: Box::new(bound), body: Box::new(body), flat_map_id: None })
+    "do" <bind: DoBinding> <body: InExpr> => {
+        Expr::Do(Do { id: Some(bind.0), bound: Box::new(bind.1), body: Box::new(body), flat_map_id: None })
+    },
+
+    "seq" <bound: SpExpr> <body: InExpr> => {
+        Expr::Do(Do { id: None, bound: Box::new(bound), body: Box::new(body), flat_map_id: None })
     },
 
     BlockExpr,
@@ -763,6 +768,10 @@ Expr: Expr<Id> = {
         errors.push(<>.error);
         Expr::Error(None)
     }
+};
+
+DoBinding: (SpannedPattern<Id>, SpannedExpr<Id>) = {
+    <id: Sp<Pattern>> "=" <bound: SpExpr> => (id, bound),
 };
 
 BlockExpr: Expr<Id> = {

--- a/parser/src/layout.rs
+++ b/parser/src/layout.rs
@@ -500,7 +500,7 @@ where
                 Token::Rec => Some(Context::Rec),
                 Token::Type => Some(Context::Type),
                 Token::Let => Some(Context::Let),
-                Token::Do => Some(Context::Let),
+                Token::Do | Token::Seq => Some(Context::Let),
                 Token::If => Some(Context::If),
                 Token::Match => Some(Context::Expr),
                 Token::Lambda => Some(Context::Lambda),

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -28,6 +28,7 @@ pub enum Token<'input> {
     In,
     Let,
     Do,
+    Seq,
     Match,
     Then,
     Type,
@@ -82,6 +83,7 @@ impl<'input> fmt::Display for Token<'input> {
             In => "In",
             Let => "Let",
             Do => "Do",
+            Seq => "Seq",
             Match => "Match",
             Then => "Then",
             Type => "Type",
@@ -497,7 +499,7 @@ impl<'input> Tokenizer<'input> {
                 let (end, float) = self.take_while(start, is_digit);
                 match self.lookahead {
                     Some((_, ch)) if is_ident_start(ch) => {
-                        return self.error(end, UnexpectedChar(ch))
+                        return self.error(end, UnexpectedChar(ch));
                     }
                     _ => (start, end, Token::FloatLiteral(float.parse().unwrap())),
                 }
@@ -509,7 +511,7 @@ impl<'input> Tokenizer<'input> {
                 match int {
                     "0" | "-0" => match self.lookahead {
                         Some((_, ch)) if is_ident_start(ch) => {
-                            return self.error(end, UnexpectedChar(ch))
+                            return self.error(end, UnexpectedChar(ch));
                         }
                         _ => {
                             if hex.is_empty() {
@@ -530,7 +532,7 @@ impl<'input> Tokenizer<'input> {
                 let end = self.next_loc();
                 match self.lookahead {
                     Some((pos, ch)) if is_ident_start(ch) => {
-                        return self.error(pos, UnexpectedChar(ch))
+                        return self.error(pos, UnexpectedChar(ch));
                     }
                     _ => {
                         if let Ok(val) = int.parse() {
@@ -574,6 +576,7 @@ impl<'input> Tokenizer<'input> {
             "in" => Token::In,
             "let" => Token::Let,
             "do" => Token::Do,
+            "seq" => Token::Seq,
             "match" => Token::Match,
             "then" => Token::Then,
             "type" => Token::Type,

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -821,7 +821,7 @@ fn do_in_parens() {
     let _ = ::env_logger::try_init();
     let text = r"
         scope_state (
-            do _ = add_args
+            seq add_args
             eval_exprs
         )
     ";

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -209,7 +209,7 @@ let cmd_parser : Parser { cmd : String, arg : String } =
     let word = recognize (skip_many1 letter)
     let arg_parser = recognize (skip_many1 any)
 
-    do _ = token ':'
+    seq token ':'
     do cmd = word
     do arg = (spaces *> arg_parser) <|> wrap ""
     wrap { cmd, arg }
@@ -251,11 +251,11 @@ let loop _ : () -> Eff (ReplEffect r) () =
         match continue with
         | Continue -> loop ()
         | Quit ->
-            do _ = lift <| rustyline.save_history repl.editor
+            seq lift <| rustyline.save_history repl.editor
             wrap ()
 
 let run settings : Settings -> IO () =
-    do _ = io.println "gluon (:h for help, :q to quit)"
+    seq io.println "gluon (:h for help, :q to quit)"
     do editor = rustyline.new_editor ()
     do cpu_pool = repl_prim.new_cpu_pool 1
     let repl = { commands, editor, cpu_pool }

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -207,7 +207,7 @@ let skip_many p : Parser a -> Parser () =
     skip_many1 p <|> wrap ()
 /// Parses with `p` one or more times, ignoring the result of the parser
 let skip_many1 p : Parser a -> Parser () =
-    do _ = p
+    seq p
     skip_many p
 in
 /// Parses one of the characters of `s`

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -79,7 +79,7 @@ fn write_and_flush_file() {
     assert_eq!(content, vec![1, 2, 3, 4]);
 }
 
-test_expr!{ no_io_eval,
+test_expr! { no_io_eval,
 r#"
 let { error } = import! std.prim
 let io = import! std.io
@@ -171,7 +171,8 @@ fn spawn_on_twice() {
             Compiler::new()
                 .run_io(true)
                 .run_expr_async::<IO<String>>(&vm, "<top>", text),
-        ).unwrap_or_else(|err| panic!("{}", err));
+        )
+        .unwrap_or_else(|err| panic!("{}", err));
     match result {
         IO::Value(result) => {
             assert_eq!(result, "abc");
@@ -184,7 +185,8 @@ fn spawn_on_twice() {
             Compiler::new()
                 .run_io(true)
                 .run_expr_async::<IO<String>>(&vm, "<top>", text),
-        ).unwrap_or_else(|err| panic!("{}", err));
+        )
+        .unwrap_or_else(|err| panic!("{}", err));
     match result {
         IO::Value(result) => {
             assert_eq!(result, "abc");
@@ -204,7 +206,7 @@ fn spawn_on_runexpr() {
         do child = thread.new_thread ()
         do action = thread.spawn_on child (\_ -> io.run_expr "123")
         do x = action
-        do _ = io.println x.value
+        seq io.println x.value
         wrap x.value
     "#;
 
@@ -215,7 +217,8 @@ fn spawn_on_runexpr() {
             Compiler::new()
                 .run_io(true)
                 .run_expr_async::<IO<String>>(&vm, "<top>", text),
-        ).unwrap_or_else(|err| panic!("{}", err));
+        )
+        .unwrap_or_else(|err| panic!("{}", err));
     match result {
         IO::Value(result) => {
             assert_eq!(result, "123");
@@ -241,8 +244,8 @@ fn spawn_on_do_action_twice() {
         let action = thread.spawn_on child (\_ ->
                 counter <- (load counter + 1)
                 wrap ())
-        do _ = join action
-        do _ = join action
+        seq join action
+        seq join action
         wrap (load counter)
     "#;
 
@@ -253,7 +256,8 @@ fn spawn_on_do_action_twice() {
             Compiler::new()
                 .run_io(true)
                 .run_expr_async::<IO<i32>>(&vm, "<top>", text),
-        ).unwrap_or_else(|err| panic!("{}", err));
+        )
+        .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(result, IO::Value(2));
 }
 
@@ -273,8 +277,8 @@ fn spawn_on_force_action_twice() {
         do action = thread.spawn_on child (\_ ->
                 counter <- (load counter + 1)
                 wrap ())
-        do _ = action
-        do _ = action
+        seq action
+        seq action
         wrap (load counter)
     "#;
 
@@ -285,7 +289,8 @@ fn spawn_on_force_action_twice() {
             Compiler::new()
                 .run_io(true)
                 .run_expr_async::<IO<i32>>(&vm, "<top>", text),
-        ).unwrap_or_else(|err| panic!("{}", err));
+        )
+        .unwrap_or_else(|err| panic!("{}", err));
     assert_eq!(result, IO::Value(1));
 }
 
@@ -316,7 +321,8 @@ fn spawn_on_runexpr_in_catch() {
             Compiler::new()
                 .run_io(true)
                 .run_expr_async::<IO<String>>(&vm, "<top>", text),
-        ).unwrap_or_else(|err| panic!("{}", err));
+        )
+        .unwrap_or_else(|err| panic!("{}", err));
     match result {
         IO::Value(result) => {
             assert_eq!(result, "123");
@@ -329,7 +335,8 @@ fn spawn_on_runexpr_in_catch() {
             Compiler::new()
                 .run_io(true)
                 .run_expr_async::<IO<String>>(&vm, "<top>", text),
-        ).unwrap_or_else(|err| panic!("{}", err));
+        )
+        .unwrap_or_else(|err| panic!("{}", err));
     match result {
         IO::Value(result) => {
             assert_eq!(result, "123");

--- a/tests/pass/state.glu
+++ b/tests/pass/state.glu
@@ -3,12 +3,20 @@ let { (<|) } = import! std.function
 let { Test, run, assert, assert_eq, test, group, ? } = import! std.test
 let int = import! std.int
 let state @ { State, put, get, modify, runState, evalState, execState, ? } = import! std.state
-let { Applicative, (*>), ? } = import! std.applicative
+let { Applicative, wrap, (*>), ? } = import! std.applicative
 
 group "state" [
     test "modify execState" <| \_ -> (assert_eq (execState (modify (\x -> x + 2) *> modify (\x -> x * 4)) 0) 8),
     test "modify evalState" <| \_ -> (assert_eq (evalState (modify (\x -> x + 2) *> get) 0) 2),
     test "put get evalState" <| \_ -> (assert_eq (evalState (put "hello" *> get) "") "hello"),
     test "put get runState" <| \_ -> (assert_eq (runState (put "hello" *> get) "").value "hello"),
+
+    /* FIXME
+    test "record unpack runState" <| \_ ->
+        let m : State { x : Int } Int =
+            do { x } = get
+            wrap x
+        assert_eq (evalState m { x = 1 }) 1,
+    */
 ]
 

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -29,11 +29,11 @@ resume thread
 
 let tests : TestEff r () =
     assert_eq (recv receiver) (Ok 0) *> (
-            do _ = assert_eq (recv receiver) (Err ())
+            seq assert_eq (recv receiver) (Err ())
             resume thread
             assert_eq (recv receiver) (Ok 1)
         ) *> (
-            do _ = assert_eq (recv receiver) (Err ())
+            seq assert_eq (recv receiver) (Err ())
             assert_any_err (resume thread) (Err "Any error message here")
         )
 


### PR DESCRIPTION
This adds the `seq EXPR1 in EXPR2` syntax which desugars to `flat_map (\_ -> EXPR2) EXPR1`. In the long run we should probably desugar this to

```
let x = lazy (\expr -> EXPR2)
flat_map x EXPR1
// or with **>> : [Applicative f] -> f a -> Lazy (f b) -> f b
// EXPR1 **>> x
```

cc #566