### PR TITLE
fix(check): The alias reduction stack must be cleared between unifyin…

### DIFF
--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -1033,3 +1033,30 @@ x
     "#,
     "test.Test2 String"
 }
+
+test_check! {
+    alias_reduction_stack_must_be_cleared_between_function_arguments,
+    r#"
+type StateT s m a = s -> m { value : a, state : s }
+
+#[implicit]
+type Alternative f = {
+    or : forall a . f a -> f a -> f a,
+}
+
+let any x = any x
+
+#[infix(left, 4)]
+let (<*>) : f (a -> b) -> f a -> f b = any ()
+
+#[infix(right, 9)]
+let (<<) : (b -> c) -> (a -> b) -> a -> c = any ()
+
+let alternative ?alt : [Alternative m] -> Alternative (StateT s m) = 
+    let or sra srb = alt.or << sra <*> srb
+    { or }
+
+()
+    "#,
+    "()"
+}


### PR DESCRIPTION
…g function arguments

Otherwise spurious errors about illegal self recursion would be triggered as it looks like we are reducing the same alias twice.

Found in #686

cc @Etherian