### PR TITLE
chore: Let cargo test work out of the box

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ web = ["hyper", "http", "native-tls", "tokio-tcp", "tokio-tls"]
 
 docs_rs = ["serialization"]
 
-test = ["serialization", "little-skeptic", "http", "web", "gluon_vm/test", "gluon_check/test", "gluon_parser/test"]
+test = ["serialization", "little-skeptic", "http", "web", "gluon_vm/test"]
 nightly = ["compiletest_rs"]
 test_nightly = ["test", "nightly"]
 

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -32,11 +32,9 @@ gluon_parser = { path = "../parser", version = "0.9.4", optional = true } # GLUO
 [dev-dependencies]
 env_logger = "0.6"
 
+gluon_parser = { path = "../parser", version = "0.9.4" } # GLUON
 gluon_format = { path = "../format", version = ">=0.9" }
 
 collect-mac = "0.1.0"
 pretty_assertions = "0.5"
-
-[features]
-test = ["gluon_parser"]
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -31,6 +31,3 @@ pretty_assertions = "0.5"
 
 [build-dependencies]
 lalrpop = "0.16"
-
-[features]
-test = []

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -487,14 +487,6 @@ where
     }
 }
 
-#[cfg(feature = "test")]
-pub fn parse_string<'env, 'input>(
-    symbols: &'env mut IdentEnv<Ident = String>,
-    input: &'input str,
-) -> Result<SpannedExpr<String>, (Option<SpannedExpr<String>>, ParseErrors)> {
-    parse_partial_expr(symbols, &TypeCache::default(), input)
-}
-
 pub fn reparse_infix<Id>(
     metadata: &FnvMap<Id, Metadata>,
     symbols: &IdentEnv<Ident = Id>,

--- a/parser/tests/indentation.rs
+++ b/parser/tests/indentation.rs
@@ -6,8 +6,8 @@ extern crate gluon_parser as parser;
 mod support;
 
 use base::ast::*;
-use parser::{parse_string, ParseErrors};
-use support::MockEnv;
+use parser::ParseErrors;
+use support::*;
 
 fn parse(text: &str) -> Result<SpannedExpr<String>, ParseErrors> {
     parse_string(&mut MockEnv::new(), text).map_err(|(_, err)| err)

--- a/parser/tests/stack_overflow.rs
+++ b/parser/tests/stack_overflow.rs
@@ -4,8 +4,8 @@ extern crate gluon_base as base;
 extern crate gluon_parser as parser;
 
 use base::ast::SpannedExpr;
-use parser::{parse_string, ParseErrors};
-use support::MockEnv;
+use parser::ParseErrors;
+use support::*;
 
 mod support;
 

--- a/parser/tests/support/mod.rs
+++ b/parser/tests/support/mod.rs
@@ -2,20 +2,25 @@
 
 pub extern crate codespan;
 
-use base::ast::{
-    walk_mut_alias, walk_mut_ast_type, walk_mut_expr, walk_mut_pattern, Alternative, Argument,
-    Array, AstType, DisplayEnv, Expr, ExprField, IdentEnv, Lambda, Literal, MutVisitor, Pattern,
-    SpannedAlias, SpannedAstType, SpannedExpr, SpannedIdent, SpannedPattern, TypeBinding,
-    TypedIdent, ValueBinding,
-};
-use base::error::Errors;
-use base::kind::Kind;
-use base::metadata::{Comment, CommentType, Metadata};
-use base::pos::{self, BytePos, Span, Spanned};
-use base::types::{Alias, AliasData, ArcType, Field, Generic, Type};
-use parser::infix::{Fixity, OpMeta, OpTable, Reparser};
-use parser::{parse_string, Error, ParseErrors};
 use std::marker::PhantomData;
+
+use base::{
+    ast::{
+        walk_mut_alias, walk_mut_ast_type, walk_mut_expr, walk_mut_pattern, Alternative, Argument,
+        Array, AstType, DisplayEnv, Expr, ExprField, IdentEnv, Lambda, Literal, MutVisitor,
+        Pattern, SpannedAlias, SpannedAstType, SpannedExpr, SpannedIdent, SpannedPattern,
+        TypeBinding, TypedIdent, ValueBinding,
+    },
+    error::Errors,
+    kind::Kind,
+    metadata::{Comment, CommentType, Metadata},
+    pos::{self, BytePos, Span, Spanned},
+    types::{Alias, AliasData, ArcType, Field, Generic, Type, TypeCache},
+};
+use parser::{
+    infix::{Fixity, OpMeta, OpTable, Reparser},
+    {parse_partial_expr, Error, ParseErrors},
+};
 
 pub struct MockEnv<T>(PhantomData<T>);
 
@@ -79,6 +84,13 @@ where
         s.span = (self.0)(s.span);
         walk_mut_ast_type(self, s);
     }
+}
+
+pub fn parse_string<'env, 'input>(
+    symbols: &'env mut IdentEnv<Ident = String>,
+    input: &'input str,
+) -> Result<SpannedExpr<String>, (Option<SpannedExpr<String>>, ParseErrors)> {
+    parse_partial_expr(symbols, &TypeCache::default(), input)
 }
 
 pub fn parse(

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -2,7 +2,7 @@
 use base::{
     scoped_map::ScopedMap,
     symbol::{Symbol, Symbols},
-    types::{self, ArcType, Field, Type},
+    types::{self, ArcType, Type},
 };
 use {
     forget_lifetime,

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -1113,7 +1113,7 @@ impl<'a> Compiler<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test"))]
 mod tests {
     use super::*;
 

--- a/vm/src/core/interpreter.rs
+++ b/vm/src/core/interpreter.rs
@@ -752,7 +752,7 @@ impl<'a, 'e> Compiler<'a, 'e> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test"))]
 mod tests {
     use super::*;
 

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -27,7 +27,7 @@ macro_rules! assert_deq {
     });
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test"))]
 lalrpop_mod!(
     #[cfg_attr(rustfmt, rustfmt_skip)]
     pub grammar,
@@ -1674,7 +1674,7 @@ impl<'a> ExactSizeIterator for PatternIdentifiers<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test"))]
 mod tests {
     extern crate gluon_parser as parser;
 

--- a/vm/src/core/optimize.rs
+++ b/vm/src/core/optimize.rs
@@ -321,7 +321,7 @@ where
     })
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test"))]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
`cargo test --all --features test` is still necessary to run all tests but this will at least run most of them.