### PR TITLE
Correct record test in vm

### DIFF
--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -79,7 +79,7 @@ fn record() {
             assert_eq!(data.get(0).unwrap(), ValueRef::Int(0));
             assert_eq!(data.get(1).unwrap(), ValueRef::Float(1.0));
             match data.get(2).unwrap() {
-                ValueRef::Data(data) if data.tag() == 0 => (),
+                ValueRef::Data(data) if data.len() == 0 => (),
                 _ => panic!(),
             }
         }


### PR DESCRIPTION
Use len instead of tag for verify record with 0 field.