### PR TITLE
fix(std): fix a couple mistakes in a couple std modules

### DIFF
--- a/std/foldable.glu
+++ b/std/foldable.glu
@@ -49,7 +49,7 @@ let all pred : [Foldable t] -> (a -> Bool) -> t a -> Bool =
 let any pred : [Foldable t] -> (a -> Bool) -> t a -> Bool =
     foldl (\acc x -> acc || pred x) False
 
-let elem eq x : [Foldable t] -> Eq a -> a -> t a -> Bool =
+let elem eq x : [Foldable t] -> [Eq a] -> a -> t a -> Bool =
     any (eq.(==) x)
 
 let count : [Foldable t] -> t a -> Int =

--- a/std/foldable.glu
+++ b/std/foldable.glu
@@ -49,8 +49,8 @@ let all pred : [Foldable t] -> (a -> Bool) -> t a -> Bool =
 let any pred : [Foldable t] -> (a -> Bool) -> t a -> Bool =
     foldl (\acc x -> acc || pred x) False
 
-let elem eq x : [Foldable t] -> [Eq a] -> a -> t a -> Bool =
-    any (eq.(==) x)
+let elem x : [Foldable t] -> [Eq a] -> a -> t a -> Bool =
+    any ((==) x)
 
 let count : [Foldable t] -> t a -> Int =
     foldl (\acc _ -> acc #Int+ 1) 0

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -273,6 +273,7 @@ let parse p input : Parser a -> String -> Result String a =
     satisfy_map,
     spaces,
     take1,
+    take,
     lazy_parser,
     fail,
     recognize,


### PR DESCRIPTION
Added `take` to `std.parser` exports and made second parameter of `std.foldable.elem` implicit