### PR TITLE
Fix missing newlines in gluon_repl command-line output

### DIFF
--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -296,6 +296,8 @@ fn main() {
                 let mut stderr = termcolor::StandardStream::stderr(opt.color.into());
                 if let Err(err) = err.emit(&mut stderr, compiler.code_map()) {
                     eprintln!("{}", err);
+                } else {
+                    eprintln!("");
                 }
             }
         }

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -274,7 +274,7 @@ fn run(
         } else if !opt.input.is_empty() {
             run_files(compiler, &vm, &opt.input)?;
         } else {
-            write!(io::stderr(), "{}", Opt::clap().get_matches().usage())
+            writeln!(io::stderr(), "{}", Opt::clap().get_matches().usage())
                 .expect("Error writing help to stderr");
         },
     }


### PR DESCRIPTION
The `gluon` command provided by `gluon_repl` fails to print a trailing
newline after the usage string when no arguments are given, and it
fails to print a trailing newline after the error string when a file
provided as input cannot be found.  These missing newlines result in
unsightly output as the shell prints the `$PS1` without a preceding
line break.  The commits in this series address these two issues.
