### PR TITLE
[WIP] feat(vm): Generalize OpaqueValue to support lifetime rooting

### DIFF
--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -1296,6 +1296,13 @@ impl<'vm, T: Pushable<'vm>> Pushable<'vm> for IO<T> {
     }
 }
 
+impl<'vm> Pushable<'vm> for Variants<'vm> {
+    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+        context.push(self);
+        Ok(())
+    }
+}
+
 impl<'vm, T> Pushable<'vm> for RootedValue<T>
 where
     T: Deref<Target = Thread>,
@@ -1609,13 +1616,12 @@ where
 
 impl<'s, 'value, 'vm, T, V> Pushable<'vm> for Opaque<T, V>
 where
-    T: AsVariant<'s, 'value, Variant = Variants<'value>> + 's,
-    V: ?Sized + VmType + 's,
+    T: Pushable<'vm>,
+    V: ?Sized + VmType,
     V::Type: Sized,
 {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        context.push(self.0.get_value());
-        Ok(())
+        self.0.push(context)
     }
 }
 

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -5,7 +5,7 @@ use std::string::String as StdString;
 
 use api::generic::A;
 use api::{
-    generic, primitive, Array, Getable, OpaqueRef, Pushable, Pushed, RuntimeResult, Unrooted,
+    generic, primitive, Getable, OpaqueRef, OpaqueValue, Pushable, Pushed, RuntimeResult, Unrooted,
     ValueRef, WithVM,
 };
 use gc::{DataDef, Gc, Traverseable, WriteOnly};
@@ -24,6 +24,8 @@ pub mod array {
     pub fn len(array: Array<generic::A>) -> VmInt {
         array.len() as VmInt
     }
+
+    type Array<'vm, T> = OpaqueValue<&'vm Thread, [T]>;
 
     pub(crate) fn index<'vm>(
         array: Array<'vm, OpaqueRef<'vm, generic::A>>,

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -5,8 +5,8 @@ use std::string::String as StdString;
 
 use api::generic::A;
 use api::{
-    generic, primitive, Getable, OpaqueRef, OpaqueValue, Pushable, Pushed, RuntimeResult, Unrooted,
-    ValueRef, WithVM,
+    generic, primitive, Array, Getable, OpaqueRef, Pushable, Pushed, RuntimeResult, ValueRef,
+    WithVM,
 };
 use gc::{DataDef, Gc, Traverseable, WriteOnly};
 use stack::{ExternState, StackFrame};
@@ -25,22 +25,20 @@ pub mod array {
         array.len() as VmInt
     }
 
-    type Array<'vm, T> = OpaqueValue<&'vm Thread, [T]>;
-
     pub(crate) fn index<'vm>(
-        array: Array<'vm, OpaqueRef<'vm, generic::A>>,
+        array: OpaqueRef<'vm, [generic::A]>,
         index: VmInt,
-    ) -> RuntimeResult<Unrooted<generic::A>, String> {
+    ) -> RuntimeResult<OpaqueRef<'vm, generic::A>, String> {
         match array.get(index) {
-            Some(value) => RuntimeResult::Return(Unrooted::from(value.get_variant().get_value())),
+            Some(value) => RuntimeResult::Return(value),
             None => RuntimeResult::Panic(format!("Index {} is out of range", index)),
         }
     }
 
     pub(crate) fn append<'vm>(
-        lhs: Array<'vm, OpaqueRef<'vm, generic::A>>,
-        rhs: Array<'vm, OpaqueRef<'vm, generic::A>>,
-    ) -> RuntimeResult<Array<'vm, Unrooted<generic::A>>, Error> {
+        lhs: Array<'vm, generic::A>,
+        rhs: Array<'vm, generic::A>,
+    ) -> RuntimeResult<Array<'vm, generic::A>, Error> {
         struct Append<'b> {
             lhs: &'b ValueArray,
             rhs: &'b ValueArray,

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -5,7 +5,7 @@ use std::string::String as StdString;
 
 use api::generic::A;
 use api::{
-    generic, primitive, Array, Generic, Getable, Pushable, Pushed, RuntimeResult, Unrooted,
+    generic, primitive, Array, Getable, OpaqueRef, Pushable, Pushed, RuntimeResult, Unrooted,
     ValueRef, WithVM,
 };
 use gc::{DataDef, Gc, Traverseable, WriteOnly};
@@ -26,7 +26,7 @@ pub mod array {
     }
 
     pub(crate) fn index<'vm>(
-        array: Array<'vm, Generic<generic::A>>,
+        array: Array<'vm, OpaqueRef<'vm, generic::A>>,
         index: VmInt,
     ) -> RuntimeResult<Unrooted<generic::A>, String> {
         match array.get(index) {
@@ -35,10 +35,10 @@ pub mod array {
         }
     }
 
-    pub fn append<'vm>(
-        lhs: Array<'vm, Generic<generic::A>>,
-        rhs: Array<'vm, Generic<generic::A>>,
-    ) -> RuntimeResult<Array<'vm, Generic<'vm, generic::A>>, Error> {
+    pub(crate) fn append<'vm>(
+        lhs: Array<'vm, OpaqueRef<'vm, generic::A>>,
+        rhs: Array<'vm, OpaqueRef<'vm, generic::A>>,
+    ) -> RuntimeResult<Array<'vm, Unrooted<generic::A>>, Error> {
         struct Append<'b> {
             lhs: &'b ValueArray,
             rhs: &'b ValueArray,
@@ -91,7 +91,7 @@ pub mod array {
         };
         unsafe {
             RuntimeResult::Return(Getable::from_value(
-                lhs.vm(),
+                lhs.vm_(),
                 Variants::new(&ValueRepr::Array(value).into()),
             ))
         }
@@ -521,7 +521,7 @@ pub fn load<'vm>(vm: &'vm Thread) -> Result<ExternModule> {
             string_compare => named_primitive!(2, "std.prim.string_compare", str::cmp),
             string_eq => named_primitive!(2, "std.prim.string_eq", <str as PartialEq>::eq),
             error => primitive::<fn(StdString) -> Pushed<A>>("std.prim.error", std::prim::error),
-            discriminant_value => primitive::<fn(Generic<'vm, A>) -> VmInt>(
+            discriminant_value => primitive::<fn(OpaqueRef<'vm, A>) -> VmInt>(
                 "std.prim.discriminant_value",
                 std::prim::discriminant_value
             ),

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -275,8 +275,7 @@ pub mod gc {
                         .alloc(RecordDef {
                             elems: &def.fields,
                             fields: &fields[..],
-                        })
-                        .map_err(D::Error::custom),
+                        }).map_err(D::Error::custom),
                     DataTag::Data(tag) => seed
                         .thread
                         .context()
@@ -284,8 +283,7 @@ pub mod gc {
                         .alloc(Def {
                             tag: tag,
                             elems: &def.fields,
-                        })
-                        .map_err(D::Error::custom),
+                        }).map_err(D::Error::custom),
                 }
             }
         }
@@ -549,16 +547,16 @@ pub mod closure {
                                         .alloc(ClosureDataModel {
                                             function: function,
                                             upvars: upvars,
-                                        })
-                                        .map_err(V::Error::custom)?;
+                                        }).map_err(V::Error::custom)?;
                                     self.state.gc_map.insert(id, closure);
 
                                     for i in 0..upvars {
                                         let value = seq
                                             .next_element_seed(::serde::de::Seed::new(
                                                 &mut self.state,
-                                            ))?
-                                            .ok_or_else(|| V::Error::invalid_length(i + 2, &self))?;
+                                            ))?.ok_or_else(|| {
+                                                V::Error::invalid_length(i + 2, &self)
+                                            })?;
                                         closure.as_mut().upvars[i] = value;
                                     }
                                     Ok(closure)
@@ -714,8 +712,7 @@ impl<'de> DeserializeState<'de, DeSeed> for ExternFunction {
                 } else {
                     Cow::Borrowed(s)
                 }
-            })
-            .intersperse(Cow::Borrowed("."));
+            }).intersperse(Cow::Borrowed("."));
         for s in iter {
             escaped_id += s;
         }


### PR DESCRIPTION
Creates `Opaque` as a generalized version of `OpaqueValue` (which is now an alias). `Opaque` supports almost all of the operations `OpaqueValue` does and is meant to be a reference to a gluon value (which may be rooted with a lifetime or by reference counted root).

In effect `Opaque` is the cheapest way to get a value out of the gluon interpreter as no copying is done (and when used as argument to a Rust function it does not even need to increment any reference counters).

- [ ] Rename `Opaque` to something else?