### PR TITLE
fix(check): Bring nested implicit instances into scope

### DIFF
--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -2012,13 +2012,20 @@ impl<'a> Typecheck<'a> {
             }
 
             debug!("End generalize recursive");
-
-            // Update the implicit bindings with the generalized types we just created
-            let bindings = self.implicit_resolver.implicit_bindings.last_mut().unwrap();
-
-            let stack = &self.environment.stack;
-            bindings.update(|name| Some(stack.get(name).unwrap().typ.concrete.clone()));
         }
+        // Update the implicit bindings with the generalized types we just created
+        let bindings = self.implicit_resolver.implicit_bindings.last_mut().unwrap();
+        let stack = &self.environment.stack;
+        bindings.update(|name| {
+            Some(
+                stack
+                    .get(name)
+                    .unwrap_or_else(|| ice!("Implicit binding `{}` could not be updated", name))
+                    .typ
+                    .concrete
+                    .clone(),
+            )
+        });
 
         debug!("Typecheck `in`");
         self.environment.type_variables.exit_scope();

--- a/check/tests/implicits.rs
+++ b/check/tests/implicits.rs
@@ -873,6 +873,31 @@ f 1
     assert!(result.is_ok(), "{}", result.unwrap_err());
 }
 
+#[test]
+fn allow_sub_classed_duplicate() {
+    let _ = ::env_logger::try_init();
+    let text = r#"
+#[implicit]
+type Base a = { x : a }
+#[implicit]
+type Derived a = { base : Base a, y : a }
+#[implicit]
+type Derived2 a = { derived : Derived a, z : a }
+
+let { ? } = 
+    let base : Base Int = { x = 0 }
+    let derived : Derived Int = { base, y = 1 }
+    let derived2 : Derived2 Int = { derived, z = 2 }
+    { base, derived, derived2 }
+
+let f ?b x : [Base a] -> a -> a = b.x
+f 1
+"#;
+    let result = support::typecheck(text);
+
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+}
+
 test_check_err! {
 break_infinite_implicit_resolve_early,
     r#"
@@ -1001,6 +1026,32 @@ let transformer : Transformer (StateT s) =
 }
 
 test_check! {
+unable_to_resolve_double_nested_instance,
+r#"
+#[implicit]
+type Functor f = {
+    map : forall a b . (a -> b) -> f a -> f b
+}
+#[implicit]
+type Applicative f = {
+    functor : Functor f,
+}
+#[implicit]
+type Monad m = { functor : Applicative m }
+
+let any x = any x
+
+let eval_state_t f : [Functor m] -> m a -> () = ()
+
+let associativity mx : [Monad m] -> m a -> () =
+    eval_state_t mx
+
+()
+"#,
+"()"
+}
+
+test_check! {
 match_inference,
 r#"
 let any x = any x
@@ -1015,6 +1066,49 @@ let f receiver : Channel Int -> _ =
     match recv receiver with
     | Ok x -> assert (x == 1)
     | Err _ -> assert False
+
+()
+"#,
+"()"
+}
+
+test_check! {
+ord_array_implicit_resolution,
+r#"
+
+#[implicit]
+type Eq a = { (==) : a -> a -> Bool }
+
+#[implicit]
+type Ord a = { eq : Eq a, compare : a -> a -> () }
+
+let eq ?eq : [Eq a] -> Eq (Array a) =
+    { (==) = \x y -> False }
+
+let ord ?ord : [Ord a] -> Ord (Array a) =
+    let array_cmp l r = array_cmp l r
+    { eq, compare = \_ _ -> () }
+
+()
+"#,
+"()"
+}
+
+test_check! {
+ord_array_implicit_resolution2,
+r#"
+
+#[implicit]
+type Eq a = { (==) : a -> a -> Bool }
+
+#[implicit]
+type Ord a = { eq : Eq a, compare : a -> a -> () }
+
+let eq ?eq : [Eq a] -> Eq (Array a) =
+    { (==) = \x y -> False }
+
+let ord ?ord : [Ord a] -> Ord (Array a) =
+    { eq, compare = \_ _ -> () }
 
 ()
 "#,

--- a/examples/http/main.rs
+++ b/examples/http/main.rs
@@ -97,6 +97,8 @@ mod tests {
 
     #[test]
     fn hello_world() {
+        let _ = env_logger::try_init();
+
         let mut runtime = Runtime::new().unwrap();
 
         let port = 12234;
@@ -115,6 +117,8 @@ mod tests {
 
     #[test]
     fn echo() {
+        let _ = env_logger::try_init();
+
         let mut runtime = Runtime::new().unwrap();
 
         let port = 12235;

--- a/std/list.glu
+++ b/std/list.glu
@@ -97,7 +97,6 @@ let many ?alt x : [Alternative f] -> f a -> f (List a) =
     let many_v _ =
         some_v () <|> wrap Nil
     let some_v _ =
-        let { ? } = alt.applicative
         map (\h l -> Cons h l) x <*> many_v ()
     in
     many_v ()
@@ -108,7 +107,6 @@ let some ?alt x : [Alternative f] -> f a -> f (List a) =
     let many_v _ =
         some_v () <|> wrap Nil
     let some_v _ =
-        let { ? } = alt.applicative
         map (\h l -> Cons h l) x <*> many_v ()
     in
     some_v ()


### PR DESCRIPTION
Traverses records fully to bring their implicit instances in scope (`Monad -> Applicative -> Functor` etc)

Found in #686

cc @Etherian