### PR TITLE
Version 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+<a name="v0.11.2"></a>
+### v0.11.2 (2019-03-26)
+
+
+#### Features
+
+* **doc:**  Don't display the full path to types in the documentation ([a669faaa](https://github.com/gluon-lang/gluon/commit/a669faaadadd388e23d36393204820d73316cbf5))
+
+#### Bug Fixes
+
+*   Ignore mdbook for osx builds ([7755967a](https://github.com/gluon-lang/gluon/commit/7755967ad5e3defb5a1d1b1c10ce920ec030556d))
+* **check:**  The alias reduction stack must be cleared between unifying function arguments ([170072a4](https://github.com/gluon-lang/gluon/commit/170072a4734d4ec27c97c307aae7dc5b7d181dcc))
+* **doc:**
+  *  Correct all the remaining links in docs ([494675fe](https://github.com/gluon-lang/gluon/commit/494675fe3dbfc229c795ed3b076ce0c87c7297a1))
+  *  Point breadcrumb links correctly ([2a9cca72](https://github.com/gluon-lang/gluon/commit/2a9cca7282a74bd13851a25f88f2b04d398f2dbe))
+  *  Point Rust defined types to their doc location ([b170f2f3](https://github.com/gluon-lang/gluon/commit/b170f2f3a2bd9b8a33ca4eb7620ea0e7f2a26784))
+  *  Don't generate dead links in the documentation ([04131b71](https://github.com/gluon-lang/gluon/commit/04131b71176bc824cee956aa431ab84063d98861))
+  *  Point sibling module links correctly ([3bbf4a99](https://github.com/gluon-lang/gluon/commit/3bbf4a9927ef2060707bf8345cf028f6a03df658))
+
+
+
 <a name="v0.11.1"></a>
 ### v0.11.1 (2019-02-13)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gluon"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -659,13 +659,13 @@ dependencies = [
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon_base 0.11.1",
- "gluon_check 0.11.1",
- "gluon_codegen 0.11.1",
- "gluon_completion 0.11.1",
- "gluon_format 0.11.1",
- "gluon_parser 0.11.1",
- "gluon_vm 0.11.1",
+ "gluon_base 0.11.2",
+ "gluon_check 0.11.2",
+ "gluon_codegen 0.11.2",
+ "gluon_completion 0.11.2",
+ "gluon_format 0.11.2",
+ "gluon_parser 0.11.2",
+ "gluon_vm 0.11.2",
  "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_base"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anymap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -720,25 +720,25 @@ dependencies = [
 
 [[package]]
 name = "gluon_c-api"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
- "gluon 0.11.1",
+ "gluon 0.11.2",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gluon_check"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "codespan 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "collect-mac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon_base 0.11.1",
- "gluon_codegen 0.11.1",
- "gluon_format 0.11.1",
- "gluon_parser 0.11.1",
+ "gluon_base 0.11.2",
+ "gluon_codegen 0.11.2",
+ "gluon_format 0.11.2",
+ "gluon_parser 0.11.2",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -753,11 +753,11 @@ dependencies = [
 
 [[package]]
 name = "gluon_codegen"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon 0.11.1",
- "gluon_vm 0.11.1",
+ "gluon 0.11.2",
+ "gluon_vm 0.11.2",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -767,27 +767,27 @@ dependencies = [
 
 [[package]]
 name = "gluon_completion"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "codespan 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "collect-mac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon_base 0.11.1",
- "gluon_check 0.11.1",
- "gluon_parser 0.11.1",
+ "gluon_base 0.11.2",
+ "gluon_check 0.11.2",
+ "gluon_parser 0.11.2",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gluon_doc"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon 0.11.1",
+ "gluon 0.11.2",
  "handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,13 +806,13 @@ dependencies = [
 
 [[package]]
 name = "gluon_format"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "codespan 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon 0.11.1",
- "gluon_base 0.11.1",
+ "gluon 0.11.2",
+ "gluon_base 0.11.2",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -821,14 +821,14 @@ dependencies = [
 
 [[package]]
 name = "gluon_parser"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "codespan 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan-reporting 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "collect-mac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon_base 0.11.1",
+ "gluon_base 0.11.2",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_repl"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -850,12 +850,12 @@ dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon 0.11.1",
- "gluon_codegen 0.11.1",
- "gluon_completion 0.11.1",
- "gluon_doc 0.11.1",
- "gluon_format 0.11.1",
- "gluon_vm 0.11.1",
+ "gluon 0.11.2",
+ "gluon_codegen 0.11.2",
+ "gluon_completion 0.11.2",
+ "gluon_doc 0.11.2",
+ "gluon_format 0.11.2",
+ "gluon_vm 0.11.2",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_vm"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,11 +880,11 @@ dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "frunk_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "gluon 0.11.1",
- "gluon_base 0.11.1",
- "gluon_check 0.11.1",
- "gluon_codegen 0.11.1",
- "gluon_parser 0.11.1",
+ "gluon 0.11.2",
+ "gluon_base 0.11.2",
+ "gluon_check 0.11.2",
+ "gluon_codegen 0.11.2",
+ "gluon_parser 0.11.2",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 build = "build.rs"
 edition = "2018"
@@ -22,12 +22,12 @@ name = "gluon"
 path = "src/lib.rs"
 
 [dependencies]
-gluon_base = { path = "base", version = "0.11.1" } # GLUON
-gluon_check = { path = "check", version = "0.11.1" } # GLUON
-gluon_parser = { path = "parser", version = "0.11.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.11.1" } # GLUON
-gluon_vm = { path = "vm", version = "0.11.1", default-features = false } # GLUON
-gluon_format = { path = "format", version = "0.11.1", default-features = false } # GLUON
+gluon_base = { path = "base", version = "0.11.2" } # GLUON
+gluon_check = { path = "check", version = "0.11.2" } # GLUON
+gluon_parser = { path = "parser", version = "0.11.2" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.11.2" } # GLUON
+gluon_vm = { path = "vm", version = "0.11.2", default-features = false } # GLUON
+gluon_format = { path = "format", version = "0.11.2", default-features = false } # GLUON
 
 log = "0.4"
 quick-error = "1.0.0"
@@ -59,7 +59,7 @@ rand = { version = "0.6", optional = true }
 rand_xorshift = { version = "0.1", optional = true }
 
 [build-dependencies]
-gluon_base = { path = "base", version = "0.11.1" } # GLUON
+gluon_base = { path = "base", version = "0.11.2" } # GLUON
 
 itertools = "0.8"
 little-skeptic = { version = "0.15.0", optional = true }
@@ -87,8 +87,8 @@ bincode = "1"
 
 pulldown-cmark = "0.2"
 
-gluon_completion = { path = "completion", version = "0.11.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.11.1" } # GLUON
+gluon_completion = { path = "completion", version = "0.11.2" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.11.2" } # GLUON
 
 [features]
 default = ["regex", "random"]

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Gluon requires a recent Rust compiler to build (1.9.0 or later) and is available
 
 ```toml
 [dependencies]
-gluon = "0.11.1"
+gluon = "0.11.2"
 ```
 
 ### Other languages

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_base"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/gluon_base/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_base/0.11.2")] // # GLUON
 #![allow(unknown_lints)]
 //! The base crate contains pervasive types used in the compiler such as type representations, the
 //! AST and some basic containers.

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_c-api"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ documentation = "https://docs.rs/gluon"
 crate-type = ["cdylib"]
 
 [dependencies]
-gluon = { version = "0.11.1", path = ".." } # GLUON
+gluon = { version = "0.11.2", path = ".." } # GLUON
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc = "0.2.14"

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,5 +1,5 @@
 //! A (WIP) C API allowing use of gluon in other langauges than Rust.
-#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.11.2")] // # GLUON
 
 extern crate gluon;
 #[cfg(not(target_arch = "wasm32"))]

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_check"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -27,13 +27,13 @@ codespan-reporting = "0.2"
 
 strsim = "0.8.0"
 
-gluon_base = { path = "../base", version = "0.11.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.11.1" } # GLUON
+gluon_base = { path = "../base", version = "0.11.2" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.11.2" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.6"
 
-gluon_parser = { path = "../parser", version = "0.11.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.11.2" } # GLUON
 gluon_format = { path = "../format", version = ">=0.9" }
 
 collect-mac = "0.1.0"

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -3,7 +3,7 @@
 //! If an AST passes the checks in `Typecheck::typecheck_expr` (which runs all of theses checks
 //! the expression is expected to compile succesfully (if it does not it should be considered an
 //! internal compiler error.
-#![doc(html_root_url = "https://docs.rs/gluon_check/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_check/0.11.2")] // # GLUON
 
 extern crate codespan;
 extern crate codespan_reporting;

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_codegen"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 
 license = "MIT"

--- a/completion/Cargo.toml
+++ b/completion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_completion"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,11 +17,11 @@ itertools = "0.8"
 walkdir = "2"
 codespan = "0.2"
 
-gluon_base = { path = "../base", version = "0.11.1" } # GLUON
+gluon_base = { path = "../base", version = "0.11.2" } # GLUON
 
 [dev-dependencies]
 collect-mac = "0.1.0"
 env_logger = "0.6"
 
-gluon_check = { path = "../check", version = "0.11.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.11.1" } # GLUON
+gluon_check = { path = "../check", version = "0.11.2" } # GLUON
+gluon_parser = { path = "../parser", version = "0.11.2" } # GLUON

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -1,5 +1,5 @@
 //! Primitive auto completion and type quering on ASTs
-#![doc(html_root_url = "https://docs.rs/gluon_completion/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_completion/0.11.2")] // # GLUON
 
 extern crate codespan;
 extern crate either;

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_doc"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -31,7 +31,7 @@ serde = "1.0.0"
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 
-gluon = { version = "0.11.1", path = ".." } # GLUON
+gluon = { version = "0.11.2", path = ".." } # GLUON
 
 
 [dev-dependencies]

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_format"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,13 +17,13 @@ pretty = "0.5"
 itertools = "0.8"
 codespan = "0.2"
 
-gluon_base = { path = "../base", version = "0.11.1" } # GLUON
+gluon_base = { path = "../base", version = "0.11.2" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.6"
 difference = "2"
 pretty_assertions = "0.5"
-gluon_base = { path = "../base", version = "0.11.1" } # GLUON
+gluon_base = { path = "../base", version = "0.11.2" } # GLUON
 gluon = { path = "..", version = ">=0.9" }
 
 [features]

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,5 +1,5 @@
 //! Code formatter.
-#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.11.2")] // # GLUON
 
 extern crate codespan;
 #[macro_use]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_parser"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -20,7 +20,7 @@ quick-error = "1.0.0"
 lalrpop-util = "0.16"
 log = "0.4"
 pretty = "0.5"
-gluon_base = { path = "../base", version = "0.11.1" } # GLUON
+gluon_base = { path = "../base", version = "0.11.2" } # GLUON
 ordered-float = "1"
 codespan = "0.2"
 codespan-reporting = "0.2"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,7 +1,7 @@
 //! The parser is a bit more complex than it needs to be as it needs to be fully specialized to
 //! avoid a recompilation every time a later part of the compiler is changed. Due to this the
 //! string interner and therefore also garbage collector needs to compiled before the parser.
-#![doc(html_root_url = "https://docs.rs/gluon_parser/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_parser/0.11.2")] // # GLUON
 
 extern crate codespan;
 extern crate codespan_reporting;

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_repl"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,12 +17,12 @@ doc = false
 
 [dependencies]
 
-gluon = { version = "0.11.1", path = "..", features = ["serialization"] } # GLUON
-gluon_vm = { version = "0.11.1", path = "../vm", features = ["serialization"] } # GLUON
-gluon_completion = { path = "../completion", version = "0.11.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.11.1" } # GLUON
-gluon_format = { version = "0.11.1", path = "../format" } # GLUON
-gluon_doc = { version = "0.11.1", path = "../doc" } # GLUON
+gluon = { version = "0.11.2", path = "..", features = ["serialization"] } # GLUON
+gluon_vm = { version = "0.11.2", path = "../vm", features = ["serialization"] } # GLUON
+gluon_completion = { path = "../completion", version = "0.11.2" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.11.2" } # GLUON
+gluon_format = { version = "0.11.2", path = "../format" } # GLUON
+gluon_doc = { version = "0.11.2", path = "../doc" } # GLUON
 
 app_dirs = "1.0.0"
 futures = "0.1.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! behaviour. For information about how to use this library the best resource currently is the
 //! [tutorial](http://gluon-lang.org/book/index.html) which contains examples
 //! on how to write gluon programs as well as how to run them using this library.
-#![doc(html_root_url = "https://docs.rs/gluon/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon/0.11.2")] // # GLUON
 
 #[cfg(test)]
 extern crate env_logger;

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_vm"
-version = "0.11.1" # GLUON
+version = "0.11.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -33,9 +33,9 @@ serde_state = { version = "0.4.0", optional = true }
 serde_derive = { version = "1.0.0", optional = true }
 serde_derive_state = { version = "0.4.0", optional = true }
 
-gluon_base = { path = "../base", version = "0.11.1" } # GLUON
-gluon_check = { path = "../check", version = "0.11.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.11.1" } # GLUON
+gluon_base = { path = "../base", version = "0.11.2" } # GLUON
+gluon_check = { path = "../check", version = "0.11.2" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.11.2" } # GLUON
 
 [build-dependencies]
 lalrpop = { version = "0.16", optional = true }
@@ -52,7 +52,7 @@ lalrpop-util = "0.16"
 regex = "1"
 serde_json = "1.0.0"
 
-gluon_parser = { path = "../parser", version = "0.11.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.11.2" } # GLUON
 
 [features]
 serialization = ["serde", "serde_state", "serde_derive", "serde_derive_state", "serde_json", "gluon_base/serialization", "codespan/serialization"]

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,5 +1,5 @@
 //! Crate which contain the virtual machine which executes gluon programs
-#![doc(html_root_url = "https://docs.rs/gluon_vm/0.11.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_vm/0.11.2")] // # GLUON
 #![recursion_limit = "1024"]
 
 #[macro_use]


### PR DESCRIPTION
<a name="v0.11.2"></a>
### v0.11.2 (2019-03-26)

#### Features

* **doc:**  Don't display the full path to types in the documentation ([a669faaa](https://github.com/gluon-lang/gluon/commit/a669faaadadd388e23d36393204820d73316cbf5))

#### Bug Fixes

*   Ignore mdbook for osx builds ([7755967a](https://github.com/gluon-lang/gluon/commit/7755967ad5e3defb5a1d1b1c10ce920ec030556d))
* **check:**  The alias reduction stack must be cleared between unifying function arguments ([170072a4](https://github.com/gluon-lang/gluon/commit/170072a4734d4ec27c97c307aae7dc5b7d181dcc))
* **doc:**
  *  Correct all the remaining links in docs ([494675fe](https://github.com/gluon-lang/gluon/commit/494675fe3dbfc229c795ed3b076ce0c87c7297a1))
  *  Point breadcrumb links correctly ([2a9cca72](https://github.com/gluon-lang/gluon/commit/2a9cca7282a74bd13851a25f88f2b04d398f2dbe))
  *  Point Rust defined types to their doc location ([b170f2f3](https://github.com/gluon-lang/gluon/commit/b170f2f3a2bd9b8a33ca4eb7620ea0e7f2a26784))
  *  Don't generate dead links in the documentation ([04131b71](https://github.com/gluon-lang/gluon/commit/04131b71176bc824cee956aa431ab84063d98861))
  *  Point sibling module links correctly ([3bbf4a99](https://github.com/gluon-lang/gluon/commit/3bbf4a9927ef2060707bf8345cf028f6a03df658))