### PR TITLE
test: Try to make rexpect tests more reliable

### DIFF
--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -14,6 +14,7 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 extern crate structopt;
+#[allow(unused_imports)]
 #[macro_use]
 extern crate structopt_derive;
 extern crate tokio;
@@ -141,17 +142,28 @@ const LONG_VERSION: &str = concat!(crate_version!(), "\n", "commit: ", env!("GIT
 pub struct Opt {
     #[structopt(short = "i", long = "interactive", help = "Starts the repl")]
     interactive: bool,
+
     #[structopt(
         long = "color",
         default_value = "auto",
         help = "Coloring: auto, always, always-ansi, never"
     )]
     color: Color,
+
+    #[structopt(
+        long = "prompt",
+        short = "p",
+        default_value = "> ",
+        help = "String printed as the prompt for the repl"
+    )]
+    prompt: String,
+
     #[structopt(
         name = "FILE",
         help = "Executes each file as a gluon program"
     )]
     input: Vec<String>,
+
     #[structopt(subcommand)]
     subcommand_opt: Option<SubOpt>,
 }
@@ -270,7 +282,8 @@ fn run(
         }
         None => if opt.interactive {
             let mut runtime = Runtime::new()?;
-            runtime.block_on(future::lazy(move || repl::run(color)))?;
+            let prompt = opt.prompt.clone();
+            runtime.block_on(future::lazy(move || repl::run(color, &prompt)))?;
         } else if !opt.input.is_empty() {
             run_files(compiler, &vm, &opt.input)?;
         } else {

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -167,7 +167,13 @@ let store line : String -> IO ReplAction =
         io.load_script binding expr *> wrap Continue
     | None -> io.println "Expected binding in definition" *> wrap Continue
 
-type Repl = { commands : Commands, editor : Editor, cpu_pool : CpuPool, color : Color }
+type Repl = {
+    commands : Commands,
+    editor : Editor,
+    cpu_pool : CpuPool,
+    color : Color,
+    prompt : String
+}
 
 let loop repl : Repl -> IO () =
     let run_line line =
@@ -182,7 +188,7 @@ let loop repl : Repl -> IO () =
                 repl_prim.finish_or_interrupt repl.cpu_pool eval_thread eval_action
             io.catch action io.println *> wrap Continue
 
-    do line_result = rustyline.readline repl.editor "> "
+    do line_result = rustyline.readline repl.editor repl.prompt
     match line_result with
     | Err Eof -> wrap ()
     | Err Interrupted -> loop repl
@@ -194,12 +200,12 @@ let loop repl : Repl -> IO () =
             do _ = rustyline.save_history repl.editor
             wrap ()
 
-let run color : Color -> IO () =
+let run color prompt : Color -> String -> IO () =
     do _ = io.println "gluon (:h for help, :q to quit)"
     do editor = rustyline.new_editor ()
     do cpu_pool = repl_prim.new_cpu_pool 1
     let commands = make_commands cpu_pool
-    let repl = { commands, editor, cpu_pool, color }
+    let repl = { commands, editor, cpu_pool, color, prompt }
     loop repl
 
 run

--- a/repl/tests/rexpect.rs
+++ b/repl/tests/rexpect.rs
@@ -22,16 +22,14 @@ impl REPL {
     /// Wraps a rexpect::session::PtySession. expecting the prompt after launch.
     fn new_() -> Result<REPL> {
         let timeout: u64 = 30_000;
+        let prompt: &'static str = "REXPECT> ";
 
         let mut command = Command::new("../target/debug/gluon");
         command
-            .arg("-i")
-            .arg("--color")
-            .arg("never")
+            .args(&["-i", "--color", "never", "--prompt", prompt])
             .env("GLUON_PATH", "..");
         let mut session = spawn_command(command, Some(timeout))?;
 
-        let prompt: &'static str = "> ";
         session.exp_string(prompt)?;
 
         Ok(REPL { session, prompt })


### PR DESCRIPTION
The flakiness may be because some output matches the prompt that is used
so set a unique one.

cc #625