### PR TITLE
Add marshalling features to implement gluon_specs

### DIFF
--- a/check/src/typecheck.rs
+++ b/check/src/typecheck.rs
@@ -2846,7 +2846,7 @@ impl<'a> Typecheck<'a> {
             Some((found_arg_type, arg, ret))
                 if function_arg_type == Some(found_arg_type) || function_arg_type == None =>
             {
-                return (found_arg_type, arg.clone(), ret.clone())
+                return (found_arg_type, arg.clone(), ret.clone());
             }
             _ => (),
         }

--- a/codegen/src/attr.rs
+++ b/codegen/src/attr.rs
@@ -27,6 +27,7 @@ pub enum CrateName {
 pub struct Container {
     pub crate_name: CrateName,
     pub vm_type: Option<String>,
+    pub newtype: bool,
 }
 
 impl Container {
@@ -35,6 +36,7 @@ impl Container {
 
         let mut crate_name = CrateName::None;
         let mut vm_type = None;
+        let mut newtype = false;
 
         for meta_items in item.attrs.iter().filter_map(get_gluon_meta_items) {
             for meta_item in meta_items {
@@ -51,6 +53,10 @@ impl Container {
                         crate_name = CrateName::GluonVm;
                     }
 
+                    Meta(Word(ref w)) if w == "newtype" => {
+                        newtype = true;
+                    }
+
                     Meta(NameValue(ref m)) if m.ident == "vm_type" => {
                         vm_type = Some(get_lit_str(&m.ident, &m.ident, &m.lit).unwrap().value())
                     }
@@ -63,6 +69,7 @@ impl Container {
         Container {
             crate_name,
             vm_type,
+            newtype,
         }
     }
 }

--- a/codegen/src/getable.rs
+++ b/codegen/src/getable.rs
@@ -211,7 +211,7 @@ fn gen_impl(
                     Ok(value)
                 }
 
-                fn from_proxy(vm: &'__vm _gluon_thread::Thread, proxy: &'__value Self::Proxy) -> Self {
+                fn from_proxy(vm: &'__vm _gluon_thread::Thread, proxy: &'__value mut Self::Proxy) -> Self {
                     Self::from_value(vm, *proxy)
                 }
 

--- a/codegen/src/getable.rs
+++ b/codegen/src/getable.rs
@@ -179,16 +179,19 @@ fn gen_impl(
             use #ident::api as _gluon_api;
             use #ident::thread as _gluon_thread;
             use #ident::Variants as _GluonVariants;
+            use #ident::Result as _GluonResult;
         },
         attr::CrateName::GluonVm => quote! {
-            use api as _gluon_api;
-            use thread as _gluon_thread;
-            use Variants as _GluonVariants;
+            use crate::api as _gluon_api;
+            use crate::thread as _gluon_thread;
+            use crate::Variants as _GluonVariants;
+            use crate::Result as _GluonResult;
         },
         attr::CrateName::None => quote! {
             use gluon::vm::api as _gluon_api;
             use gluon::vm::thread as _gluon_thread;
             use gluon::vm::Variants as _GluonVariants;
+            use gluon::vm::Result as _GluonResult;
         },
     };
 
@@ -202,6 +205,16 @@ fn gen_impl(
             impl #impl_generics _gluon_api::Getable<'__vm, '__value> for #ident #ty_generics
             #where_clause #(#getable_bounds,)* #(#lifetime_bounds),*
             {
+                type Proxy = _GluonVariants<'__value>;
+
+                fn to_proxy(vm: &'__vm _gluon_thread::Thread, value: _GluonVariants<'__value>) -> _GluonResult<Self::Proxy> {
+                    Ok(value)
+                }
+
+                fn from_proxy(vm: &'__vm _gluon_thread::Thread, proxy: &'__value Self::Proxy) -> Self {
+                    Self::from_value(vm, *proxy)
+                }
+
                 fn from_value(vm: &'__vm _gluon_thread::Thread, variants: _GluonVariants<'__value>) -> Self {
                     #push_impl
                 }

--- a/codegen/src/userdata.rs
+++ b/codegen/src/userdata.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use shared::{map_lifetimes, map_type_params, split_for_impl};
-use syn::{self, Data, DeriveInput, GenericParam, Generics};
+use syn::{self, Data, DeriveInput, Generics};
 
 use attr::{Container, CrateName};
 
@@ -48,12 +48,6 @@ fn gen_impl(container: &Container, ident: Ident, generics: Generics) -> TokenStr
         },
     };
 
-    let associated_type_generics = generics.params.iter().map(|param| match param {
-        GenericParam::Type(ty) => quote!( #ty :: Type ),
-        GenericParam::Lifetime(_) => quote!( 'static ),
-        GenericParam::Const(c) => quote!( #c ),
-    });
-
     let dummy_const = Ident::new(&format!("_IMPL_USERDATA_FOR_{}", ident), Span::call_site());
 
     quote! {
@@ -71,16 +65,6 @@ fn gen_impl(container: &Container, ident: Ident, generics: Generics) -> TokenStr
             #[automatically_derived]
             #[allow(unused_attributes, unused_variables)]
             impl #impl_generics _gluon_gc::Traverseable for #ident #ty_generics {}
-
-            #[automatically_derived]
-            #[allow(unused_attributes, unused_variables)]
-            impl #impl_generics _gluon_api::VmType for #ident #ty_generics
-            #where_clause #(#trait_bounds,)* #(#lifetime_bounds),*
-            {
-                type Type = #ident<
-                        #(#associated_type_generics),*
-                    >;
-            }
         };
     }
 }

--- a/codegen/tests/derive_userdata.rs
+++ b/codegen/tests/derive_userdata.rs
@@ -11,7 +11,8 @@ use gluon::{import, Compiler, Thread};
 use init::new_vm;
 use std::sync::Arc;
 
-#[derive(Userdata, Debug)]
+#[derive(Userdata, Debug, VmType)]
+#[gluon(vm_type = "WindowHandle")]
 struct WindowHandle {
     id: Arc<u64>,
     metadata: Arc<str>,

--- a/codegen/tests/derive_vm_type.rs
+++ b/codegen/tests/derive_vm_type.rs
@@ -4,7 +4,7 @@ extern crate gluon;
 
 mod init;
 
-use gluon::vm::api::VmType;
+use gluon::{base::types::Type, vm::api::VmType};
 use init::new_vm;
 
 #[derive(VmType)]
@@ -45,14 +45,35 @@ fn enum_() {
 
 #[derive(VmType)]
 #[allow(unused)]
+struct NewtypeInner(Struct);
+
+#[test]
+fn newtype_inner() {
+    let vm = new_vm();
+
+    assert_eq!(
+        NewtypeInner::make_type(&vm).to_string(),
+        Struct::make_type(&vm).to_string(),
+    );
+}
+
+#[derive(VmType)]
+#[gluon(newtype)]
+#[allow(unused)]
 struct Newtype(Struct);
 
 #[test]
 fn newtype() {
     let vm = new_vm();
 
-    assert_eq!(
-        Newtype::make_type(&vm).to_string(),
-        Struct::make_type(&vm).to_string(),
-    );
+    match &*Newtype::make_type(&vm) {
+        Type::Alias(alias) => {
+            assert_eq!(alias.name.declared_name(), "Newtype");
+            assert_eq!(
+                alias.unresolved_type().to_string(),
+                Struct::make_type(&vm).to_string()
+            );
+        }
+        _ => panic!(),
+    }
 }

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -47,6 +47,7 @@ impl<'vm, 'value> api::Pushable<'vm> for Enum {
 }
 
 impl<'vm, 'value> api::Getable<'vm, 'value> for Enum {
+    impl_getable_simple!();
     fn from_value(thread: &'vm Thread, value: vm::Variants<'value>) -> Self {
         api::de::De::from_value(thread, value).0
     }
@@ -271,6 +272,8 @@ impl<'vm, 'value, T> Getable<'vm, 'value> for GluonUser<T>
 where
     T: Getable<'vm, 'value>,
 {
+    impl_getable_simple!();
+
     fn from_value(vm: &'vm Thread, data: Variants<'value>) -> GluonUser<T> {
         // get the data, it must be a complex type
         let data = match data.as_ref() {

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -334,7 +334,8 @@ fn marshal_wrapper() -> Result<()> {
     Ok(())
 }
 
-#[derive(Userdata, Debug, Clone)]
+#[derive(Userdata, Debug, Clone, VmType)]
+#[gluon(vm_type = "WindowHandle")]
 struct WindowHandle {
     id: Arc<u64>,
     metadata: Arc<str>,

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -190,14 +190,16 @@ macro_rules! impl_userdata {
     };
 }
 
-#[derive(Userdata)]
+#[derive(Userdata, VmType)]
+#[gluon(vm_type = "Editor")]
 struct Editor {
     editor: Mutex<rustyline::Editor<Completer>>,
 }
 
 impl_userdata! { Editor }
 
-#[derive(Userdata)]
+#[derive(Userdata, VmType)]
+#[gluon(vm_type = "CpuPool")]
 struct CpuPool(self::futures_cpupool::CpuPool);
 
 impl_userdata! { CpuPool }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,7 +716,7 @@ impl Compiler {
 
 pub const PRELUDE: &'static str = r#"
 let __implicit_prelude = import! std.prelude
-let { Num, Eq, Ord, Show, Functor, Applicative, Monad, Option, Bool, ? } = __implicit_prelude
+let { IO, Num, Eq, Ord, Show, Functor, Applicative, Monad, Option, Bool, ? } = __implicit_prelude
 
 let { (+), (-), (*), (/), (==), (/=), (<), (<=), (>=), (>), (++), show, not, flat_map } = __implicit_prelude
 

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -100,7 +100,8 @@ impl<'vm, 'value> Getable<'vm, 'value> for Headers {
 
 // By implementing `Userdata` on `Body` it can be automatically pushed and retrieved from gluon
 // threads
-#[derive(Userdata)]
+#[derive(Userdata, VmType)]
+#[gluon(vm_type = "std.http.types.Body")]
 #[gluon(crate_name = "::vm")]
 // Representation of a http body that is in the prograss of being read
 pub struct Body(Arc<Mutex<Box<Stream<Item = PushAsRef<Chunk, [u8]>, Error = vm::Error> + Send>>>);
@@ -127,13 +128,14 @@ fn read_chunk(
 }
 
 // A http body that is being written
-#[derive(Userdata)]
+#[derive(Userdata, VmType)]
+#[gluon(vm_type = "std.http.types.ResponseBody")]
 #[gluon(crate_name = "::vm")]
 pub struct ResponseBody(Arc<Mutex<Option<hyper::body::Sender>>>);
 
 impl fmt::Debug for ResponseBody {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "hyper::Response")
+        write!(f, "ResponseBody")
     }
 }
 
@@ -176,7 +178,8 @@ fn write_response(
     })
 }
 
-#[derive(Debug, Userdata)]
+#[derive(Debug, Userdata, VmType)]
+#[gluon(vm_type = "std.http.types.Uri")]
 #[gluon(crate_name = "::vm")]
 struct Uri(http::Uri);
 
@@ -383,9 +386,9 @@ pub fn load_types(vm: &Thread) -> vm::Result<ExternModule> {
         vm,
         record! {
             // Define the types so that they can be used from gluon
-            type Body => Body,
-            type ResponseBody => ResponseBody,
-            type Uri => Uri,
+            type std::http::types::Body => Body,
+            type std::http::types::ResponseBody => ResponseBody,
+            type std::http::types::Uri => Uri,
             type std::http::Method => String,
             type std::http::StatusCode => u16,
             type std::http::Request => Request,

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -81,6 +81,8 @@ impl<'vm> Pushable<'vm> for Headers {
 }
 
 impl<'vm, 'value> Getable<'vm, 'value> for Headers {
+    impl_getable_simple!();
+
     fn from_value(vm: &'vm Thread, value: Variants<'value>) -> Self {
         Headers(
             Collect::from_value(vm, value)

--- a/src/std_lib/io.rs
+++ b/src/std_lib/io.rs
@@ -49,7 +49,8 @@ fn eprintln(s: &str) -> IO<()> {
     IO::Value(())
 }
 
-#[derive(Userdata)]
+#[derive(Userdata, VmType)]
+#[gluon(vm_type = "std.io.File")]
 #[gluon(crate_name = "::vm")]
 struct GluonFile(Mutex<Option<File>>);
 

--- a/src/std_lib/io.rs
+++ b/src/std_lib/io.rs
@@ -360,9 +360,9 @@ pub fn load(vm: &Thread) -> Result<ExternModule> {
     ExternModule::new(
         vm,
         record! {
-            type File => GluonFile,
+            type std::io::File => GluonFile,
             type OpenOptions => OpenOptions,
-            type IO a => IO<A>,
+            type std::io::IO a => IO<A>,
             flat_map => TypedBytecode::<FlatMap>::new("std.io.prim.flat_map", 3, flat_map),
             wrap => TypedBytecode::<Wrap>::new("std.io.prim.wrap", 2, wrap),
             open_file_with => primitive!(2, std::io::prim::open_file_with),

--- a/src/std_lib/random.rs
+++ b/src/std_lib/random.rs
@@ -5,10 +5,13 @@ extern crate rand_xorshift;
 
 use self::rand::{Rng, SeedableRng};
 
-use crate::vm::api::{RuntimeResult, IO};
-use crate::vm::thread::Thread;
-use crate::vm::types::VmInt;
-use crate::vm::{self, ExternModule};
+use crate::vm::{
+    self,
+    api::{RuntimeResult, IO},
+    thread::Thread,
+    types::VmInt,
+    ExternModule,
+};
 
 #[derive(Clone, Debug, Userdata, VmType)]
 #[gluon(vm_type = "std.random.XorShiftRng")]
@@ -67,7 +70,7 @@ pub fn load(vm: &Thread) -> vm::Result<ExternModule> {
     ExternModule::new(
         vm,
         record! {
-            type XorShiftRng => XorShiftRng,
+            type std::random::XorShiftRng => XorShiftRng,
             next_int => primitive!(1, std::random::prim::next_int),
             next_float => primitive!(1, std::random::prim::next_float),
             gen_int_range => primitive!(2, std::random::prim::gen_int_range),

--- a/src/std_lib/random.rs
+++ b/src/std_lib/random.rs
@@ -10,7 +10,8 @@ use crate::vm::thread::Thread;
 use crate::vm::types::VmInt;
 use crate::vm::{self, ExternModule};
 
-#[derive(Clone, Debug, Userdata)]
+#[derive(Clone, Debug, Userdata, VmType)]
+#[gluon(vm_type = "std.random.XorShiftRng")]
 #[gluon(crate_name = "::vm")]
 struct XorShiftRng(self::rand_xorshift::XorShiftRng);
 

--- a/src/std_lib/regex.rs
+++ b/src/std_lib/regex.rs
@@ -6,11 +6,13 @@ use crate::real_std::error::Error as StdError;
 
 use crate::vm::{self, api::Collect, thread::Thread, ExternModule};
 
-#[derive(Debug, Userdata)]
+#[derive(Debug, Userdata, VmType)]
+#[gluon(vm_type = "std.regex.Regex")]
 #[gluon(crate_name = "vm")]
 struct Regex(regex::Regex);
 
-#[derive(Debug, Userdata)]
+#[derive(Debug, Userdata, VmType)]
+#[gluon(vm_type = "std.regex.Error")]
 #[gluon(crate_name = "vm")]
 struct Error(regex::Error);
 

--- a/std/disposable.glu
+++ b/std/disposable.glu
@@ -1,7 +1,7 @@
 //@NO-IMPLICIT-PRELUDE
 //! A `Disposable` abstracts over different kinds of resources.
 
-let { wrap, flat_map } = import! std.io.prim
+let { IO, wrap, flat_map } = import! std.io.prim
 let { Bool } = import! std.types
 
 

--- a/std/effect/st.glu
+++ b/std/effect/st.glu
@@ -2,9 +2,9 @@ let { Eff, inject_rest, ? } = import! std.effect
 let { map } = import! std.functor
 let { wrap } = import! std.applicative
 let { (<<) } = import! std.function
-let { ref, (<-), load } = import! std.reference
+let { Reference, ref, (<-), load } = import! std.reference
 
-type STRef s a = { __ref : Ref a }
+type STRef s a = { __ref : Reference a }
 type State s r a =
     | New : forall b . b -> State s r (STRef s b)
     | Read : STRef s a -> State s r a

--- a/std/http.glu
+++ b/std/http.glu
@@ -22,8 +22,10 @@ let {
     Request,
     StatusCode,
     Response,
+    ResponseBody,
     HttpEffect,
-    HttpState, } = import! std.http.types
+    HttpState,
+    Uri, } = import! std.http.types
 let http_prim = import! std.http.prim
 
 let status =

--- a/std/http/types.glu
+++ b/std/http/types.glu
@@ -1,4 +1,4 @@
-let { Body, ResponseBody, StatusCode, Method, Request, Response, Headers, HttpState } = import! std.http.prim_types
+let { Body, ResponseBody, StatusCode, Method, Request, Response, Headers, HttpState, Uri } = import! std.http.prim_types
 
 let { Eff } = import! std.effect
 let { Error } = import! std.effect.error
@@ -19,6 +19,8 @@ type HttpEffect r a = [| alt : Alt, state : State HttpState, lift : Lift IO | r 
     StatusCode,
     Headers,
     Response,
+    ResponseBody,
     HttpEffect,
     HttpState,
+    Uri,
 }

--- a/std/io.glu
+++ b/std/io.glu
@@ -1,7 +1,7 @@
 //@NO-IMPLICIT-PRELUDE
 //! Functions for working with I/O
 
-let io_prim @ { IO } = import! std.io.prim
+let io_prim @ { IO, File } = import! std.io.prim
 let { Read } = import! std.io.read
 let { Write } = import! std.io.write
 let { Disposable } = import! std.disposable

--- a/std/io/read.glu
+++ b/std/io/read.glu
@@ -1,7 +1,7 @@
 //@NO-IMPLICIT-PRELUDE
 //! Functions and types for working with `Read`ers.
 
-let { wrap, flat_map, default_buf_len } = import! std.io.prim
+let { IO, wrap, flat_map, default_buf_len } = import! std.io.prim
 let { Option, Bool } = import! std.types
 let { Disposable, dispose, is_disposed } = import! std.disposable
 let { (>), (<=), (>=), min } = import! std.cmp
@@ -9,7 +9,7 @@ let { assert } = import! std.assert
 let { not } = import! std.bool
 let { ? } = import! std.int
 let { Result } = import! std.result
-let { ref, load, (<-) } = import! std.reference
+let { Reference, ref, load, (<-) } = import! std.reference
 let array = import! std.array
 let string = import! std.string
 
@@ -65,7 +65,7 @@ let default_read_to_end read : forall a . (a -> Int -> IO (Option (Array Byte)))
 /// If you are reading all data at once, buffering is not necessary. 
 type Buffered r = {
     reader : r,
-    buf : Ref (Array Byte),
+    buf : Reference (Array Byte),
     capacity : Int,
 }
 

--- a/std/io/write.glu
+++ b/std/io/write.glu
@@ -4,9 +4,9 @@
 let string = import! std.string
 let array = import! std.array
 let { wrap } = import! std.applicative
-let { flat_map, wrap, default_buf_len, throw } = import! std.io.prim
+let { IO, flat_map, wrap, default_buf_len, throw } = import! std.io.prim
 let { Disposable, dispose, is_disposed } = import! std.disposable
-let { (<-), load, ref } = import! std.reference
+let { Reference, (<-), load, ref } = import! std.reference
 let { ? } = import! std.int
 let { assert } = import! std.assert
 let { (>=), (>), (==) } = import! std.cmp
@@ -68,7 +68,7 @@ let flush ?write : [Write a] -> a -> IO () = write.flush
 /// If you are writing all data at once, buffering is not necessary.
 type Buffered w = {
     writer : w,
-    buf : Ref (Array Byte),
+    buf : Reference (Array Byte),
     capacity : Int,
 }
 

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -1,6 +1,7 @@
 //@NO-IMPLICIT-PRELUDE
 //! Definitions which gets implicit re-export in every file.
 
+let { IO } = import! std.io.prim
 let { Option } = import! std.types
 let { Functor } = import! std.functor
 let { Applicative, (*>), wrap } = import! std.applicative
@@ -20,6 +21,8 @@ let { error } = import! std.prim
 let { flat_map } = import! std.monad
 
 {
+    IO,
+
     Ordering,
 
     Semigroup,

--- a/std/random.glu
+++ b/std/random.glu
@@ -2,7 +2,7 @@
 //!
 //! _This module is only available if gluon is compiled with the `rand` feature._
 
-let prim = import! std.random.prim
+let prim @ { XorShiftRng } = import! std.random.prim
 
 type RandomGen g = { next : g -> { value : Int, gen : g } }
 
@@ -18,6 +18,7 @@ let xor_shift_rng =
 
 {
     RandomGen,
+    XorShiftRng,
 
     xor_shift_rng,
 

--- a/std/reference.glu
+++ b/std/reference.glu
@@ -1,9 +1,10 @@
 //! A mutable reference type
 
-let reference = import! std.reference.prim
+let reference @ { Reference } = import! std.reference.prim
 #[infix(right, 9)]
 let (<-) = reference.(<-)
 {
+    Reference,
     (<-),
     ..
     reference

--- a/std/regex.glu
+++ b/std/regex.glu
@@ -2,7 +2,7 @@
 //! Bindings for rust-lang/regex
 
 let { Match, eq_Match, show_Match } = import! std.regex.types
-let regex_prim = import! std.regex.prim
+let regex_prim @ { Regex, Error  } = import! std.regex.prim
 
 {
     Match,

--- a/std/stream.glu
+++ b/std/stream.glu
@@ -9,7 +9,7 @@ let { Option } = import! std.option
 let { Monoid } = import! std.monoid
 let { Semigroup, (<>) } = import! std.semigroup
 let { Foldable } = import! std.foldable
-let { lazy, force } = import! std.lazy
+let { Lazy, lazy, force } = import! std.lazy
 
 rec
 type Stream_ a =

--- a/tests/pass/buffered_io.glu
+++ b/tests/pass/buffered_io.glu
@@ -8,7 +8,7 @@ let { (<|), (|>) } = import! std.function
 let { ? } = import! std.io
 let io_read @ { Read, default_read_to_end, read, read_to_end, ? } = import! std.io.read
 let io_write @ { Write, write_slice, write, write_all, flush, ? } = import! std.io.write
-let { ref, (<-), load } = import! std.reference
+let { Reference, ref, (<-), load } = import! std.reference
 let { min } = import! std.cmp
 let { ? } = import! std.byte
 let array @ { ? } = import! std.array
@@ -17,7 +17,7 @@ let { lift } = import! std.effect.lift
 let { test, group } = import! std.test
 
 type Cursor = {
-    pos : Ref Int,
+    pos : Reference Int,
     buf : Array Byte
 }
 
@@ -43,7 +43,7 @@ let read_cursor : Read Cursor =
         read_to_end = default_read_to_end read
     }
 
-let write_array_ref : Write (Ref (Array Byte)) = {
+let write_array_ref : Write (Reference (Array Byte)) = {
     write_slice = \array_ref buf start end ->
         let written = array.append (load array_ref) (array.slice buf start end)
         array_ref <- written
@@ -101,7 +101,7 @@ let test_read_to_end = [
 
 let test_write_and_flush = [
     test "buffer all data if it fits" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 5
 
         do bytes_written = lift <| write writer [1b, 2b]
@@ -111,7 +111,7 @@ let test_write_and_flush = [
         assert_eq (load written) [1b, 2b],
     
     test "flush immediately if buffer is empty and new data wouldn't fit" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 2
 
         do bytes_written = lift <| write writer [1b, 2b, 3b]
@@ -121,7 +121,7 @@ let test_write_and_flush = [
         assert_eq (load written) [1b, 2b, 3b],
 
     test "flush buffer and then write new data if it wouldn't fit the buffer" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 2
 
         do bytes_written = lift <| write writer [1b]
@@ -134,7 +134,7 @@ let test_write_and_flush = [
         assert_eq (load written) [1b, 2b, 3b],
 
     test "flush buffer if new data doesn't fit, then buffer the data" <| \_ -> 
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 5
 
         do bytes_written = lift <| write writer [1b, 2b, 3b]
@@ -149,7 +149,7 @@ let test_write_and_flush = [
 
 let test_write_slice = [
     test "empty slice" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 5
         do bytes_written = lift <| write_slice writer [1b, 2b, 3b, 4b] 0 0
         do _ = assert_eq (bytes_written) 0
@@ -157,7 +157,7 @@ let test_write_slice = [
         assert_eq (load written) [],
 
     test "slice" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 5
         do bytes_written = lift <| write_slice writer [1b, 2b, 3b, 4b] 1 3
         do _ = assert_eq (bytes_written) 2
@@ -165,7 +165,7 @@ let test_write_slice = [
         assert_eq (load written) [2b, 3b],
 
     test "slice everything" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 5
         do bytes_written = lift <| write_slice writer [1b, 2b, 3b, 4b] 0 4
         do _ = assert_eq (bytes_written) 4
@@ -175,14 +175,14 @@ let test_write_slice = [
 
 let test_write_all = [
     test "basic" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 1
         do _ = lift <| write_all writer [1b, 2b, 3b, 4b]
         do _ = lift <| flush writer
         assert_eq (load written) [1b, 2b, 3b, 4b],
 
     test "write the data that's already buffered too" <| \_ ->
-        let written : Ref (Array Byte) = ref []
+        let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 2
         do _ = lift <| write writer [1b]
         do _ = lift <| write_all writer [2b, 3b, 4b]

--- a/tests/pattern_match.rs
+++ b/tests/pattern_match.rs
@@ -5,8 +5,8 @@ extern crate gluon;
 #[macro_use]
 mod support;
 
-use gluon::Compiler;
 use crate::support::*;
+use gluon::Compiler;
 
 test_expr! { prelude match_on_bool,
 r#"

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -810,7 +810,7 @@ fn completion_with_prelude() {
 let prelude  = import! std.prelude
 let { Option } = import! std.option
 let { Num } = prelude
-let { lazy } = import! std.lazy
+let { Lazy, lazy } = import! std.lazy
 
 rec
 type Stream_ a =
@@ -1059,7 +1059,7 @@ let category : Category (->) = {
 
 test_expr! { load_io_skolem_bug,
 r"
-let io_prim = import! std.io.prim
+let io_prim @ { IO } = import! std.io.prim
 
 type Monad (m : Type -> Type) = {
     flat_map : forall a b . (a -> m b) -> m a -> m b

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -175,6 +175,8 @@ where
     T: VmType,
     T: DeserializeOwned,
 {
+    impl_getable_simple!();
+
     fn from_value(thread: &'vm Thread, value: Variants<'value>) -> Self {
         let typ = T::make_type(thread);
         match from_value(thread, value, &typ).map(De) {

--- a/vm/src/api/function.rs
+++ b/vm/src/api/function.rs
@@ -330,7 +330,7 @@ where $($args: Getable<'vm, 'vm> + 'vm,)*
             let stack = StackFrame::<ExternState>::current(context.stack());
             $(
                 let variants = Variants::with_root(stack[i].clone(), vm);
-                let proxy = match $args::to_proxy(vm, variants) {
+                let mut proxy = match $args::to_proxy(vm, variants) {
                     Ok(x) => x,
                     Err(err) => {
                         drop(stack);
@@ -339,7 +339,7 @@ where $($args: Getable<'vm, 'vm> + 'vm,)*
                     }
                 };
                 // The proxy will live as along as the 'value lifetime we just created
-                let $args = $args::from_proxy(vm, &*(&proxy as *const _));
+                let $args = $args::from_proxy(vm, &mut *(&mut proxy as *mut _));
                 i += 1;
             )*
             // Lock the frame to ensure that any references to the stack stay rooted

--- a/vm/src/api/json.rs
+++ b/vm/src/api/json.rs
@@ -153,6 +153,8 @@ impl<'vm> crate::api::Pushable<'vm> for JsonValue {
 }
 
 impl<'vm, 'value> crate::api::Getable<'vm, 'value> for JsonValue {
+    impl_getable_simple!();
+
     fn from_value(vm: &'vm Thread, value: Variants<'value>) -> Self {
         JsonValue(crate::api::Getable::from_value(vm, value))
     }
@@ -223,7 +225,8 @@ impl<'de> de::DeserializeState<'de, ActiveThread<'de>> for JsonValue {
             where
                 E: de::Error,
             {
-                let value = crate::api::convert_with_active_thread(self.0, value).map_err(E::custom)?;
+                let value =
+                    crate::api::convert_with_active_thread(self.0, value).map_err(E::custom)?;
                 Ok(self.marshal(Value::String(value)))
             }
 
@@ -232,7 +235,8 @@ impl<'de> de::DeserializeState<'de, ActiveThread<'de>> for JsonValue {
             where
                 E: de::Error,
             {
-                let value = crate::api::convert_with_active_thread(self.0, value).map_err(E::custom)?;
+                let value =
+                    crate::api::convert_with_active_thread(self.0, value).map_err(E::custom)?;
                 Ok(self.marshal(Value::String(value)))
             }
 

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -895,6 +895,29 @@ impl<'vm, 'value> Getable<'vm, 'value> for f64 {
         }
     }
 }
+
+impl VmType for f32 {
+    type Type = Self;
+}
+impl<'vm> Pushable<'vm> for f32 {
+    #[inline]
+    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+        context.push(ValueRepr::Float(self as f64));
+        Ok(())
+    }
+}
+impl<'vm, 'value> Getable<'vm, 'value> for f32 {
+    impl_getable_simple!();
+
+    #[inline]
+    fn from_value(_: &'vm Thread, value: Variants<'value>) -> Self {
+        match value.as_ref() {
+            ValueRef::Float(f) => f as f32,
+            _ => ice!("ValueRef is not a Float"),
+        }
+    }
+}
+
 impl VmType for bool {
     type Type = Self;
     fn make_type(vm: &Thread) -> ArcType {
@@ -1509,7 +1532,7 @@ where
     type Type = IO<T::Type>;
     fn make_type(vm: &Thread) -> ArcType {
         let env = vm.global_env().get_env();
-        let alias = env.find_type_info("IO").unwrap().into_owned();
+        let alias = env.find_type_info("std.io.IO").unwrap().into_owned();
         Type::app(alias.into_type(), collect![T::make_type(vm)])
     }
     fn extra_args() -> VmIndex {

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -14,9 +14,9 @@ use crate::vm;
 use crate::{Result, Variants};
 
 #[cfg(feature = "serde")]
-use std::result::Result as StdResult;
-#[cfg(feature = "serde")]
 use crate::thread::RootedThread;
+#[cfg(feature = "serde")]
+use std::result::Result as StdResult;
 
 #[cfg(feature = "serde")]
 use crate::serde::de::{Deserialize, Deserializer};
@@ -356,6 +356,8 @@ impl<'vm, 'value, V> Getable<'vm, 'value> for Opaque<Variants<'value>, V>
 where
     V: ?Sized,
 {
+    impl_getable_simple!();
+
     fn from_value(_vm: &'vm Thread, value: Variants<'value>) -> Self {
         Opaque::from_value(value)
     }
@@ -366,6 +368,8 @@ where
     V: ?Sized,
     T: VmRoot<'vm>,
 {
+    impl_getable_simple!();
+
     fn from_value(vm: &'vm Thread, value: Variants<'value>) -> Self {
         OpaqueValue::from_value(vm.root_value(value))
     }

--- a/vm/src/api/record.rs
+++ b/vm/src/api/record.rs
@@ -232,6 +232,8 @@ where
     T: Default,
     U: GetableFieldList<'vm, 'value>,
 {
+    impl_getable_simple!();
+
     fn from_value(vm: &'vm Thread, value: Variants<'value>) -> Self {
         match value.as_ref() {
             ValueRef::Data(ref data) => {

--- a/vm/src/api/scoped.rs
+++ b/vm/src/api/scoped.rs
@@ -1,0 +1,144 @@
+use std::{fmt, ops::Deref, ptr::NonNull};
+
+use std::sync::RwLock;
+
+use base::types::ArcType;
+
+use crate::{
+    api::{Opaque, OpaqueValue, Pushable, VmType},
+    gc::{Gc, Traverseable},
+    thread::{ActiveThread, RootedThread, Thread, ThreadInternal},
+    value::Userdata,
+    Result,
+};
+
+pub struct Ref<'a, T>
+where
+    T: Userdata,
+{
+    reference: &'a T,
+    gluon_reference: Option<RefGuard<T>>,
+}
+
+impl<'a, 'b, T> VmType for &'b mut Ref<'a, T>
+where
+    T: Userdata + VmType,
+{
+    type Type = T::Type;
+    fn make_type(vm: &Thread) -> ArcType {
+        T::make_type(vm)
+    }
+}
+
+impl<'vm, 'a, 'b, T> Pushable<'vm> for &'b mut Ref<'a, T>
+where
+    T: VmType + Userdata,
+{
+    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+        Scoped::<T>::new(self.reference).push(context)?;
+        let value = context.last().unwrap();
+        self.gluon_reference = Some(RefGuard {
+            gluon_reference: Opaque::from_value(context.thread().root_value(value)),
+        });
+        Ok(())
+    }
+}
+
+impl<'a, T> Ref<'a, T>
+where
+    T: Userdata,
+{
+    pub fn new(reference: &'a T) -> Self {
+        Ref {
+            reference,
+            gluon_reference: None,
+        }
+    }
+}
+
+pub struct RefGuard<T>
+where
+    T: Userdata,
+{
+    gluon_reference: OpaqueValue<RootedThread, Scoped<T>>,
+}
+
+impl<T> Drop for RefGuard<T>
+where
+    T: Userdata,
+{
+    fn drop(&mut self) {
+        Scoped::invalidate(&*self.gluon_reference);
+    }
+}
+
+pub(crate) struct Scoped<T: ?Sized> {
+    ptr: RwLock<Option<NonNull<T>>>,
+}
+
+unsafe impl<T> Send for Scoped<T> where T: Send + Sync + ?Sized {}
+unsafe impl<T> Sync for Scoped<T> where T: Send + Sync + ?Sized {}
+
+impl<T> fmt::Debug for Scoped<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Scoped")
+    }
+}
+
+impl<T> Scoped<T> {
+    pub fn new(ptr: &T) -> Self {
+        Scoped {
+            ptr: RwLock::new(NonNull::new(ptr as *const T as *mut T)),
+        }
+    }
+
+    pub fn read(&self) -> Result<ReadGuard<T>> {
+        let ptr = self.ptr.read().unwrap();
+        if let None = *ptr {
+            return Err("Scoped pointer is invalidated".to_string().into());
+        }
+        Ok(ReadGuard(ptr))
+    }
+
+    pub fn invalidate(&self) {
+        *self.ptr.write().unwrap() = None;
+    }
+}
+
+impl<'vm, T: VmType> VmType for Scoped<T> {
+    type Type = T::Type;
+    fn make_type(vm: &Thread) -> ArcType {
+        T::make_type(vm)
+    }
+}
+
+impl<T> Traverseable for Scoped<T>
+where
+    T: Traverseable,
+{
+    fn traverse(&self, gc: &mut Gc) {
+        unsafe {
+            if let Some(v) = *self.ptr.read().unwrap() {
+                v.as_ref().traverse(gc);
+            }
+        }
+    }
+}
+
+impl<T> Userdata for Scoped<T> where T: Userdata {}
+
+#[doc(hidden)]
+pub struct ReadGuard<'a, T>(std::sync::RwLockReadGuard<'a, Option<NonNull<T>>>);
+
+impl<'a, T> Deref for ReadGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            match *self.0 {
+                Some(v) => &*v.as_ptr(),
+                None => panic!("Scoped pointer is invalidated"),
+            }
+        }
+    }
+}

--- a/vm/src/api/scoped.rs
+++ b/vm/src/api/scoped.rs
@@ -1,4 +1,9 @@
-use std::{fmt, ops::Deref, ptr::NonNull};
+use std::{
+    fmt,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
 
 use std::sync::RwLock;
 
@@ -17,7 +22,7 @@ where
     T: Userdata,
 {
     reference: &'a T,
-    gluon_reference: Option<RefGuard<T>>,
+    gluon_reference: Option<RefGuard<T, &'static ()>>,
 }
 
 impl<'a, 'b, T> VmType for &'b mut Ref<'a, T>
@@ -35,7 +40,7 @@ where
     T: VmType + Userdata,
 {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        Scoped::<T>::new(self.reference).push(context)?;
+        Scoped::<T, _>::new(self.reference).push(context)?;
         let value = context.last().unwrap();
         self.gluon_reference = Some(RefGuard {
             gluon_reference: Opaque::from_value(context.thread().root_value(value)),
@@ -56,42 +61,109 @@ where
     }
 }
 
-pub struct RefGuard<T>
+pub struct RefMut<'a, T>
 where
     T: Userdata,
 {
-    gluon_reference: OpaqueValue<RootedThread, Scoped<T>>,
+    reference: &'a mut T,
+    gluon_reference: Option<RefGuard<T, &'static mut ()>>,
 }
 
-impl<T> Drop for RefGuard<T>
+impl<'a, 'b, T> VmType for &'b mut RefMut<'a, T>
+where
+    T: Userdata + VmType,
+{
+    type Type = T::Type;
+    fn make_type(vm: &Thread) -> ArcType {
+        T::make_type(vm)
+    }
+}
+
+impl<'vm, 'a, 'b, T> Pushable<'vm> for &'b mut RefMut<'a, T>
+where
+    T: VmType + Userdata,
+{
+    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+        Scoped::<T, _>::new_mut(self.reference).push(context)?;
+        let value = context.last().unwrap();
+        self.gluon_reference = Some(RefGuard {
+            gluon_reference: Opaque::from_value(context.thread().root_value(value)),
+        });
+        Ok(())
+    }
+}
+
+impl<'a, T> RefMut<'a, T>
 where
     T: Userdata,
+{
+    pub fn new(reference: &'a mut T) -> Self {
+        RefMut {
+            reference,
+            gluon_reference: None,
+        }
+    }
+}
+
+struct RefGuard<T, M>
+where
+    T: Userdata,
+    M: 'static,
+{
+    gluon_reference: OpaqueValue<RootedThread, Scoped<T, M>>,
+}
+
+impl<T, M> Drop for RefGuard<T, M>
+where
+    T: Userdata,
+    M: 'static,
 {
     fn drop(&mut self) {
         Scoped::invalidate(&*self.gluon_reference);
     }
 }
 
-pub(crate) struct Scoped<T: ?Sized> {
+pub(crate) struct Scoped<T: ?Sized, M> {
     ptr: RwLock<Option<NonNull<T>>>,
+    _marker: PhantomData<M>,
 }
 
-unsafe impl<T> Send for Scoped<T> where T: Send + Sync + ?Sized {}
-unsafe impl<T> Sync for Scoped<T> where T: Send + Sync + ?Sized {}
+unsafe impl<T, M> Send for Scoped<T, M> where T: Send + Sync + ?Sized {}
+unsafe impl<T, M> Sync for Scoped<T, M> where T: Send + Sync + ?Sized {}
 
-impl<T> fmt::Debug for Scoped<T> {
+impl<T, M> fmt::Debug for Scoped<T, M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Scoped")
     }
 }
 
-impl<T> Scoped<T> {
+impl<T> Scoped<T, &'static ()> {
     pub fn new(ptr: &T) -> Self {
         Scoped {
             ptr: RwLock::new(NonNull::new(ptr as *const T as *mut T)),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> Scoped<T, &'static mut ()> {
+    pub fn new_mut(ptr: &mut T) -> Self {
+        Scoped {
+            ptr: RwLock::new(NonNull::new(ptr as *mut T)),
+            _marker: PhantomData,
         }
     }
 
+    pub fn write(&self) -> Result<WriteGuard<T>> {
+        let ptr = self.ptr.write().unwrap();
+        if let None = *ptr {
+            return Err("Scoped pointer is invalidated".to_string().into());
+        }
+        Ok(WriteGuard(ptr))
+    }
+}
+
+impl<T, M> Scoped<T, M> {
     pub fn read(&self) -> Result<ReadGuard<T>> {
         let ptr = self.ptr.read().unwrap();
         if let None = *ptr {
@@ -105,14 +177,14 @@ impl<T> Scoped<T> {
     }
 }
 
-impl<'vm, T: VmType> VmType for Scoped<T> {
+impl<'vm, T: VmType, M> VmType for Scoped<T, M> {
     type Type = T::Type;
     fn make_type(vm: &Thread) -> ArcType {
         T::make_type(vm)
     }
 }
 
-impl<T> Traverseable for Scoped<T>
+impl<T, M> Traverseable for Scoped<T, M>
 where
     T: Traverseable,
 {
@@ -125,7 +197,12 @@ where
     }
 }
 
-impl<T> Userdata for Scoped<T> where T: Userdata {}
+impl<T, M> Userdata for Scoped<T, M>
+where
+    T: Userdata,
+    M: 'static,
+{
+}
 
 #[doc(hidden)]
 pub struct ReadGuard<'a, T>(std::sync::RwLockReadGuard<'a, Option<NonNull<T>>>);
@@ -137,6 +214,33 @@ impl<'a, T> Deref for ReadGuard<'a, T> {
         unsafe {
             match *self.0 {
                 Some(v) => &*v.as_ptr(),
+                None => panic!("Scoped pointer is invalidated"),
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct WriteGuard<'a, T>(std::sync::RwLockWriteGuard<'a, Option<NonNull<T>>>);
+
+impl<'a, T> Deref for WriteGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            match *self.0 {
+                Some(v) => &*v.as_ptr(),
+                None => panic!("Scoped pointer is invalidated"),
+            }
+        }
+    }
+}
+
+impl<'a, T> DerefMut for WriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            match *self.0 {
+                Some(v) => &mut *v.as_ptr(),
                 None => panic!("Scoped pointer is invalidated"),
             }
         }

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -95,7 +95,7 @@ where
         let symbol = vm
             .global_env()
             .get_env()
-            .find_type_info("Sender")
+            .find_type_info("std.channel.Sender")
             .unwrap()
             .name
             .clone();
@@ -112,7 +112,7 @@ where
         let symbol = vm
             .global_env()
             .get_env()
-            .find_type_info("Receiver")
+            .find_type_info("std.channel.Receiver")
             .unwrap()
             .name
             .clone();

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -593,11 +593,13 @@ pub enum Component<'a> {
     Normal(&'a OsStr),
 }
 
-#[derive(Userdata, Debug)]
+#[derive(Userdata, Debug, VmType)]
+#[gluon(vm_type = "std.fs.Metadata")]
 #[gluon(gluon_vm)]
 pub struct Metadata(fs::Metadata);
 
-#[derive(Userdata, Debug)]
+#[derive(Userdata, Debug, VmType)]
+#[gluon(vm_type = "std.fs.DirEntry")]
 #[gluon(gluon_vm)]
 pub struct DirEntry(fs::DirEntry);
 

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -486,7 +486,7 @@ where
 {
     fn drop(&mut self) {
         // Move the cached frame back to storage
-        self.store_frame()
+        self.store_frame();
     }
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -701,6 +701,10 @@ impl Thread {
         self.global_env().register_type_as(name, alias, id)
     }
 
+    pub fn cache_alias(&self, alias: Alias<Symbol, ArcType>) -> ArcType {
+        self.global_env().cache_alias(alias)
+    }
+
     /// Locks and retrieves the global environment of the vm
     pub fn get_env<'b>(&'b self) -> RwLockReadGuard<'b, VmEnv> {
         self.global_env().get_env()
@@ -1484,7 +1488,9 @@ impl<'b> OwnedContext<'b> {
 
             maybe_context = match state {
                 State::Unknown => return Ok(Async::Ready(Some(context))),
-                State::Extern(ref ext) if ext.is_locked() => return Ok(Async::Ready(Some(context))),
+                State::Extern(ref ext) if ext.is_locked() => {
+                    return Ok(Async::Ready(Some(context)))
+                }
 
                 State::Extern(mut ext) => {
                     // We are currently in the poll call of this extern function.

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1484,9 +1484,7 @@ impl<'b> OwnedContext<'b> {
 
             maybe_context = match state {
                 State::Unknown => return Ok(Async::Ready(Some(context))),
-                State::Extern(ref ext) if ext.is_locked() => {
-                    return Ok(Async::Ready(Some(context)))
-                }
+                State::Extern(ref ext) if ext.is_locked() => return Ok(Async::Ready(Some(context))),
 
                 State::Extern(mut ext) => {
                     // We are currently in the poll call of this extern function.
@@ -1760,7 +1758,7 @@ impl<'b> ExecuteContext<'b> {
                             return Err(Error::Panic(
                                 format!("ICE: Stack push out of bounds in {}", function.name),
                                 Some(self.stack.stack.stacktrace(0)),
-                            ))
+                            ));
                         }
                     };
                     self.stack.push(v);

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -592,6 +592,16 @@ impl GlobalVmState {
         }
     }
 
+    pub fn cache_alias(&self, alias: Alias<Symbol, ArcType>) -> ArcType {
+        let mut env = self.env.write().unwrap();
+        let type_infos = &mut env.type_infos;
+        let t = alias.clone().into_type();
+        type_infos
+            .id_to_type
+            .insert(alias.name.definition_name().into(), alias);
+        t
+    }
+
     pub fn get_macros(&self) -> &MacroEnv {
         &self.macros
     }


### PR DESCRIPTION
https://github.com/Marwes/gluon_specs

Allows references to passed to gluon and adds support for generating aliases when deriving `VmType`