### PR TITLE
fix(vm): Automatically remove the elements added to pushed data

### DIFF
--- a/codegen/src/pushable.rs
+++ b/codegen/src/pushable.rs
@@ -187,12 +187,10 @@ fn gen_push_impl(
         }
     };
 
-    let fields_len_u32 = fields_len as u32;
     quote! {
         #(#stack_pushes)*
         let vm = ctx.thread();
         #new_data;
-        ctx.context().slide(#fields_len_u32);
     }
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1258,9 +1258,6 @@ impl Context {
         .map(ValueRepr::Data)
         .map(Value::from)
     }
-    pub fn slide(&mut self, fields: VmIndex) {
-        self.stack.slide(fields);
-    }
 
     pub fn push_new_data(
         &mut self,
@@ -1282,6 +1279,7 @@ impl Context {
             .map(ValueRepr::Data)
             .map(Value::from)?
         };
+        self.stack.pop_many(fields as u32);
         self.stack.push(value);
         Ok(self.stack.last().unwrap())
     }
@@ -1304,6 +1302,7 @@ impl Context {
                 },
             )?)
         };
+        self.stack.pop_many(fields as u32);
         self.stack.push(value);
         Ok(self.stack.last().unwrap())
     }


### PR DESCRIPTION
The generated code accounted for this but by moving it in we get a
simpler interface.

Fixes #719