### PR TITLE
fix(check): Don't lose type information in catch-all

### DIFF
--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -895,6 +895,7 @@ impl<'a> Typecheck<'a> {
                     // TODO Make this more general so it can error when not matching on all the
                     // variants
                     {
+                        *unaliased_scrutinee_type = self.subs.zonk(&unaliased_scrutinee_type);
                         let replaced = match (&alt.pattern.value, &**unaliased_scrutinee_type) {
                             (Pattern::Constructor(id, _), Type::Variant(row)) => {
                                 let mut variant_iter = row.row_iter();

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -772,3 +772,20 @@ let f x : a -> () =
 
     assert_err!(result, KindError(..));
 }
+
+test_check_err! {
+    issue_703_type_mismatch_in_recursive_function,
+    r#"
+type List a = | Nil | Cons a (List a)
+
+let reverse xs =
+    match xs with
+    | Nil -> Nil
+    | l -> l
+
+match reverse (Cons 1 Nil) with
+| Cons x _ -> x
+| Nil -> ""
+"#,
+Unification(..)
+}


### PR DESCRIPTION
Introduced when adding row polymorphism for variants which were need for
effects.

cc @tyler-conrad

Fixes #702
Fixes #703
Fixes #704
Fixes #705