### PR TITLE
[RFC] feat: Remove the indentation aware syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ do digits =
     wrap [a, b, c, d]
 
 let print_digits = for digits (\d ->
-        do _ = io.print " "
+        do io.print " "
         io.print (show d))
-do _ = io.print "Four digits:" *> print_digits *> io.println ""
+do io.print "Four digits:" *> print_digits *> io.println ""
 
 let guess_loop _ =
     do line = io.read_line

--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -262,7 +262,7 @@ pub struct ExprField<Id, E> {
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Do<Id> {
-    pub id: SpannedIdent<Id>,
+    pub id: Option<SpannedIdent<Id>>,
     pub bound: Box<SpannedExpr<Id>>,
     pub body: Box<SpannedExpr<Id>>,
     pub flat_map_id: Option<Box<SpannedExpr<Id>>>,
@@ -559,7 +559,9 @@ pub fn walk_mut_expr<'a, V: ?Sized + MutVisitor<'a>>(v: &mut V, e: &'a mut Spann
             ref mut body,
             ref mut flat_map_id,
         }) => {
-            v.visit_spanned_typed_ident(id);
+            if let Some(ref mut id) = *id {
+                v.visit_spanned_typed_ident(id);
+            }
             v.visit_expr(bound);
             v.visit_expr(body);
             if let Some(ref mut flat_map_id) = *flat_map_id {

--- a/build.rs
+++ b/build.rs
@@ -217,5 +217,6 @@ fn main() {
     println!("cargo:rerun-if-changed=examples/24.glu");
 
     generate_std_include();
+    #[cfg(not(feature = "test"))]
     println!("cargo:rerun-if-changed=std/");
 }

--- a/check/src/rename.rs
+++ b/check/src/rename.rs
@@ -2,7 +2,7 @@ use base::ast::{
     self, DisplayEnv, Do, Expr, MutVisitor, Pattern, SpannedAlias, SpannedAstType, SpannedExpr,
     TypedIdent,
 };
-use base::pos::{self, BytePos, Span};
+use base::pos::{self, ByteOffset, BytePos, Span};
 use base::scoped_map::ScopedMap;
 use base::symbol::{Symbol, SymbolModule};
 use base::types::{self, Type};
@@ -213,7 +213,7 @@ pub fn rename(symbols: &mut SymbolModule, expr: &mut SpannedExpr<Symbol>) {
                 }) => {
                     let flat_map = self.symbols.symbol("flat_map");
                     *flat_map_id = Some(Box::new(pos::spanned(
-                        id.span,
+                        Span::new(expr.span.end(), expr.span.start() + ByteOffset::from(2)),
                         Expr::Ident(TypedIdent {
                             name: flat_map,
                             typ: Type::hole(),
@@ -229,7 +229,9 @@ pub fn rename(symbols: &mut SymbolModule, expr: &mut SpannedExpr<Symbol>) {
 
                     self.env.stack.enter_scope();
 
-                    id.value.name = self.stack_var(id.value.name.clone(), id.span);
+                    if let Some(ref mut id) = *id {
+                        id.value.name = self.stack_var(id.value.name.clone(), id.span);
+                    }
 
                     return TailCall::TailCall;
                 }

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -670,7 +670,11 @@ where
                 self.visit_one(exprs)
             },
             Expr::Do(ref do_expr) => {
-                let iter = once(Either::Left(&do_expr.id))
+                let iter = do_expr
+                    .id
+                    .as_ref()
+                    .map(Either::Left)
+                    .into_iter()
                     .chain(once(Either::Right(&do_expr.bound)))
                     .chain(once(Either::Right(&do_expr.body)));
                 match self.select_spanned(iter, |x| x.either(|i| i.span, |e| e.span)) {

--- a/examples/24.glu
+++ b/examples/24.glu
@@ -136,9 +136,9 @@ do digits =
     wrap [a, b, c, d]
 
 let print_digits = for digits (\d ->
-        do _ = io.print " "
+        do io.print " "
         io.print (show d))
-do _ = io.print "Four digits:" *> print_digits *> io.println ""
+do io.print "Four digits:" *> print_digits *> io.println ""
 
 let guess_loop _ =
     do line = io.read_line

--- a/examples/http/server.glu
+++ b/examples/http/server.glu
@@ -58,17 +58,17 @@ let sum : Handler Response =
     do body = get_request >>= array_body
     match string.from_utf8 body with
     | Err _ ->
-        do _ = write_response (string.as_bytes "Request contained invalid UTF-8")
+        do write_response (string.as_bytes "Request contained invalid UTF-8")
         wrap { status = status.bad_request }
     | Ok string_body ->
         match de.deserialize de.deserializer string_body with
         | Ok int_array ->
             let int_array : Array Int = int_array
             let s = foldl (+) 0 int_array 
-            do _ = write_response (string.as_bytes (show s))
+            do write_response (string.as_bytes (show s))
             wrap { status = status.ok }
         | Err err ->
-            do _ = write_response (string.as_bytes err)
+            do write_response (string.as_bytes err)
             wrap { status = status.bad_request }
 
 

--- a/examples/lisp/lisp.glu
+++ b/examples/lisp/lisp.glu
@@ -98,7 +98,7 @@ let modify_state f : (LispState -> LispState) -> Lisp () =
 let scope_state run : Lisp a -> Lisp a =
     do original = get_state
     do x = run
-    do _ = set_state original
+    do set_state original
     wrap x
 
 let fail msg : String -> Lisp a = lisp (\_ -> Err msg)
@@ -139,7 +139,7 @@ let define xs =
     | Cons (Atom name) (Cons value Nil) ->
         do state = get_state
         let new_state = map.insert name value state
-        do _ = set_state new_state
+        do set_state new_state
         wrap value
     | Cons (List (Cons (Atom name) params)) body ->
         do closure = get_state
@@ -152,7 +152,7 @@ let define xs =
                 }
         let new_state = map.insert name function closure
 
-        do _ = set_state new_state
+        do set_state new_state
 
         wrap function
     | _ -> fail "Unexpected parameters to define `define`"
@@ -167,7 +167,7 @@ let apply f xs : Expr -> List Expr -> Lisp Expr =
     let add_args names values =
         match (names, values) with
         | (Cons name names, Cons value values) ->
-            do _ = modify_state (\state -> map.insert name value state)
+            do modify_state (\state -> map.insert name value state)
             add_args names values
         | (Nil, _) -> wrap ()
         | _ -> fail "Not enough arguments to function"
@@ -176,7 +176,7 @@ let apply f xs : Expr -> List Expr -> Lisp Expr =
     | Primitive primitive -> primitive xs
     | Function function ->
         scope_state (
-            do _ = add_args function.params xs
+            do add_args function.params xs
             eval_exprs function.body)
     | _ -> fail ("Can\'t call value: " <> show f)
 

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -193,7 +193,7 @@ fn marshal_generic() -> Result<()> {
         let either: forall r . Either String r = Left "hello rust!"
 
         // we can pass the generic Either to the Rust function without an issue
-        do _ = 
+        do 
             match flip either with
             | Left _ -> error "unreachable!"
             | Right val -> io.println ("Right is: " <> val)

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -694,8 +694,8 @@ Expr: Expr<Id> = {
         Expr::TypeBindings(bindings, Box::new(body))
     },
 
-    "do" <id: SpannedIdent> "=" <bound: SpExpr> "in" <body: SpExpr> => {
-        Expr::Do(Do { id, bound: Box::new(bound), body: Box::new(body), flat_map_id: None })
+    "do" <bind: DoBinding>  "in" <body: SpExpr> => {
+        Expr::Do(Do { id: bind.0, bound: Box::new(bind.1), body: Box::new(body), flat_map_id: None })
     },
 
     BlockExpr,
@@ -704,6 +704,11 @@ Expr: Expr<Id> = {
         errors.push(<>.error);
         Expr::Error(None)
     }
+};
+
+DoBinding: (Option<SpannedIdent<Id>>, SpannedExpr<Id>) = {
+    <id: SpannedIdent> "=" <bound: SpExpr> => (Some(id), bound),
+    <bound: SpExpr> => (None, bound)
 };
 
 BlockExpr: Expr<Id> = {

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -699,6 +699,10 @@ Binding<A>: Expr<Id> = {
 BindingEnd<A>: SpannedExpr<Id> = {
     <bind: Sp<Binding<A>>> => bind,
     "in" <body: SpExprRestricted<A>> => body,
+    Sp<!> => {
+        errors.push(<>.value.error);
+        pos::spanned(<>.span, Expr::Error(None))
+    }
 };
 
 Expr: Expr<Id> = {

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -478,8 +478,8 @@ Literal: Literal = {
     "float literal" => Literal::Float(NotNaN::new(<>).unwrap()),
 };
 
-Alternative: Alternative<Id> = {
-    "|" <pat: Sp<Pattern>> "->" <expr: Sp<BlockExpr>> => {
+Alternative<A>: Alternative<Id> = {
+    "|" <pat: Sp<Pattern>> "->" <expr: SpExprRestricted<"">> => {
         Alternative {
             pattern: pat,
             expr: super::shrink_hidden_spans(expr),
@@ -639,17 +639,17 @@ LambdaArgument: Argument<SpannedIdent<Id>> = {
     }
 };
 
-InfixExpr = {
+InfixExpr<A> = {
     AppExpr,
 
-    "\\" <args: LambdaArgument+> "->" <body: SpExpr> =>
+    "\\" <args: LambdaArgument+> "->" <body: SpExprRestricted<A>> =>
         Expr::Lambda(Lambda {
             id: new_ident(type_cache, env.from_str("")),
             args,
             body: Box::new(body),
         }),
 
-    <lhs: Sp<AppExpr>> <op: Sp<Operator>> <rhs: Sp<InfixExpr>> =>
+    <lhs: Sp<AppExpr>> <op: Sp<Operator>> <rhs: Sp<InfixExpr<A>>> =>
         Expr::Infix { lhs: Box::new(lhs), op, rhs: Box::new(super::shrink_hidden_spans(rhs)), implicit_args: Vec::new(), },
 };
 
@@ -667,16 +667,13 @@ AndTypeBinding: TypeBinding<Id> =
         binding
     };
 
-Expr: Expr<Id> = {
-    InfixExpr,
+DoBinding: (Option<SpannedIdent<Id>>, SpannedExpr<Id>) = {
+    <id: SpannedIdent> "=" <bound: SpExpr> => (Some(id), bound),
+    <bound: SpExpr> => (None, bound)
+};
 
-    "if" <pred: SpExpr> "then" <if_true: SpExpr> "else" <if_false: SpExpr> =>
-        Expr::IfElse(Box::new(pred), Box::new(if_true), Box::new(if_false)),
-
-    "match" <body: SpExpr> "with" <arms: Alternative+> =>
-        Expr::Match(Box::new(body), arms),
-
-    <metadata: Metadata?> "let" <first: ValueBinding> <bindings: AndValueBinding*> SkipExtraTokens "in" <body: SpExpr> => {
+Binding<A>: Expr<Id> = {
+    <metadata: Metadata?> "let" <first: ValueBinding> <bindings: AndValueBinding*> <body: BindingEnd<A>> => {
         let mut first = first;
         first.metadata = metadata.unwrap_or_default();
         let mut bindings = bindings;
@@ -685,7 +682,7 @@ Expr: Expr<Id> = {
         Expr::LetBindings(bindings, Box::new(body))
     },
 
-    <metadata: Metadata?> "type" <first: TypeBinding> <bindings: AndTypeBinding*> SkipExtraTokens "in" <body: SpExpr> => {
+    <metadata: Metadata?> "type" <first: TypeBinding> <bindings: AndTypeBinding*> <body: BindingEnd<A>> => {
         let mut first = first;
         first.metadata = metadata.unwrap_or_default();
         let mut bindings = bindings;
@@ -694,11 +691,29 @@ Expr: Expr<Id> = {
         Expr::TypeBindings(bindings, Box::new(body))
     },
 
-    "do" <bind: DoBinding>  "in" <body: SpExpr> => {
+    "do" <bind: DoBinding> <body: BindingEnd<A>> => {
         Expr::Do(Do { id: bind.0, bound: Box::new(bind.1), body: Box::new(body), flat_map_id: None })
     },
+};
 
-    BlockExpr,
+BindingEnd<A>: SpannedExpr<Id> = {
+    <bind: Sp<Binding<A>>> => bind,
+    "in" <body: SpExprRestricted<A>> => body,
+};
+
+Expr: Expr<Id> = {
+    ExprRestricted<"A">
+};
+ExprRestricted<A>: Expr<Id> = {
+    InfixExpr<A>,
+
+    "if" <pred: SpExpr> "then" <if_true: SpExpr> "else" <if_false: SpExprRestricted<A>> =>
+        Expr::IfElse(Box::new(pred), Box::new(if_true), Box::new(if_false)),
+
+    "match" <body: SpExpr> "with" <arms: Alternative<A>+> if A != "" =>
+        Expr::Match(Box::new(body), arms),
+
+    <Binding<A>>,
 
     ! => {
         errors.push(<>.error);
@@ -706,31 +721,20 @@ Expr: Expr<Id> = {
     }
 };
 
-DoBinding: (Option<SpannedIdent<Id>>, SpannedExpr<Id>) = {
-    <id: SpannedIdent> "=" <bound: SpExpr> => (Some(id), bound),
-    <bound: SpExpr> => (None, bound)
-};
-
-BlockExpr: Expr<Id> = {
-    "block open" <exprs: (<SpExpr> "block separator")*> <last: SpExpr> "block close" => {
-        let mut exprs = exprs;
-        exprs.push(last);
-        Expr::Block(exprs)
-    },
-};
-
 SpExpr: SpannedExpr<Id> = {
-    <expr: Sp<Expr>> => super::shrink_hidden_spans(expr),
+    <SpExprRestricted<"A">>,
+};
+
+SpExprRestricted<A>: SpannedExpr<Id> = {
+    <expr: Sp<ExprRestricted<A>>> => super::shrink_hidden_spans(expr),
 };
 
 pub TopExpr: SpannedExpr<Id> = {
-    "shebang line"? <expr: SpExpr> SkipExtraTokens => expr,
+    "shebang line"? <expr: SpExpr> => expr,
 };
 
 pub ReplLine: Option<ReplLine<Id>> = {
     <TopExpr> => Some(ReplLine::Expr(<>)),
-    "block open" "let" <ValueBinding> SkipExtraTokens
-        // Ugh but I just need the parser to be happy for now
-        "in" "block close" "block close" "block open" "block open" => Some(ReplLine::Let(<>)),
+    "let" <ValueBinding> => Some(ReplLine::Let(<>)),
     => None,
 };

--- a/parser/tests/attributes.rs
+++ b/parser/tests/attributes.rs
@@ -13,6 +13,7 @@ fn any_tokens() {
     let text = r#"
 #[test(ident "string" 42 = 'a' + )]
 let (+) x y = error ""
+in
 { }
 "#;
     parse_clear_span!(text);
@@ -26,7 +27,7 @@ fn bindings() {
 let (+) x y = error ""
 #[implicit]
 type Test = Int
-
+in
 {
     #[abc()]
     Test,

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -27,6 +27,7 @@ let x = 1
 in
 
 let y = 2
+in
 y
 "#;
     let e = parse_clear_span!(text);
@@ -155,6 +156,7 @@ fn tuple_type() {
 
     let expr = r#"
         let _: (Int, String, Option Int) = (1, "", None)
+in
         1"#;
     parse_new!(expr);
 }
@@ -459,6 +461,7 @@ fn comment_on_let() {
     let text = r#"
 /// The identity function
 let id x = x
+in
 id
 "#;
     let e = parse_clear_span!(text);
@@ -491,6 +494,7 @@ fn comment_on_and() {
 let id x = x
 /// The identity function
 and id2 y = y
+in
 id
 "#;
     let e = parse_clear_span!(text);
@@ -532,6 +536,7 @@ fn comment_on_type() {
     let text = r#"
 /** Test type */
 type Test = Int
+in
 id
 "#;
     let e = parse_clear_span!(text);
@@ -563,6 +568,7 @@ let x = 1
 
 /** Test type */
 type Test = Int
+in
 id
 "#;
     let e = parse_clear_span!(text);
@@ -599,6 +605,7 @@ fn merge_line_comments() {
 /// consecutive
 /// line comments.
 type Test = Int
+in
 id
 "#;
     let e = parse_clear_span!(text);
@@ -638,34 +645,11 @@ fn partial_field_access_simple() {
 }
 
 #[test]
-fn partial_field_access_in_block() {
-    let _ = ::env_logger::try_init();
-    let text = r#"
-test.
-test
-"#;
-    let e = parse(text);
-    assert!(e.is_err());
-    assert_eq!(
-        clear_span(e.unwrap_err().0.unwrap()),
-        Spanned {
-            span: Span::default(),
-            value: Expr::Block(vec![
-                Spanned {
-                    span: Span::new(BytePos::from(0), BytePos::from(0)),
-                    value: Expr::Projection(Box::new(id("test")), intern(""), Type::hole()),
-                },
-                id("test"),
-            ]),
-        }
-    );
-}
-
-#[test]
 fn function_operator_application() {
     let _ = ::env_logger::try_init();
     let text = r#"
 let x: ((->) Int Int) = x
+in
 x
 "#;
     let e = parse_clear_span!(text);
@@ -699,38 +683,6 @@ fn quote_in_identifier() {
         app(id("f'"), vec![int(1), int(2)]),
     );
     assert_eq!(e, a);
-}
-
-// Test that this is `let x = 1 in {{ a; b }}` and not `{{ (let x = 1 in a) ; b }}`
-#[test]
-fn block_open_after_let_in() {
-    let _ = ::env_logger::try_init();
-    let text = r#"
-        let x = 1
-        a
-        b
-        "#;
-    let e = parse_zero_index!(text);
-    match e.value {
-        Expr::LetBindings(..) => (),
-        _ => panic!("{:?}", e),
-    }
-}
-
-#[test]
-fn block_open_after_explicit_let_in() {
-    let _ = ::env_logger::try_init();
-    let text = r#"
-        let x = 1
-        in
-        a
-        b
-        "#;
-    let e = parse_zero_index!(text);
-    match e.value {
-        Expr::LetBindings(..) => (),
-        _ => panic!("{:?}", e),
-    }
 }
 
 #[test]
@@ -807,7 +759,7 @@ fn do_in_parens() {
     let _ = ::env_logger::try_init();
     let text = r"
         scope_state (
-            do add_args
+            do add_args in
             eval_exprs
         )
     ";
@@ -852,6 +804,7 @@ fn alias_in_record_type() {
 
     let text = r#"
         type Test = { MyInt }
+        in
         1
         "#;
     let e = parse_clear_span!(text);

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -807,7 +807,7 @@ fn do_in_parens() {
     let _ = ::env_logger::try_init();
     let text = r"
         scope_state (
-            do _ = add_args
+            do add_args
             eval_exprs
         )
     ";

--- a/parser/tests/error_handling.rs
+++ b/parser/tests/error_handling.rs
@@ -74,26 +74,6 @@ fn missing_match_expr() {
 }
 
 #[test]
-fn wrong_indent_expression() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-let y =
-    let x = 1
-    x
-   2
-y
-"#,
-    );
-    let error = Error::UnexpectedToken("IntLiteral".into(), vec![]);
-    let span = pos::span(BytePos::from(0), BytePos::from(0));
-    let errors = ParseErrors::from(vec![pos::spanned(span, error)]);
-
-    assert_eq!(remove_expected(result.unwrap_err().1), errors);
-}
-
-#[test]
 fn unclosed_string() {
     let _ = ::env_logger::try_init();
 
@@ -195,7 +175,7 @@ fn incomplete_alternative() {
         case(int(1), vec![(Pattern::Error, error())])
     );
 
-    let error = Error::UnexpectedToken("CloseBlock".into(), vec![]);
+    let error = Error::UnexpectedEof(vec![]);
     let span = pos::span(BytePos::from(0), BytePos::from(0));
     assert_eq!(
         remove_expected(err),
@@ -266,7 +246,7 @@ fn incomplete_alternative_with_partial_pattern() {
 
     let errors = vec![
         no_loc(Error::UnexpectedToken("RBrace".into(), vec![])),
-        no_loc(Error::UnexpectedToken("CloseBlock".into(), vec![])),
+        no_loc(Error::UnexpectedEof(vec![])),
     ];
     assert_eq!(remove_expected(err), ParseErrors::from(errors));
 }
@@ -277,6 +257,7 @@ fn incomplete_let_binding() {
 
     let expr = r#"
     let test =
+    in
     1
     "#;
     let result = parse(expr);
@@ -287,7 +268,7 @@ fn incomplete_let_binding() {
         let_("test", no_loc(Expr::Error(None)), int(1),)
     );
 
-    let errors = vec![no_loc(Error::UnexpectedToken("CloseBlock".into(), vec![]))];
+    let errors = vec![no_loc(Error::UnexpectedToken("In".into(), vec![]))];
     assert_eq!(remove_expected(err), ParseErrors::from(errors));
 }
 
@@ -306,10 +287,7 @@ fn incomplete_let_binding_2() {
         let_("test", id("io"), no_loc(Expr::Error(None)))
     );
 
-    let errors = vec![
-        no_loc(Error::UnexpectedToken("CloseBlock".into(), vec![])),
-        no_loc(Error::UnexpectedToken("CloseBlock".into(), vec![])),
-    ];
+    let errors = vec![no_loc(Error::UnexpectedEof(vec![]))];
     assert_eq!(remove_expected(err), ParseErrors::from(errors));
 }
 

--- a/parser/tests/indentation.rs
+++ b/parser/tests/indentation.rs
@@ -29,43 +29,6 @@ y
 }
 
 #[test]
-fn sequence_expressions() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-f 1 2
-g ""
-"#,
-    );
-
-    match result {
-        Ok(expr) => if let Expr::Block(ref exprs) = expr.value {
-            assert_eq!(exprs.len(), 2);
-        } else {
-            assert!(false, "Expected block, found {:?}", expr);
-        },
-        Err(err) => assert!(false, "{}", err),
-    }
-}
-
-#[test]
-fn let_in_let_args() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-let x =
-    let y = 1
-    let z = ""
-    y + 1
-in x
-"#,
-    );
-
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-}
-#[test]
 fn and_on_same_line_as_type() {
     let _ = ::env_logger::try_init();
 
@@ -81,22 +44,6 @@ in 1
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
 
-#[test]
-fn close_brace_on_same_line_as_type() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-type M = {
-    x: Int
-}
-
-{ M }
-"#,
-    );
-
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-}
 #[test]
 fn record_unindented_fields() {
     let _ = ::env_logger::try_init();
@@ -116,111 +63,6 @@ in 1
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
 
-// match clauses cannot be unindented past the enclosing block
-#[test]
-fn to_much_unindented_case_of() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-let test x =
-    match x with
-  | Some y -> y
-  | None -> 0
-in test
-"#,
-    );
-
-    assert!(result.is_err(), "{:?}", result.unwrap());
-}
-
-#[test]
-fn match_with_alignment() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-match x with
-    | Some y ->
-        match x with
-            | Some y2 -> y2
-            | None -> 0
-    | None -> 0
-"#,
-    );
-
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-
-    match result.as_ref().unwrap().value {
-        Expr::Match(_, ref alts) => assert_eq!(alts.len(), 2),
-        ref x => panic!("{:?}", x),
-    }
-}
-
-#[test]
-fn allow_unindented_lambda() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-let f = \x ->
-    let y = x + 1
-    y
-
-f
-"#,
-    );
-
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-}
-
-#[test]
-fn close_lambda_on_implicit_statement() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-\x -> x
-1
-"#,
-    );
-
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-
-    match result.unwrap().value {
-        Expr::Block(ref exprs) if exprs.len() == 2 => (),
-        expr => assert!(false, "{:?}", expr),
-    }
-}
-
-#[test]
-fn if_expr_else_is_block() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-let f x = ()
-if True then
-    1
-else
-    f 2
-    2
-"#,
-    );
-
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-
-    if let Expr::LetBindings(_, ref expr) = result.as_ref().unwrap().value {
-        if let Expr::IfElse(_, _, ref if_false) = expr.value {
-            if let Expr::Block(_) = if_false.as_ref().value {
-                return;
-            }
-        }
-    }
-
-    assert!(false, "{:?}", result.unwrap());
-}
-
 #[test]
 fn if_else_if_else() {
     let _ = ::env_logger::try_init();
@@ -237,27 +79,4 @@ else
     );
 
     assert!(result.is_ok(), "{}", result.unwrap_err());
-}
-
-#[test]
-fn block_match() {
-    let _ = ::env_logger::try_init();
-
-    let result = parse(
-        r#"
-match True with
-| True -> 1
-| False -> 0
-2
-"#,
-    );
-
-    assert!(result.is_ok(), "{}", result.unwrap_err());
-
-    if let Expr::Block(ref exprs) = result.as_ref().unwrap().value {
-        assert_eq!(2, exprs.len());
-        return;
-    }
-
-    assert!(false, "{:?}", result.unwrap());
 }

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -146,7 +146,7 @@ let cmd_parser : Parser { cmd : String, arg : String } =
     let word = recognize (skip_many1 letter)
     let arg_parser = recognize (skip_many1 any)
 
-    do _ = token ':'
+    do token ':'
     do cmd = word
     do arg = (spaces *> arg_parser) <|> wrap ""
     wrap { cmd, arg }
@@ -194,11 +194,11 @@ let loop repl : Repl -> IO () =
         match continue with
         | Continue -> loop repl
         | Quit ->
-            do _ = rustyline.save_history repl.editor
+            do rustyline.save_history repl.editor
             wrap ()
 
 let run color : Color -> IO () =
-    do _ = io.println "gluon (:h for help, :q to quit)"
+    do io.println "gluon (:h for help, :q to quit)"
     do editor = rustyline.new_editor ()
     do cpu_pool = repl_prim.new_cpu_pool 1
     let commands = make_commands cpu_pool

--- a/std/alternative.glu
+++ b/std/alternative.glu
@@ -17,6 +17,7 @@ let or ?alt : [Alternative f] -> f a -> f a -> f a = alt.or
 #[infix(left, 3)]
 let (<|>) : [Alternative f] -> f a -> f a -> f a = or
 
+in
 {
     Alternative,
     empty, or, (<|>),

--- a/std/applicative.glu
+++ b/std/applicative.glu
@@ -81,6 +81,7 @@ let map9 fn a b c d e f g h i : [Applicative f] -> _ =
 let map10 fn a b c d e f g h i j : [Applicative f] -> _ =
     map9 fn a b c d e f g h i <*> j
 
+in
 {
     Applicative,
     apply, wrap, (<*>), (<*), (*>),

--- a/std/array.glu
+++ b/std/array.glu
@@ -24,10 +24,13 @@ let eq ?eq : [Eq a] -> Eq (Array a) =
                 if i < len then
                     let x = prim.index l i
                     let y = prim.index r i
+                    in
                     eq.(==) x y && array_eq_ (i + 1)
                 else
                     True
+            in
             array_eq_ 0
+    in
     { (==) = array_eq }
 
 let ord ?ord : [Ord a] -> Ord (Array a) =
@@ -37,30 +40,37 @@ let ord ?ord : [Ord a] -> Ord (Array a) =
             if i < min_len then
                 let x = prim.index l i
                 let y = prim.index r i
+                in
                 match ord.compare x y with
                 | EQ -> array_cmp_ (i + 1)
                 | o -> o
             else
                 compare (prim.len l) (prim.len r)
 
+        in
         array_cmp_ 0
+    in
     { eq, compare = array_cmp }
 
 let show ?d : [Show a] -> Show (Array a) =
 
     let show xs =
         let len = prim.len xs
+        in
         if len == 0 then
             "[]"
         else
             let show_elems i =
                 if i < len then
                     let x = prim.index xs i
+                    in
                     ", " ++ d.show x ++ show_elems (i + 1)
                 else
                     ""
 
+            in
             "[" ++ d.show (prim.index xs 0) ++ show_elems 1 ++ "]"
+    in
     { show }
 
 let functor : Functor Array =
@@ -68,10 +78,13 @@ let functor : Functor Array =
         let map_ i =
             if i < prim.len xs then
                 let y = prim.index xs i
+                in
                 cons (f y) (map_ (i + 1))
             else
                 []
+        in
         map_ 0
+    in
     { map }
 
 let foldable : Foldable Array =
@@ -82,7 +95,9 @@ let foldable : Foldable Array =
                 y
             else
                 let x = prim.index xs (i - 1)
+                in
                 foldr_ (i - 1) (f x y)
+        in
         foldr_ len y
 
     let foldl f y xs =
@@ -90,12 +105,15 @@ let foldable : Foldable Array =
         let foldl_ i y =
             if i < len then
                 let x = prim.index xs i
+                in
                 foldl_ (i + 1) (f y x)
             else
                 y
 
+        in
         foldl_ 0 y
 
+    in
     { foldr, foldl }
 
 let traversable : Traversable Array =
@@ -111,6 +129,7 @@ let traversable : Traversable Array =
 let semigroup : Semigroup (Array a) = { append = prim.append }
 let monoid : Monoid (Array a) = { semigroup, empty = [] }
 
+in
 {
     eq,
     ord,

--- a/std/bool.glu
+++ b/std/bool.glu
@@ -25,6 +25,7 @@ let conjunctive =
         empty = True,
     }
 
+    in
     { semigroup, monoid }
 
 let disjunctive =
@@ -37,6 +38,8 @@ let disjunctive =
         empty = False,
     }
 
+
+    in
     { semigroup, monoid }
 
 let exclusive =
@@ -52,6 +55,7 @@ let exclusive =
         inverse = id,
     }
 
+    in
     { semigroup, monoid, group }
 
 let eq : Eq Bool = {
@@ -66,6 +70,7 @@ let show : Show Bool = {
     show = \x -> if x then "True" else "False"
 }
 
+in
 {
     Bool,
     not,

--- a/std/category.glu
+++ b/std/category.glu
@@ -18,6 +18,7 @@ let (<<) : forall a b c . [Category cat] -> cat b c -> cat a b -> cat a c = comp
 #[infix(left, 9)]
 let (>>) f g : forall a b c . [Category cat] -> cat a b -> cat b c -> cat a c = compose g f
 
+in
 {
     Category,
     id, compose,

--- a/std/cmp.glu
+++ b/std/cmp.glu
@@ -79,6 +79,7 @@ let monoid : Monoid Ordering = {
     empty = EQ,
 }
 
+in
 {
     Eq,
     (==), (/=),

--- a/std/float.glu
+++ b/std/float.glu
@@ -16,6 +16,7 @@ let additive =
         inverse = \x -> 0.0 #Float- x,
     }
 
+    in
     { semigroup, monoid, group }
 
 let multiplicative =
@@ -31,6 +32,7 @@ let multiplicative =
         inverse = \x -> 1.0 #Float/ x,
     }
 
+    in
     { semigroup, monoid, group }
 
 let eq : Eq Float = {
@@ -55,6 +57,7 @@ let show : Show Float = {
     show = (import! std.prim).show_float
 }
 
+in
 {
     additive,
     multiplicative,

--- a/std/foldable.glu
+++ b/std/foldable.glu
@@ -32,7 +32,7 @@ let find ?fold pred : [Foldable t] -> (a -> Bool) -> t a -> Option a =
         match acc with
         | None -> if pred next then Some next else None
         | Some _ -> acc
-
+    in
     fold.foldl go None
 
 let find_map ?fold pred : [Foldable t] -> (a -> Option b) -> t a -> Option b =
@@ -40,7 +40,7 @@ let find_map ?fold pred : [Foldable t] -> (a -> Option b) -> t a -> Option b =
         match acc with
         | None -> pred next
         | Some _ -> acc
-
+    in
     fold.foldl go None
 
 let all pred : [Foldable t] -> (a -> Bool) -> t a -> Bool =
@@ -55,6 +55,7 @@ let elem eq x : [Foldable t] -> Eq a -> a -> t a -> Bool =
 let count : [Foldable t] -> t a -> Int =
     foldl (\acc _ -> acc #Int+ 1) 0
 
+in
 {
     Foldable,
     foldr,

--- a/std/function.glu
+++ b/std/function.glu
@@ -59,6 +59,7 @@ let (<<) : (b -> c) -> (a -> b) -> a -> c = category.compose
 #[infix(left, 9)]
 let (>>) : (a -> b) -> (b -> c) -> a -> c = flip category.compose
 
+in
 {
     semigroup,
     monoid,

--- a/std/functor.glu
+++ b/std/functor.glu
@@ -27,4 +27,5 @@ type Functor f = {
 
 let map ?functor : [Functor f] -> (a -> b) -> f a -> f b = functor.map
 
+in
 { Functor, map }

--- a/std/group.glu
+++ b/std/group.glu
@@ -14,6 +14,7 @@ type Group a = {
     inverse : a -> a
 }
 
+in
 {
     Group
 }

--- a/std/int.glu
+++ b/std/int.glu
@@ -18,6 +18,7 @@ let additive =
         inverse = \x -> 0 #Int- x,
     }
 
+    in
     { semigroup, monoid, group }
 
 let multiplicative =
@@ -30,6 +31,7 @@ let multiplicative =
         empty = 1,
     }
 
+    in
     { semigroup, monoid }
 
 let eq : Eq Int = {
@@ -54,6 +56,7 @@ let show : Show Int = {
     show = (import! std.prim).show_int
 }
 
+in
 {
     additive,
     multiplicative,

--- a/std/json/de.glu
+++ b/std/json/de.glu
@@ -28,6 +28,7 @@ let deserializer : Deserializer i a -> Deserializer i a = id
 let functor : Functor (Deserializer i) = {
     map = \f m -> deserializer (\input ->
             do a = deserializer m input
+            in
             Ok { value = f a.value, input = a.input })
 }
 
@@ -37,6 +38,7 @@ let applicative : Applicative (Deserializer i) = {
     apply = \f m -> deserializer (\input ->
             do g = deserializer f input
             do a = deserializer m g.input
+            in
             Ok { value = g.value a.value, input = a.input }),
 
     wrap = \value -> deserializer (\input -> Ok { value, input }),
@@ -58,6 +60,7 @@ let monad : Monad (Deserializer i) = {
     flat_map = \f m ->
         deserializer (\input ->
                 do a = deserializer m input
+                in
                 deserializer (f a.value) a.input
             ),
 }
@@ -142,7 +145,9 @@ let array a : ValueDeserializer a -> ValueDeserializer (Array a) = \input ->
     | Array xs ->
         do value = for xs (\v ->
             do state = a v
+            in
             Ok state.value)
+        in
         Ok { value, input }
     | _ -> Err (error_msg "Expected array")
 
@@ -179,11 +184,12 @@ let option a : ValueDeserializer a -> ValueDeserializer (Option a) = \input ->
 let field name a : String -> ValueDeserializer a -> ValueDeserializer a = \input ->
     match input with
     | Object o ->
-        match std_map.find name o with
+        (match std_map.find name o with
         | Some value ->
             do state = a value
+            in
             Ok { value = state.value, input }
-        | None -> Err (error_msg ("Expected field `" ++ name ++ "`"))
+        | None -> Err (error_msg ("Expected field `" ++ name ++ "`")))
     | _ -> Err (error_msg "Expected map") 
 
 /// Deserializes the a `Map String a`
@@ -206,8 +212,10 @@ let map a : ValueDeserializer a -> ValueDeserializer (Map String a) = \input ->
     | Object xs ->
         let f = \key value ->
             do state = a value
+            in
             Ok state.value
         do value = std_map.traverse_with_key f xs
+        in
         Ok { value, input }
     | _ -> Err (error_msg "Expected map") 
 
@@ -220,10 +228,12 @@ let value : ValueDeserializer Value = \input ->
 let deserialize de input : ValueDeserializer a -> String -> Result Error a =
     do value = prim.deserialize input
     do state = de value
+    in
     Ok state.value
 
 let run de value : ValueDeserializer a -> Value -> Result Error a =
     do state = de value
+    in
     Ok state.value
 
 #[doc(hidden)]
@@ -255,7 +265,7 @@ let array_deserializer : [Deserialize a] -> Deserialize (Array a) =
 let { Map } = import! std.map
 let map_deserializer : [Deserialize a] -> Deserialize (Map String a) =
     { deserializer = map deserializer }
-
+in
 {
     Value,
     Error,

--- a/std/json/value.glu
+++ b/std/json/value.glu
@@ -10,4 +10,5 @@ type Value =
     | Array (Array Value)
     | Object (Map String Value)
 
+in
 { Value }

--- a/std/list.glu
+++ b/std/list.glu
@@ -44,7 +44,9 @@ let of xs : Array a -> List a =
             ys
         else
             let x = array.index xs (i - 1)
+            in
             of_ (i - 1) (Cons x ys)
+    in
     of_ len Nil
 
 let semigroup : Semigroup (List a) =
@@ -52,7 +54,7 @@ let semigroup : Semigroup (List a) =
         match xs with
         | Cons x zs -> Cons x (append zs ys)
         | Nil -> ys
-
+    in
     { append }
 
 let monoid : Monoid (List a) = {
@@ -65,11 +67,12 @@ let ord ?ord : [Ord a] -> Ord (List a) =
         match (l, r) with
         | (Nil, Nil) -> EQ
         | (Cons x xs, Cons y ys) ->
-            match ord.compare x y with
+            (match ord.compare x y with
             | EQ -> list_cmp xs ys
-            | o -> o
+            | o -> o)
         | (Cons _ _, Nil) -> GT
         | (Nil, Cons _ _) -> LT
+    in
     { eq = eq_List, compare = list_cmp }
 
 let functor : Functor List =
@@ -77,6 +80,7 @@ let functor : Functor List =
         match xs with
         | Cons y ys -> Cons (f y) (map f ys)
         | Nil -> Nil
+    in
     { map }
 
 let applicative : Applicative List =
@@ -87,6 +91,7 @@ let applicative : Applicative List =
         | Nil -> Nil
     let wrap x = Cons x Nil
 
+    in
     { functor = functor, apply, wrap }
 
 let many ?alt x : [Alternative f] -> f a -> f (List a) =
@@ -95,7 +100,9 @@ let many ?alt x : [Alternative f] -> f a -> f (List a) =
         some_v () <|> wrap Nil
     and some_v _ =
         let { ? } = alt.applicative
+        in
         map (\h l -> Cons h l) x <*> many_v ()
+    in
     many_v ()
 
 let some ?alt x : [Alternative f] -> f a -> f (List a) =
@@ -104,7 +111,9 @@ let some ?alt x : [Alternative f] -> f a -> f (List a) =
         some_v () <|> wrap Nil
     and some_v _ =
         let { ? } = alt.applicative
+        in
         map (\h l -> Cons h l) x <*> many_v ()
+    in
     some_v ()
 
 let alternative : Alternative List = {
@@ -119,6 +128,7 @@ let monad : Monad List =
         | Cons x ys -> (f x) <> (flat_map f ys)
         | Nil -> Nil
 
+    in
     { applicative = applicative, flat_map }
 
 let show ?d : [Show a] -> Show (List a) =
@@ -127,12 +137,10 @@ let show ?d : [Show a] -> Show (List a) =
         show = \xs ->
             let show_elems ys =
                 match ys with
-                | Cons y ys2 ->
-                    match ys2 with
-                    | Cons z zs -> d.show y <> ", " <> show_elems ys2
-                    | Nil -> d.show y
+                | Cons y ys2@(Cons _ _) -> d.show y <> ", " <> show_elems ys2
+                | Cons y Nil -> d.show y
                 | Nil -> ""
-
+            in
             "[" <> show_elems xs <> "]",
     }
 
@@ -146,7 +154,7 @@ let foldable : Foldable List =
         match xs with
         | Cons y ys -> foldl f (f x y) ys
         | Nil -> x
-
+    in
     { foldr, foldl }
 
 let traversable : Traversable List = {
@@ -172,6 +180,7 @@ let filter predicate xs : (a -> Bool) -> List a -> List a =
     | Nil -> Nil
     | Cons y ys ->
         let rest = filter predicate ys
+        in
         if predicate y then Cons y rest else rest
 
 let scan compare xs less equal greater : (a -> Ordering)
@@ -182,11 +191,11 @@ let scan compare xs less equal greater : (a -> Ordering)
         -> (List a, List a, List a) =
     match xs with
     | Nil -> (less, equal, greater)
-    | Cons y ys ->
+    | Cons y ys -> (
         match compare y with
         | LT -> scan compare ys (Cons y less) equal greater
         | EQ -> scan compare ys less (Cons y equal) greater
-        | GT -> scan compare ys less equal (Cons y greater)
+        | GT -> scan compare ys less equal (Cons y greater))
 
 /// Sorts the list using `ord`.
 ///
@@ -200,9 +209,10 @@ let sort xs : [Ord a] -> List a -> List a =
     | Nil -> Nil
     | Cons pivot ys ->
         let (less, equal, greater) = scan (\a -> compare a pivot) ys Nil (Cons pivot Nil) Nil
+        in
         sort less <> equal <> sort greater
 
-
+in
 {
     List,
     of,

--- a/std/map.glu
+++ b/std/map.glu
@@ -37,20 +37,20 @@ let singleton k v = Bin k v empty empty
 let find k m : [Ord k] -> k -> Map k a -> Option a =
     match m with
     | Bin k2 v l r ->
-        match compare k k2 with
+        (match compare k k2 with
         | LT -> find k l
         | EQ -> Some v
-        | GT -> find k r
+        | GT -> find k r)
     | Tip -> None
 
 /// Inserts the value `v` at the key `k` in the map `m`. If the key already exists in the map the current value gets replaced.
 let insert k v m : [Ord k] -> k -> a -> Map k a -> Map k a =
     match m with
     | Bin k2 v2 l r ->
-        match compare k k2 with
+        (match compare k k2 with
         | LT -> Bin k2 v2 (insert k v l) r
         | EQ -> Bin k v l r
-        | GT -> Bin k2 v2 l (insert k v r)
+        | GT -> Bin k2 v2 l (insert k v r))
     | Tip -> Bin k v empty empty
 
 let map f m : [Ord k] -> (a -> b) -> Map k a -> Map k b =
@@ -97,7 +97,7 @@ let traverse_with_key f m : [Ord k] -> [Applicative t] -> (k -> a -> t b)
         | Tip -> wrap Tip
         | Bin k v l r ->
             map3 (flip (Bin k)) (go l) (f k v) (go r)
-
+    in
     go m
 
 let traverse ?ord app f : [Ord k] -> Applicative t -> (a -> t b) -> Map k a -> t (Map k b) =
@@ -122,6 +122,7 @@ let keys : [Ord k] -> Map k a -> List k = foldr_with_key (\k _ acc -> Cons k acc
 /// Returns a list of all values in the map.
 let values : [Ord k] -> Map k a -> List a = foldr Cons Nil
 
+in
 {
     Map,
 

--- a/std/monad.glu
+++ b/std/monad.glu
@@ -46,6 +46,7 @@ let (>>=) x f : [Monad m] -> m a -> (a -> m b) -> m b = flat_map f x
 
 let join mm : [Monad m] -> m (m a) -> m a = mm >>= (\x -> x)
 
+in
 {
     Monad,
     flat_map, (>>=), (=<<), join,

--- a/std/monoid.glu
+++ b/std/monoid.glu
@@ -19,6 +19,7 @@ type Monoid a = {
 
 let empty ?m : [Monoid a] -> a = m.empty
 
+in
 {
     Monoid,
     empty,

--- a/std/num.glu
+++ b/std/num.glu
@@ -31,6 +31,7 @@ let (/) ?num : [Num a] -> a -> a -> a = num.(/)
 
 let negate ?num : [Num a] -> a -> a = num.negate
 
+in
 {
     Num,
 

--- a/std/option.glu
+++ b/std/option.glu
@@ -36,6 +36,7 @@ let former =
         empty = None,
     }
 
+    in
     { semigroup, monoid }
 
 let latter =
@@ -51,6 +52,7 @@ let latter =
         empty = None,
     }
 
+    in
     { semigroup, monoid }
 
 let semigroup a : Semigroup a -> Semigroup (Option a) = {
@@ -124,7 +126,7 @@ let show ?d : [Show a] -> Show (Option a) =
         match o with
         | Some x -> "Some (" <> d.show x <> ")"
         | None -> "None"
-
+    in
     { show }
 
 let foldable : Foldable Option = {
@@ -147,6 +149,7 @@ let traversable : Traversable Option = {
         | Some x -> app.functor.map Some (f x),
 }
 
+in
 {
     Option,
     unwrap,

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -206,7 +206,7 @@ let skip_many p : Parser a -> Parser () =
     skip_many1 p <|> wrap ()
 /// Parses with `p` one or more times, ignoring the result of the parser
 and skip_many1 p : Parser a -> Parser () =
-    do _ = p
+    do p
     skip_many p
 
 /// Parses one of the characters of `s`

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -18,7 +18,7 @@ let { Bool, not } = import! std.bool
 let { (++) } = import! std.string
 let { error } = import! std.prim
 let { flat_map } = import! std.monad
-
+in
 {
     Ordering,
 

--- a/std/result.glu
+++ b/std/result.glu
@@ -94,8 +94,10 @@ let show ?e ?t : [Show e] -> [Show t] -> Show (Result e t) =
         | Ok x -> "Ok (" <> t.show x <> ")"
         | Err x -> "Err (" <> e.show x <> ")"
 
+    in
     { show }
 
+in
 {
     Result,
     unwrap_ok,

--- a/std/semigroup.glu
+++ b/std/semigroup.glu
@@ -17,6 +17,7 @@ let append ?s : [Semigroup a] -> a -> a -> a = s.append
 #[infix(left, 4)]
 let (<>) : [Semigroup a] -> a -> a -> a = append
 
+in
 {
     Semigroup,
     append,

--- a/std/show.glu
+++ b/std/show.glu
@@ -17,6 +17,7 @@ type Show a = { show : a -> String }
 /// ```
 let show ?s : [Show a] -> a -> String = s.show
 
+in
 {
     Show,
     show,

--- a/std/string.glu
+++ b/std/string.glu
@@ -25,6 +25,7 @@ let ord : Ord String = { eq, compare = prim.string_compare }
 
 let show : Show String = { show = \s -> "\"" ++ s ++ "\"" }
 
+in
 {
     eq,
     ord,

--- a/std/test.glu
+++ b/std/test.glu
@@ -38,7 +38,7 @@ let run test : Test a -> () =
     match test.writer with
     | Cons _ _ -> error (foldl (\acc err -> acc <> "\n" <> err) "" test.writer)
     | Nil -> ()
-
+in
 {
     Test,
     TestCase,

--- a/std/traversable.glu
+++ b/std/traversable.glu
@@ -24,7 +24,7 @@ let sequence : [Traversable t] -> [Applicative m] -> t (m a) -> m (t a) =
 let for x f : [Traversable t] -> [Applicative m] -> t a -> (a -> m b) -> m (t b) =
     traverse f x
 
-
+in
 {
     Traversable,
 

--- a/std/types.glu
+++ b/std/types.glu
@@ -21,5 +21,5 @@ type Ordering =
     | LT
     | EQ
     | GT
-
+in
 { Bool, Option, Result, Ordering }

--- a/std/writer.glu
+++ b/std/writer.glu
@@ -29,11 +29,14 @@ let make monoid : Monoid w -> Impl w =
         applicative,
         flat_map = \f m ->
             let { value, writer } = f m.value
+            in
             { value, writer = m.writer <> writer },
     }
-
+    
+    in
     { functor, applicative, monad }
 
 let tell w : w -> Writer w () = { value = (), writer = w }
 
+in
 { Writer, Impl, make, tell }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -171,7 +171,7 @@ fn spawn_on_runexpr() {
         do child = thread.new_thread ()
         do action = thread.spawn_on child (\_ -> io.run_expr "123")
         do x = action
-        do _ = io.println x.value
+        do io.println x.value
         wrap x.value
     "#;
 
@@ -209,8 +209,8 @@ fn spawn_on_do_action_twice() {
         let action = thread.spawn_on child (\_ ->
                 counter <- (load counter + 1)
                 wrap ())
-        do _ = join action
-        do _ = join action
+        do join action
+        do join action
         wrap (load counter)
     "#;
 
@@ -242,8 +242,8 @@ fn spawn_on_force_action_twice() {
         do action = thread.spawn_on child (\_ ->
                 counter <- (load counter + 1)
                 wrap ())
-        do _ = action
-        do _ = action
+        do action
+        do action
         wrap (load counter)
     "#;
 

--- a/tests/pass/json/de.glu
+++ b/tests/pass/json/de.glu
@@ -21,6 +21,7 @@ type Recursive = { record : Record, y : Float }
 #[derive(Show, Eq, Deserialize)]
 type Variant = | Int Int | String String
 
+in
 group "json.de" [
     test "derive_record_1_field" <| \_ ->
         assert_eq (de.deserialize deserializer r#"{ "x" : 1 }"#) (Ok { x = 1 }),

--- a/tests/pass/json/ser.glu
+++ b/tests/pass/json/ser.glu
@@ -21,6 +21,7 @@ type Variant = | MyInt Int | MyString String
 #[derive(Show, Eq, Serialize)]
 type MyOption a = | MyNone | MySome a
 
+in
 group "json.ser" [
     test "derive_record_1_field" <| \_ ->
         assert_eq (ser.to_string { x = 1 }) (Ok r#"{"x":1}"#),

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -27,11 +27,11 @@ resume thread
 
 let tests : Test () =
     assert_eq (recv receiver) (Ok 0) *> (
-            do _ = assert_eq (recv receiver) (Err ())
+            do assert_eq (recv receiver) (Err ())
             resume thread
             assert_eq (recv receiver) (Ok 1)
         ) *> (
-            do _ = assert_eq (recv receiver) (Err ())
+            do assert_eq (recv receiver) (Err ())
             assert_any_err (resume thread) (Err "Any error message here")
         )
 

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -535,10 +535,13 @@ impl<'a, 'e> Translator<'a, 'e> {
                 let bound_ident =
                     binder.bind(self.translate_alloc(bound), bound.env_type_of(&self.env));
 
+                let do_id = id
+                    .as_ref()
+                    .map_or_else(|| self.dummy_symbol.clone(), |id| id.value.clone());
                 let lambda = self.new_lambda(
                     expr.span.start(),
-                    id.value.clone(),
-                    vec![id.value.clone()],
+                    do_id.clone(),
+                    vec![do_id],
                     self.translate_alloc(body),
                     body.span,
                 );


### PR DESCRIPTION
Removes the indentation aware syntax and instead forces explicit `in` tokens to be inserted to separate `let/type/do` bindings from their body. By some tweaks in the grammar `in` is not required to separate the bindings itself.

```f#
type Test = Int
let id x = x
and id2 y = y
do action
let x = id 2
in
wrap (x + 1)
```
(Could also be written as)

```f#
type Test = Int
in
let id x = x
and id2 y = y
in
do action
in
let x = id 2
in
wrap (x + 1)
```

I feel like this could be a good compromise between a non-indentation based syntax while also avoiding the verboseness of `in` everywhere (I think this is more or less how OCaml is structured, but it still avoids a concept of top-level).

Since blocks are indentation aware they were also removed so it is no longer possible to sequence two function calls.

```f#
f x
g y z

// Now parses as
f x g y z
```

`match` expressions can no longer be nested directly as that causes ambiguities.

```f#
let x = match 1 with
    | 2 ->
        match () with // Error
        | _ -> 1
    | _ -> 0
```
To fix this the inner `match` must be wrapped in parentheses
```f#

let x = match 1 with
    | 2 ->
        (match () with
        | _ -> 1)
    | _ -> 0
```

Before and after of part of the standard library https://github.com/gluon-lang/gluon/pull/596/commits/b5cfc7476359801c73a81e1165d7244aa151de4a

cc #495 cc @OvermindDL1