### PR TITLE
Add global debugging status and decide whether to print out the contents of functions

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -108,3 +108,29 @@ pub fn filename_to_module(filename: &str) -> String {
 
     name.replace(|c: char| c == '/' || c == '\\', ".")
 }
+
+#[derive(Debug, Clone)]
+pub enum DebugLevel {
+    None,
+    Low,
+    High,
+}
+
+impl Default for DebugLevel {
+    fn default() -> DebugLevel {
+        DebugLevel::None
+    }
+}
+
+impl ::std::str::FromStr for DebugLevel {
+    type Err = &'static str;
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
+        use self::DebugLevel::*;
+        Ok(match s {
+            "none" => None,
+            "low" => Low,
+            "high" => High,
+            _ => return Err("Expected on of none, low, high"),
+        })
+    }
+}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -134,3 +134,14 @@ impl ::std::str::FromStr for DebugLevel {
         })
     }
 }
+
+impl ::std::string::ToString for DebugLevel {
+    fn to_string(&self) -> String {
+        use self::DebugLevel::*;
+        match self {
+            &None => "none".to_string(),
+            &Low => "low".to_string(),
+            &High => "high".to_string(),
+        }
+    }
+}

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -28,6 +28,8 @@ extern crate serde_derive_state;
 #[cfg(feature = "serde")]
 extern crate serde_state as serde;
 
+use std::fmt;
+
 macro_rules! type_cache {
     ($name: ident ($($args: ident),*) ($($arg: ident : $arg_type: ty),*) { $typ: ty, $inner_type: ident } $( $id: ident )+) => {
 
@@ -135,13 +137,17 @@ impl ::std::str::FromStr for DebugLevel {
     }
 }
 
-impl ::std::string::ToString for DebugLevel {
-    fn to_string(&self) -> String {
+impl fmt::Display for DebugLevel {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::DebugLevel::*;
-        match self {
-            &None => "none".to_string(),
-            &Low => "low".to_string(),
-            &High => "high".to_string(),
-        }
+        write!(
+            f,
+            "{}",
+            match self {
+                &None => "none",
+                &Low => "low",
+                &High => "high",
+            }
+        )
     }
 }

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -161,6 +161,13 @@ pub struct Opt {
     prompt: String,
 
     #[structopt(
+        long = "debug",
+        default_value = "none",
+        help = "Debug Level: none, low, high"
+    )]
+    debug_level: base::DebugLevel,
+
+    #[structopt(
         name = "FILE",
         help = "Executes each file as a gluon program"
     )]
@@ -247,6 +254,7 @@ fn run(
     color: Color,
     vm: &Thread,
 ) -> std::result::Result<(), gluon::Error> {
+    vm.global_env().set_debug_level(opt.debug_level.clone());
     match opt.subcommand_opt {
         Some(SubOpt::Fmt(ref fmt_opt)) => {
             if !fmt_opt.input.is_empty() {
@@ -287,7 +295,8 @@ fn run(
             if opt.interactive {
                 let mut runtime = Runtime::new()?;
                 let prompt = opt.prompt.clone();
-                runtime.block_on(future::lazy(move || repl::run(color, &prompt)))?;
+                let debug_level = opt.debug_level.clone();
+                runtime.block_on(future::lazy(move || repl::run(color, &prompt, debug_level)))?;
             } else if !opt.input.is_empty() {
                 run_files(compiler, &vm, &opt.input)?;
             } else {

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -110,6 +110,12 @@ let make_commands cpu_pool : CpuPool -> Commands =
             action = \arg -> run_file cpu_pool arg *> wrap Continue,
         },
         {
+            name = "debug",
+            alias = "d",
+            info = "Switch debug level",
+            action = \arg -> (repl_prim.switch_debug_level arg >>= print_result) *> wrap Continue,
+        },
+        {
             name = "help",
             alias = "h",
             info = "Print this help",

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -355,7 +355,7 @@ fn eval_line_(
                 let debug_level = vm.global_env().get_debug_level();
                 println!(
                     "{}",
-                    ValuePrinter::new(&*env, &typ, value.get_variant(), &*debug_level)
+                    ValuePrinter::new(&*env, &typ, value.get_variant(), &debug_level)
                         .width(80)
                         .max_level(5)
                 );

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -338,9 +338,10 @@ fn eval_line_(
             .map(move |ExecuteValue { value, typ, .. }| {
                 let vm = value.vm();
                 let env = vm.global_env().get_env();
+                let debug_level = vm.global_env().get_debug_level();
                 println!(
                     "{}",
-                    ValuePrinter::new(&*env, &typ, value.get_variant())
+                    ValuePrinter::new(&*env, &typ, value.get_variant(), &*debug_level)
                         .width(80)
                         .max_level(5)
                 );

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -19,6 +19,7 @@ use base::pos;
 use base::resolve;
 use base::symbol::{Symbol, SymbolModule};
 use base::types::ArcType;
+use base::DebugLevel;
 use parser::{parse_partial_repl_line, ReplLine};
 use vm::api::de::De;
 use vm::api::generic::A;
@@ -535,8 +536,10 @@ fn compile_repl(compiler: &mut Compiler, vm: &Thread) -> Result<(), GluonError> 
 pub fn run(
     color: Color,
     prompt: &str,
+    debug_level: DebugLevel,
 ) -> impl Future<Item = (), Error = Box<StdError + Send + Sync + 'static>> {
     let vm = ::gluon::VmBuilder::new().build();
+    vm.global_env().set_debug_level(debug_level);
 
     let mut compiler = Compiler::new();
     try_future!(

--- a/src/io.rs
+++ b/src/io.rs
@@ -198,7 +198,7 @@ fn run_expr(
                     let typ = execute_value.typ;
                     let debug_level = vm.global_env().get_debug_level();
                     IO::Value(record_no_decl!{
-                        value => ValuePrinter::new(&*env, &typ, execute_value.value.get_variant(), &*debug_level).width(80).to_string(),
+                        value => ValuePrinter::new(&*env, &typ, execute_value.value.get_variant(), &debug_level).width(80).to_string(),
                         typ => typ.to_string()
                     })
                 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -196,8 +196,9 @@ fn run_expr(
                 Ok(execute_value) => {
                     let env = vm.global_env().get_env();
                     let typ = execute_value.typ;
+                    let debug_level = vm.global_env().get_debug_level();
                     IO::Value(record_no_decl!{
-                        value => ValuePrinter::new(&*env, &typ, execute_value.value.get_variant()).width(80).to_string(),
+                        value => ValuePrinter::new(&*env, &typ, execute_value.value.get_variant(), &*debug_level).width(80).to_string(),
                         typ => typ.to_string()
                     })
                 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -13,6 +13,7 @@ use base::symbol::{Name, Symbol, SymbolRef};
 use base::types::{
     Alias, AliasData, AppVec, ArcType, Generic, PrimitiveEnv, Type, TypeCache, TypeEnv,
 };
+use base::DebugLevel;
 
 use api::{ValueRef, IO};
 use compiler::{CompiledFunction, CompiledModule, CompilerEnv, Variable};
@@ -170,6 +171,9 @@ pub struct GlobalVmState {
     // thread
     #[cfg_attr(feature = "serde_derive", serde(state))]
     pub generation_0_threads: RwLock<Vec<GcPtr<Thread>>>,
+
+    #[cfg_attr(feature = "serde_derive", serde(skip))]
+    debug_level: RwLock<DebugLevel>,
 }
 
 impl Traverseable for GlobalVmState {
@@ -409,6 +413,7 @@ impl GlobalVmStateBuilder {
             macros: MacroEnv::new(),
             type_cache: TypeCache::default(),
             generation_0_threads: RwLock::new(Vec::new()),
+            debug_level: RwLock::new(DebugLevel::default()),
         };
         vm.add_types().unwrap();
         vm
@@ -582,5 +587,13 @@ impl GlobalVmState {
     /// Returns a borrowed structure which implements `CompilerEnv`
     pub fn get_env<'b>(&'b self) -> RwLockReadGuard<'b, VmEnv> {
         self.env.read().unwrap()
+    }
+
+    pub fn get_debug_level<'b>(&'b self) -> RwLockReadGuard<'b, DebugLevel> {
+        self.debug_level.read().unwrap()
+    }
+
+    pub fn set_debug_level(&self, debug_level: DebugLevel) {
+        *self.debug_level.write().unwrap() = debug_level;
     }
 }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -589,8 +589,8 @@ impl GlobalVmState {
         self.env.read().unwrap()
     }
 
-    pub fn get_debug_level<'b>(&'b self) -> RwLockReadGuard<'b, DebugLevel> {
-        self.debug_level.read().unwrap()
+    pub fn get_debug_level(&self) -> DebugLevel {
+        self.debug_level.read().unwrap().clone()
     }
 
     pub fn set_debug_level(&self, debug_level: DebugLevel) {


### PR DESCRIPTION
Fixes #467.
In this PR, a general purpose global debugging status is added to GlobalVmState, and it is decided whether to print out the contents of functions based on the state.