### PR TITLE
fix(check): Abort implicit checking immediately on infinite loops

### DIFF
--- a/check/src/substitution.rs
+++ b/check/src/substitution.rs
@@ -5,8 +5,7 @@ use std::fmt;
 use union_find::{QuickFindUf, Union, UnionByRank, UnionFind, UnionResult};
 
 use crate::base::fixed::{FixedMap, FixedVec};
-use crate::base::types;
-use crate::base::types::{ArcType, Type, Walker};
+use crate::base::types::{self, ArcType, Type, Walker};
 
 #[derive(Debug, PartialEq)]
 pub enum Error<T> {
@@ -396,5 +395,17 @@ impl<T: Substitutable + PartialEq + Clone> Substitution<T> {
             }
         }
         Ok(resolved_type.cloned())
+    }
+}
+
+impl Substitution<ArcType> {
+    pub fn zonk(&self, typ: &ArcType) -> ArcType {
+        types::walk_move_type(typ.clone(), &mut |typ| match typ.get_var() {
+            Some(var) => match self.find_type_for_var(var.get_id()) {
+                Some(t) => Some(self.zonk(t)),
+                None => None,
+            },
+            None => None,
+        })
     }
 }

--- a/check/tests/implicits.rs
+++ b/check/tests/implicits.rs
@@ -872,3 +872,22 @@ f 1
 
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
+
+test_check_err! {
+break_infinte_implicit_resolve_early,
+    r#"
+#[implicit]
+type Implicit a = { f : a -> String } 
+
+type Test a = { x : a }
+
+let any x = any x
+
+let test : [Implicit a] -> Implicit (Test a) = any ()
+
+let f : [Implicit a] -> a -> () = any ()
+
+f (any ())
+"#,
+TypeError::Unification(..)
+}

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -6,9 +6,10 @@ extern crate codespan;
 use crate::base::{
     self,
     ast::{DisplayEnv, Expr, IdentEnv, SpannedExpr},
-    error::InFile,
+    error::{Errors, InFile},
     kind::{ArcKind, Kind, KindEnv},
     metadata::{Metadata, MetadataEnv},
+    pos::{BytePos, Spanned},
     symbol::{Symbol, SymbolModule, SymbolRef, Symbols},
     types::{self, Alias, ArcType, Field, Generic, PrimitiveEnv, Type, TypeCache, TypeEnv},
 };
@@ -20,7 +21,7 @@ use crate::check::{
     typecheck::{self, Typecheck},
 };
 
-use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+use std::{cell::RefCell, fmt, marker::PhantomData, rc::Rc};
 
 quick_error! {
     /// Representation of all possible errors that can occur when interacting with the `vm` crate
@@ -169,6 +170,15 @@ where
     }
 }
 
+pub(crate) fn in_file_error<E>(text: &str, errors: Errors<Spanned<E, BytePos>>) -> InFile<E>
+where
+    E: fmt::Display,
+{
+    let mut source = codespan::CodeMap::new();
+    source.add_filemap("test".into(), text.into());
+    InFile::new(source, errors)
+}
+
 pub fn typecheck_expr_expected(
     text: &str,
     expected: Option<&ArcType>,
@@ -176,9 +186,7 @@ pub fn typecheck_expr_expected(
     let mut expr = match parse_new(text) {
         Ok(expr) => expr,
         Err((expr, err)) => {
-            let mut source = codespan::CodeMap::new();
-            source.add_filemap("test".into(), text.into());
-            let err = InFile::new(source, err);
+            let err = in_file_error(text, err);
             return (expr.unwrap_or_else(|| panic!("{}", err)), Err(err.into()));
         }
     };
@@ -204,14 +212,7 @@ pub fn typecheck_expr_expected(
 
     let result = tc.typecheck_expr_expected(&mut expr, expected);
 
-    (
-        expr,
-        result.map_err(|err| {
-            let mut source = codespan::CodeMap::new();
-            source.add_filemap("test".into(), text.into());
-            InFile::new(source, err).into()
-        }),
-    )
+    (expr, result.map_err(|err| in_file_error(text, err).into()))
 }
 
 pub fn typecheck_expr(text: &str) -> (SpannedExpr<Symbol>, Result<ArcType, Error>) {
@@ -252,14 +253,7 @@ pub fn typecheck_partial_expr(
 
     let result = tc.typecheck_expr(&mut expr);
 
-    (
-        expr,
-        result.map_err(|err| {
-            let mut source = codespan::CodeMap::new();
-            source.add_filemap("test".into(), text.into());
-            InFile::new(source, err)
-        }),
-    )
+    (expr, result.map_err(|err| in_file_error(text, err)))
 }
 
 #[allow(dead_code)]
@@ -402,13 +396,16 @@ macro_rules! test_check_err {
             let _ = env_logger::try_init();
             let text = $source;
             let result = support::typecheck(text);
-            assert_err!(result, $($id),+);
+            assert_err!([$source] result, $($id),+);
         }
     };
 }
 
 macro_rules! assert_err {
-    ($e: expr, $($id: pat),+) => {{
+    ($e: expr, $($id: pat),+) => {
+        assert_err!([""] $e, $($id),+)
+    };
+    ([$text: expr] $e: expr, $($id: pat),+) => {{
         #[allow(unused_imports)]
         use crate::check::{
             typecheck::TypeError::*,
@@ -428,8 +425,23 @@ macro_rules! assert_err {
                 $(
                 match iter.next() {
                     Some(&crate::base::pos::Spanned { value: crate::base::error::Help { error: $id, .. }, .. }) => (),
-                    _ => assert!(false, "Found errors:\n{}\nbut expected {}",
-                                        errors, stringify!($id)),
+                    _ => {
+                        if $text.is_empty() {
+                            assert!(
+                                false,
+                                "Found errors:\n{}\nbut expected {}",
+                                errors,
+                                stringify!($id)
+                            )
+                        } else {
+                            assert!(
+                                false,
+                                "Found errors:\n{}\nbut expected {}",
+                                crate::support::in_file_error($text, errors),
+                                stringify!($id)
+                            )
+                        }
+                    }
                 }
                 )+
                 assert!(iter.count() == 0, "Found more errors than expected\n{}", errors);


### PR DESCRIPTION
There may be some quirks to workout but everything in the gluon repo
itself works fine. This avoids the huge error messages generated when
implicit resolution ends up in an infinite loop.