### PR TITLE
refactor(all): use shorthand fields

### DIFF
--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -464,7 +464,7 @@ impl<'a> Typecheck<'a> {
             .stack
             .insert(non_renamed_symbol, StackBinding { typ: typ.clone() });
 
-        self.environment.stack.insert(id, StackBinding { typ: typ });
+        self.environment.stack.insert(id, StackBinding { typ });
     }
 
     fn stack_type(&mut self, id: Symbol, alias: &Alias<Symbol, ArcType>) {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -278,7 +278,7 @@ impl<'a, I> Clone for SharedIter<'a, I> {
 
 impl<'a, I> SharedIter<'a, I> {
     fn new(iter: &'a RefCell<I>) -> SharedIter<'a, I> {
-        SharedIter { iter: iter }
+        SharedIter { iter }
     }
 }
 

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -749,7 +749,7 @@ struct Enum<'a, 'de: 'a, 't: 'a> {
 
 impl<'a, 'de, 't> Enum<'a, 'de, 't> {
     fn new(de: &'a mut Deserializer<'de, 't>) -> Self {
-        Enum { de: de }
+        Enum { de }
     }
 }
 

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -266,7 +266,7 @@ impl AllocPtr {
                         marked: Cell::new(false),
                     },
                 );
-                AllocPtr { ptr: ptr }
+                AllocPtr { ptr }
             }
         }
         debug_assert!(mem::align_of::<T>() <= mem::align_of::<f64>());
@@ -412,7 +412,7 @@ impl<T: ?Sized> GcPtr<T> {
 
     /// Unsafe as `ptr` must have been allocted by this garbage collector
     pub unsafe fn from_raw(ptr: *const T) -> GcPtr<T> {
-        GcPtr { ptr: ptr }
+        GcPtr { ptr }
     }
 
     pub fn generation(&self) -> Generation {

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -393,7 +393,7 @@ impl Stack {
                 })),
                 State::Unknown => Some(None),
             }).collect();
-        Stacktrace { frames: frames }
+        Stacktrace { frames }
     }
 }
 


### PR DESCRIPTION
a simple refactor to use shorthand fields where possible