### PR TITLE
Fix Type::variant call for VmType derive

### DIFF
--- a/codegen/src/vm_type.rs
+++ b/codegen/src/vm_type.rs
@@ -119,7 +119,7 @@ fn gen_impl(container: &Container, ident: Ident, generics: Generics, data: &Data
                     }}
                 });
                 quote!{
-                    _gluon_base::types::Type::variants(
+                    _gluon_base::types::Type::variant(
                         vec![#(#variants),*]
                     )
                 }

--- a/codegen/tests/derive_vm_type.rs
+++ b/codegen/tests/derive_vm_type.rs
@@ -27,6 +27,24 @@ fn struct_() {
 
 #[derive(VmType)]
 #[allow(unused)]
+enum Enum {
+    One,
+    Two(u32),
+    Three { id: String },
+}
+
+#[test]
+fn enum_() {
+    let vm = new_vm();
+
+    assert_eq!(
+        Enum::make_type(&vm).to_string(),
+        "| One\n| Two Int\n| Three String"
+    );
+}
+
+#[derive(VmType)]
+#[allow(unused)]
 struct Newtype(Struct);
 
 #[test]


### PR DESCRIPTION
Fixes `Type::variant` still being referred to as `Type::variants` in the `VmType` derive, which is currently broken for enums because of it.