### PR TITLE
feat: Allow implicit resolution if the same binding is included twice

### DIFF
--- a/base/src/metadata.rs
+++ b/base/src/metadata.rs
@@ -43,6 +43,7 @@ pub struct Attribute {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde_derive", derive(Deserialize, Serialize))]
 pub struct Metadata {
+    pub definition: Option<Symbol>,
     pub comment: Option<Comment>,
     pub attributes: Vec<Attribute>,
     pub args: Vec<Argument<Symbol>>,
@@ -51,7 +52,10 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn has_data(&self) -> bool {
-        self.comment.is_some() || !self.module.is_empty() || !self.attributes.is_empty()
+        self.definition.is_some()
+            || self.comment.is_some()
+            || !self.module.is_empty()
+            || !self.attributes.is_empty()
     }
 
     pub fn merge(mut self, other: Metadata) -> Metadata {
@@ -60,6 +64,9 @@ impl Metadata {
     }
 
     pub fn merge_with(&mut self, other: Metadata) {
+        if other.definition.is_some() {
+            self.definition = other.definition;
+        }
         if self.comment.is_none() {
             self.comment = other.comment;
         }

--- a/check/tests/implicits.rs
+++ b/check/tests/implicits.rs
@@ -841,3 +841,26 @@ let map2 fn a b : [Applicative f] -> _
 
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
+
+#[test]
+fn allow_importing_same_record_twice() {
+    let _ = ::env_logger::try_init();
+    let text = r#"
+#[implicit]
+type Test a = | Test a
+
+let mod =
+    let int : Test Int = Test 0
+    let string : Test String = Test ""
+    { int, string }
+
+let { ? } = mod
+let { ? } = mod
+
+let f x : [Test a] -> a -> a = x
+f 1
+"#;
+    let result = support::typecheck(text);
+
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}

--- a/check/tests/metadata.rs
+++ b/check/tests/metadata.rs
@@ -50,6 +50,7 @@ id
     assert_eq!(
         metadata,
         Metadata {
+            definition: metadata.definition.clone(),
             comment: Some(line_comment("The identity function")),
             args: vec![Argument::explicit(intern("x:35"))],
             ..Metadata::default()
@@ -74,6 +75,7 @@ let id x = x
     assert_eq!(
         metadata.module.get("id"),
         Some(&Metadata {
+            definition: metadata.module.get("id").and_then(|m| m.definition.clone()),
             comment: Some(line_comment("The identity function")),
             args: vec![Argument::explicit(intern("x:35"))],
             ..Metadata::default()
@@ -98,6 +100,10 @@ type Test = Int
     assert_eq!(
         metadata.module.get("Test"),
         Some(&Metadata {
+            definition: metadata
+                .module
+                .get("Test")
+                .and_then(|m| m.definition.clone()),
             comment: Some(line_comment("A test type")),
             ..Metadata::default()
         })
@@ -122,6 +128,7 @@ fn propagate_metadata_record_field_comment() {
     assert_eq!(
         metadata.module.get("id"),
         Some(&Metadata {
+            definition: metadata.module.get("id").and_then(|m| m.definition.clone()),
             comment: Some(line_comment("The identity function")),
             ..Metadata::default()
         })
@@ -147,6 +154,7 @@ x.id
     assert_eq!(
         metadata,
         Metadata {
+            definition: metadata.definition.clone(),
             comment: Some(line_comment("The identity function")),
             ..Metadata::default()
         }
@@ -257,7 +265,9 @@ let x ?test : [Test a] -> a = test.x
     assert_eq!(
         metadata.module.get("x"),
         Some(&Metadata {
+            definition: metadata.module.get("x").and_then(|m| m.definition.clone()),
             comment: Some(line_comment("A field")),
+            args: vec![Argument::implicit(intern("test:55"))],
             ..Metadata::default()
         })
     );
@@ -284,7 +294,9 @@ let x ?test : [Test a] -> a = test.x
     assert_eq!(
         metadata.module.get("x"),
         Some(&Metadata {
+            definition: metadata.module.get("x").and_then(|m| m.definition.clone()),
             comment: Some(line_comment("A field")),
+            args: vec![Argument::implicit(intern("test:55"))],
             ..Metadata::default()
         })
     );
@@ -313,6 +325,7 @@ let x ?test : [Test a] -> Test (Wrap a) = { x = Wrap test.x }
     assert_eq!(
         metadata.module.get("x"),
         Some(&Metadata {
+            definition: metadata.module.get("x").and_then(|m| m.definition.clone()),
             attributes: vec![Attribute {
                 name: "attribute".into(),
                 arguments: None,

--- a/completion/tests/completion.rs
+++ b/completion/tests/completion.rs
@@ -68,7 +68,12 @@ fn get_metadata(s: &str, pos: BytePos) -> Option<Metadata> {
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
     let (_, metadata_map) = check::metadata::metadata(&env, &expr);
-    completion::get_metadata(&metadata_map, expr.span, &expr, pos).cloned()
+    completion::get_metadata(&metadata_map, expr.span, &expr, pos)
+        .cloned()
+        .map(|mut meta| {
+            meta.definition.take();
+            meta
+        })
 }
 
 fn suggest_metadata(s: &str, pos: BytePos, name: &str) -> Option<Metadata> {
@@ -77,7 +82,12 @@ fn suggest_metadata(s: &str, pos: BytePos, name: &str) -> Option<Metadata> {
     let (expr, _result) = support::typecheck_expr(s);
 
     let (_, metadata_map) = check::metadata::metadata(&env, &expr);
-    completion::suggest_metadata(&metadata_map, &env, expr.span, &expr, pos, name).cloned()
+    completion::suggest_metadata(&metadata_map, &env, expr.span, &expr, pos, name)
+        .cloned()
+        .map(|mut meta| {
+            meta.definition.take();
+            meta
+        })
 }
 
 #[test]
@@ -373,7 +383,9 @@ abc
 "#;
     let result = get_metadata(text, BytePos::from(37));
 
-    let expected = None;
+    let expected = Some(Metadata {
+        ..Metadata::default()
+    });
     assert_eq!(result, expected);
 
     let result = get_metadata(text, BytePos::from(41));

--- a/format/tests/pretty_print.rs
+++ b/format/tests/pretty_print.rs
@@ -598,7 +598,7 @@ type Record = { x : Int }
 #[derive(Deserialize)]
 type Record = { x : Int }
 rec let deserialize_Record : Deserialize Record =
-    let { ValueDeserializer } = import! std.json.de
+    let { ValueDeserializer, deserializer, field, ? } = import! std.json.de
     let { map } = import! std.functor
     let { (<*>) } = import! std.applicative
     let { (<|>) } = import! std.alternative
@@ -620,7 +620,7 @@ type Record = { x : Int, y : Float }
 #[derive(Deserialize)]
 type Record = { x : Int, y : Float }
 rec let deserialize_Record : Deserialize Record =
-    let { ValueDeserializer } = import! std.json.de
+    let { ValueDeserializer, deserializer, field, ? } = import! std.json.de
     let { map } = import! std.functor
     let { (<*>) } = import! std.applicative
     let { (<|>) } = import! std.alternative
@@ -644,7 +644,8 @@ type Record = { x : Int }
 #[derive(Serialize)]
 type Record = { x : Int }
 rec let serialize_Record : Serialize Record =
-    let { ValueSerializer, Value, serialize } = import! std.json.ser
+    let { ? } = import! std.result
+    let { ValueSerializer, Value, serialize, ? } = import! std.json.ser
     let { map } = import! std.functor
     let { (<*>) } = import! std.applicative
     let { singleton, empty, ? } = import! std.map
@@ -671,7 +672,8 @@ type Variant =
     | Int Int
     | String String
 rec let serialize_Variant : Serialize Variant =
-    let { ValueSerializer, Value, serialize } = import! std.json.ser
+    let { ? } = import! std.result
+    let { ValueSerializer, Value, serialize, ? } = import! std.json.ser
     let { map } = import! std.functor
     let { (<*>) } = import! std.applicative
     let { singleton, empty, ? } = import! std.map

--- a/tests/pass/derive.glu
+++ b/tests/pass/derive.glu
@@ -1,7 +1,4 @@
-let prelude @ { Eq, Show } = import! std.prelude
-let { (<|) } = import! std.function
-let { Test, run, assert, assert_eq, assert_neq, test, group, ? } = import! std.test
-let { Applicative, (*>) } = import! std.applicative
+// Put these first to check that they don't depend on any imports used for the actual tests
 
 #[derive(Eq, Show)]
 type TestVariant =
@@ -27,6 +24,11 @@ type Mutual1 a = | Value a | Mutual2 Mutual2
 #[derive(Show, Eq)]
 type Mutual2 = { x : Int, mutual : Mutual1 String }
 in
+
+let prelude @ { Eq, Show } = import! std.prelude
+let { (<|) } = import! std.function
+let { Test, run, assert, assert_eq, assert_neq, test, group, ? } = import! std.test
+let { Applicative, (*>) } = import! std.applicative
 
 let eq_tests =
     let variant =

--- a/tests/pass/json/de.glu
+++ b/tests/pass/json/de.glu
@@ -1,13 +1,4 @@
-let result @ { Result, ? } = import! std.result
-let de @ { Deserializer, ValueDeserializer, Deserialize, field, deserializer, ? } = import! std.json.de
-let { Test, run, assert, assert_eq, test, group, ? }  = import! std.test
-let { Applicative, (*>) } = import! std.applicative
-let { map } = import! std.functor
-let { (<|) } = import! std.function
-let int = import! std.int
-let list @ { List, ? } = import! std.list
-let { ? } = import! std.array
-let { (<>) } = import! std.semigroup
+let { Deserialize } = import! std.json.de
 
 #[derive(Show, Eq, Deserialize)]
 type Record = { x : Int }
@@ -20,6 +11,17 @@ type Recursive = { record : Record, y : Float }
 
 #[derive(Show, Eq, Deserialize)]
 type Variant = | Int Int | String String
+
+let result @ { Result, ? } = import! std.result
+let de @ { Deserializer, ValueDeserializer, Deserialize, field, deserializer, ? } = import! std.json.de
+let { Test, run, assert, assert_eq, test, group, ? }  = import! std.test
+let { Applicative, (*>) } = import! std.applicative
+let { map } = import! std.functor
+let { (<|) } = import! std.function
+let int = import! std.int
+let list @ { List, ? } = import! std.list
+let { ? } = import! std.array
+let { (<>) } = import! std.semigroup
 
 group "json.de" [
     test "derive_record_1_field" <| \_ ->

--- a/tests/pass/json/ser.glu
+++ b/tests/pass/json/ser.glu
@@ -1,13 +1,4 @@
-let result @ { Result, ? } = import! std.result
-let ser @ { ValueSerializer, Serialize, ? } = import! std.json.ser
-let { Test, run, assert, assert_eq, test, group, ? }  = import! std.test
-let { Applicative, (*>) } = import! std.applicative
-let { map } = import! std.functor
-let { (<|) } = import! std.function
-let int = import! std.int
-let list @ { List, ? } = import! std.list
-let { ? } = import! std.array
-let { (<>) } = import! std.semigroup
+let { Serialize } = import! std.json.ser
 
 #[derive(Show, Eq, Serialize)]
 type Record = { x : Int }
@@ -20,6 +11,17 @@ type Variant = | MyInt Int | MyString String
 
 #[derive(Show, Eq, Serialize)]
 type MyOption a = | MyNone | MySome a
+
+let result @ { Result, ? } = import! std.result
+let ser @ { ValueSerializer, Serialize, ? } = import! std.json.ser
+let { Test, run, assert, assert_eq, test, group, ? }  = import! std.test
+let { Applicative, (*>) } = import! std.applicative
+let { map } = import! std.functor
+let { (<|) } = import! std.function
+let int = import! std.int
+let list @ { List, ? } = import! std.list
+let { ? } = import! std.array
+let { (<>) } = import! std.semigroup
 
 group "json.ser" [
     test "derive_record_1_field" <| \_ ->

--- a/vm/src/derive.rs
+++ b/vm/src/derive.rs
@@ -691,8 +691,14 @@ fn generate_deserialize(
         _ => return Err("Unable to derive Deserialize for this type".into()),
     };
 
-    let serialization_import =
-        generate_import(span, symbols, &["ValueDeserializer"], &[], "std.json.de");
+    let serialization_import = generate_import_(
+        span,
+        symbols,
+        &["ValueDeserializer"],
+        &["deserializer", "field"],
+        true,
+        "std.json.de",
+    );
     let functor_import = generate_import(span, symbols, &[], &["map"], "std.functor");
     let applicative_import = generate_import(span, symbols, &[], &["<*>"], "std.applicative");
     let alternative_import = generate_import(span, symbols, &[], &["<|>"], "std.alternative");
@@ -888,17 +894,19 @@ fn generate_serialize(
         _ => return Err("Unable to derive Deserialize for this type".into()),
     };
 
-    let serialization_import = generate_import(
+    let serialization_import = generate_import_(
         span,
         symbols,
         &["ValueSerializer", "Value"],
         &["serialize"],
+        true,
         "std.json.ser",
     );
     let functor_import = generate_import(span, symbols, &[], &["map"], "std.functor");
     let applicative_import = generate_import(span, symbols, &[], &["<*>"], "std.applicative");
     let map_import = generate_import_(span, symbols, &[], &["singleton", "empty"], true, "std.map");
     let semigroup_import = generate_import(span, symbols, &[], &["<>"], "std.semigroup");
+    let result_import = generate_import_(span, symbols, &[], &[], true, "std.result");
 
     let serialize_ = TypedIdent::new(symbols.symbol("serialize_"));
     let serializer_binding = ValueBinding {
@@ -928,6 +936,7 @@ fn generate_serialize(
     );
 
     let serializer_record_expr = vec![
+        result_import,
         serialization_import,
         functor_import,
         applicative_import,


### PR DESCRIPTION
This is important for generated code in `derive` so that it can write
its imports without worrying about the code outside of it.