### PR TITLE
fix: Ignore mdbook for osx builds

### DIFF
--- a/scripts/install_mdbook.sh
+++ b/scripts/install_mdbook.sh
@@ -3,7 +3,7 @@
 set -ex
 
 if [[ $1 == *"apple"* ]]; then
-    TARGET=$1
+    exit 0
 else
     TARGET='x86_64-unknown-linux-musl'
 fi


### PR DESCRIPTION
mdbook does not provide binaries for osx (and we dont need to use mdbook on osx)