### PR TITLE
Implement VmType and Getable for Box<T>

### DIFF
--- a/tests/api.rs
+++ b/tests/api.rs
@@ -351,3 +351,24 @@ fn use_rust_created_record_as_polymorphic() {
     let result = f.call(record_no_decl!{ x => 1 }).unwrap();
     assert_eq!(result, 1);
 }
+
+#[test]
+fn get_value_boxed_or_unboxed() {
+    let _ = ::env_logger::try_init();
+    let vm = make_vm();
+
+    let text = r#"
+        27
+    "#;
+
+    // The user should be able to decide whether or not any gluon value should
+    // be boxed on the rust side.
+    let (unboxed, _) = Compiler::new()
+        .run_expr::<i32>(&vm, "test", text)
+        .unwrap_or_else(|err| panic!("{}", err));
+    assert_eq!(unboxed, 27);
+    let (boxed, _) = Compiler::new()
+        .run_expr::<Box<i32>>(&vm, "test", text)
+        .unwrap_or_else(|err| panic!("{}", err));
+    assert_eq!(boxed, Box::new(27));
+}

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -969,6 +969,19 @@ impl<'vm, 'value, T: vm::Userdata> Getable<'vm, 'value> for *const T {
     }
 }
 
+impl<'s, T: VmType> VmType for Box<T> {
+    type Type = T::Type;
+    fn make_type(vm: &Thread) -> ArcType {
+        T::make_type(vm)
+    }
+}
+
+impl<'vm, 'value, T: Getable<'vm, 'value>> Getable<'vm, 'value> for Box<T> {
+    fn from_value(vm: &'vm Thread, value: Variants<'value>) -> Box<T> {
+        Box::new(T::from_value(vm, value))
+    }
+}
+
 impl<K, V> VmType for BTreeMap<K, V>
 where
     K: VmType,


### PR DESCRIPTION
The type of `Box<T>` is just `T` and for `Getable` we call `from_value` for `T` and box the result. This is useful because in recursive types in rust we often have to use Box in order for the type to have a finite size.

I *think* this should not cause any problems and with this implementation the user can just choose how to represent their gluon types in rust (i.e., with or without boxing), but feel free to correct me on that. Alternatively, one could implement a `Box`-like type in gluon and map those types, but I currently don't see a reason for that.

Unfortunately, `Pushable` cannot be implemented due to the conflicting implementation for `UserData` and I could not think of a workaround. Apparently, users can implement `UserData` (or any other trait for that matter) for `Box<SomeLocallyDefinedType>`.

I also looked into adding tests for this implementation, but I'm unsure where they should go. Maybe `tests/de.rs`?