### PR TITLE
[WIP] perf(vm): Add function inlining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,6 +1016,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "collect-mac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "frunk_core 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -621,7 +621,7 @@ where
 
                 debug!("Translation returned: {}", expr);
 
-                core::optimize::optimize(&translator.allocator, expr)
+                core::optimize::optimize(&translator.allocator, &*env, expr)
             };
 
             let name = Name::new(filename);

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -42,6 +42,7 @@ gluon_codegen = { path = "../codegen", version = "0.11.2" } # GLUON
 lalrpop = { version = "0.16", optional = true }
 
 [dev-dependencies]
+difference = "2"
 env_logger = "0.6"
 pretty_assertions = "0.5"
 

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -12,7 +12,7 @@ use crate::base::{
 };
 
 use crate::{
-    core::{self, CExpr, Expr, Literal, Pattern},
+    core::{self, is_primitive, CExpr, Expr, Literal, Pattern},
     interner::InternedStr,
     source_map::{LocalMap, SourceMap},
     types::*,
@@ -746,11 +746,7 @@ impl<'a> Compiler<'a> {
             }
             Expr::Call(func, args) => {
                 if let Expr::Ident(ref id, _) = *func {
-                    if id.name.as_ref() == "&&"
-                        || id.name.as_ref() == "||"
-                        || (id.name.as_ref().starts_with('#')
-                            && id.name.declared_name() != "#error")
-                    {
+                    if is_primitive(&id.name) && id.name.declared_name() != "#error" {
                         self.compile_primitive(&id.name, args, function, tail_position)?;
                         return Ok(None);
                     }

--- a/vm/src/core/grammar.lalrpop
+++ b/vm/src/core/grammar.lalrpop
@@ -2,7 +2,8 @@ use crate::base::{
     ast::{TypedIdent},
     pos::{BytePos, Span},
     symbol::{Symbol, Symbols},
-    types::{Field, Type}};
+    types::{Field, Type},
+};
 
 use crate::core::{Allocator, Alternative, Closure, Expr, LetBinding, Literal, Named, Pattern};
 

--- a/vm/src/core/inline.rs
+++ b/vm/src/core/inline.rs
@@ -1,0 +1,366 @@
+use base::{
+    ast::{Typed, TypedIdent},
+    fnv::FnvMap,
+    merge::{merge, merge_iter},
+    symbol::{Symbol, SymbolRef},
+    types::{ArcType, TypeEnv},
+};
+
+use crate::core::{
+    is_primitive,
+    optimize::{walk_expr, walk_expr_alloc, SameLifetime, Visitor},
+    Allocator, Binder, CExpr, Closure, Expr, LetBinding, Named,
+};
+
+const INLINE_COST_LIMIT: Cost = 20;
+
+pub(crate) struct Inline<'a, 'b> {
+    allocator: &'a Allocator<'a>,
+    implementations: FnvMap<&'a SymbolRef, (usize, &'a LetBinding<'a>)>,
+    env: &'b TypeEnv<Type = ArcType>,
+    costs: Costs<'a>,
+}
+
+impl<'a, 'b> Inline<'a, 'b> {
+    pub fn new(
+        allocator: &'a Allocator<'a>,
+        env: &'b TypeEnv<Type = ArcType>,
+        costs: Costs<'a>,
+    ) -> Self {
+        Inline {
+            allocator,
+            implementations: Default::default(), // TODO
+            env,
+            costs,
+        }
+    }
+}
+
+impl<'a, 'b> Visitor<'a, 'a> for Inline<'a, 'b> {
+    type Producer = SameLifetime<'a>;
+
+    fn visit_expr(&mut self, expr: CExpr<'a>) -> Option<CExpr<'a>> {
+        match expr {
+            Expr::Call(f, args) => {
+                let f = self.visit_expr(f).unwrap_or(f);
+                let (closure_id, closure_args, closure_expr) = self.as_closure(f)?;
+
+                if closure_args.len() == args.len() {
+                    let closure_cost = self
+                        .costs
+                        .get(closure_id)
+                        .cloned()
+                        .unwrap_or_else(usize::max_value);
+                    trace!("Inline check of {}: {}", closure_id, closure_cost);
+
+                    if closure_cost < INLINE_COST_LIMIT {
+                        let mut binder = Binder::default();
+
+                        let inlined_expr = ReplaceVariables {
+                            allocator: self.allocator,
+                            ident_replacements: closure_args
+                                .iter()
+                                .map(|id| &id.name)
+                                .zip(args.iter().map(|expr| {
+                                    match expr {
+                                        Expr::Ident(..) | Expr::Const(..) => expr,
+                                        Expr::Data(_, args, _) if args.is_empty() => expr,
+                                        _ => &*self
+                                            .allocator
+                                            .arena
+                                            .alloc(binder.bind(expr, expr.env_type_of(self.env))),
+                                    }
+                                }))
+                                .collect(),
+                        }
+                        .visit_expr(closure_expr)
+                        .unwrap_or(closure_expr);
+
+                        Some(binder.into_expr_ref(&self.allocator, inlined_expr))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+
+            Expr::Let(bind, body) => {
+                let opt_named = match &bind.expr {
+                    Named::Recursive(closures) => merge_iter(
+                        closures.iter(),
+                        |closure| {
+                            self.visit_expr(&closure.expr).map(|closure_expr| Closure {
+                                pos: closure.pos.clone(),
+                                name: closure.name.clone(),
+                                args: closure.args.clone(),
+                                expr: closure_expr,
+                            })
+                        },
+                        |closure| closure.clone(),
+                    )
+                    .map(Named::Recursive),
+
+                    Named::Expr(expr) => {
+                        let new_bind = self.visit_expr(expr).map(Named::Expr);
+
+                        new_bind
+                    }
+                };
+
+                let opt_bind = opt_named.map(|bind_expr| {
+                    &*self.allocator.let_binding_arena.alloc(LetBinding {
+                        name: bind.name.clone(),
+                        expr: bind_expr,
+                        span_start: bind.span_start,
+                    })
+                });
+
+                match &bind.expr {
+                    Named::Expr(_) => {
+                        self.implementations
+                            .insert(&bind.name.name, (0, opt_bind.unwrap_or(&bind)));
+                    }
+
+                    Named::Recursive(closures) => {
+                        // Only insert the closures after as we do not want to inline the
+                        // recursive functions into themselves
+                        for (i, closure) in closures.iter().enumerate() {
+                            self.implementations.insert(&closure.name.name, (i, &bind));
+                        }
+                    }
+                }
+
+                let opt_body = self.visit_expr(body);
+
+                merge(bind, opt_bind, body, opt_body, |bind, body| {
+                    &*self.allocator.arena.alloc(Expr::Let(bind, body))
+                })
+            }
+
+            _ => walk_expr_alloc(self, expr),
+        }
+    }
+
+    fn detach_allocator(&self) -> Option<&'a Allocator<'a>> {
+        Some(self.allocator)
+    }
+}
+
+impl<'a, 'b> Inline<'a, 'b> {
+    fn get(&self, id: &Symbol) -> Option<(&'a [TypedIdent<Symbol>], CExpr<'a>)> {
+        self.implementations
+            .get(&**id)
+            .map(|&(i, ref bind)| match &bind.expr {
+                Named::Recursive(closures) => {
+                    let closure = &closures[i];
+                    (&*closure.args, closure.expr)
+                }
+                Named::Expr(expr) => (&[][..], *expr),
+            })
+    }
+
+    fn as_closure(
+        &self,
+        expr: CExpr<'a>,
+    ) -> Option<(&'a SymbolRef, &'a [TypedIdent<Symbol>], CExpr<'a>)> {
+        match expr {
+            Expr::Let(
+                LetBinding {
+                    expr: Named::Recursive(closures),
+                    ..
+                },
+                Expr::Ident(ref id, ..),
+            ) => {
+                if let Some(closure) = closures.iter().find(|closure| closure.name.name == id.name)
+                {
+                    Some((&*id.name, &closure.args, &closure.expr))
+                } else {
+                    None
+                }
+            }
+
+            Expr::Ident(id, _) => self.get(&id.name).map(|(x, y)| (&*id.name, x, y)),
+
+            _ => None,
+        }
+    }
+}
+
+struct ReplaceVariables<'a> {
+    allocator: &'a Allocator<'a>,
+    ident_replacements: FnvMap<&'a Symbol, &'a Expr<'a>>,
+}
+
+impl<'a> Visitor<'a, 'a> for ReplaceVariables<'a> {
+    type Producer = SameLifetime<'a>;
+
+    fn visit_expr(&mut self, expr: &'a Expr<'a>) -> Option<&'a Expr<'a>> {
+        match *expr {
+            Expr::Ident(ref id, _) => self.ident_replacements.get(&id.name).cloned(),
+            _ => walk_expr_alloc(self, expr),
+        }
+    }
+
+    fn detach_allocator(&self) -> Option<&'a Allocator<'a>> {
+        Some(self.allocator)
+    }
+}
+
+pub type Cost = usize;
+pub type Costs<'a> = FnvMap<&'a SymbolRef, Cost>;
+
+struct AnalyzeCost<'a> {
+    costs: Costs<'a>,
+    current: Vec<Cost>,
+}
+
+impl<'a> AnalyzeCost<'a> {
+    fn cost_of(&mut self, expr: CExpr<'a>) -> Cost {
+        self.current.push(0);
+        self.visit_expr(expr);
+        self.current.pop().unwrap()
+    }
+
+    fn push_bind(&mut self, name: &'a Symbol, expr: CExpr<'a>) {
+        let cost = self.cost_of(expr);
+        self.costs.insert(name, cost);
+    }
+}
+
+impl<'a> Visitor<'a, 'a> for AnalyzeCost<'a> {
+    type Producer = SameLifetime<'a>;
+
+    fn visit_expr(&mut self, expr: &'a Expr<'a>) -> Option<&'a Expr<'a>> {
+        // The costs here are chosen rather arbitrarily. The only real plan is that at least
+        // trivial functions such as `\x y -> x #Int+ y` get inlined
+        match *expr {
+            Expr::Let(ref bind, body) => {
+                match &bind.expr {
+                    Named::Recursive(closures) => {
+                        for closure in closures {
+                            self.push_bind(&closure.name.name, &closure.expr);
+                        }
+                    }
+                    Named::Expr(expr) => {
+                        self.push_bind(&bind.name.name, expr);
+                    }
+                }
+
+                self.visit_expr(body);
+            }
+
+            Expr::Match(body, alts) => {
+                *self.current.last_mut().unwrap() += 5;
+                self.visit_expr(body);
+
+                *self.current.last_mut().unwrap() += alts
+                    .iter()
+                    .map(|alt| self.cost_of(alt.expr))
+                    .max()
+                    .unwrap_or(0)
+            }
+
+            Expr::Call(Expr::Ident(id, ..), ..) if is_primitive(&id.name) => {
+                *self.current.last_mut().unwrap() += 2;
+                walk_expr(self, expr);
+            }
+
+            Expr::Call(..) => {
+                *self.current.last_mut().unwrap() += 10000;
+                walk_expr(self, expr);
+            }
+
+            Expr::Const(..) | Expr::Ident(..) => *self.current.last_mut().unwrap() += 1,
+
+            Expr::Data(..) => {
+                *self.current.last_mut().unwrap() += 5;
+                walk_expr(self, expr);
+            }
+        }
+        None
+    }
+
+    fn detach_allocator(&self) -> Option<&'a Allocator<'a>> {
+        None
+    }
+}
+
+pub(crate) fn analyze_costs<'a>(expr: CExpr<'a>) -> Costs<'a> {
+    let mut visitor = AnalyzeCost {
+        costs: FnvMap::default(),
+        current: vec![0],
+    };
+    visitor.visit_expr(expr);
+    visitor.costs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use base::ast::EmptyEnv;
+
+    use crate::core::tests::check_translation_with;
+
+    fn check_inline(expr_str: &str, expected_str: &str) {
+        check_translation_with(expr_str, expected_str, |allocator, expr| {
+            let costs = analyze_costs(expr);
+            Inline::new(allocator, &EmptyEnv::default(), costs)
+                .visit_expr(expr)
+                .unwrap_or(expr)
+        });
+    }
+
+    #[test]
+    fn inline_add() {
+        let expr_str = r#"
+            let add x y = x #Int+ y
+            add 1 2
+        "#;
+
+        let expected_str = r#"
+            rec let add x y = (#Int+) x y
+            in
+            (#Int+) 1 2
+        "#;
+        check_inline(expr_str, expected_str);
+    }
+
+    #[test]
+    fn dont_inline_recursive_function() {
+        let expr_str = r#"
+            let func x = 1 + func x
+            func 1
+        "#;
+
+        let expected_str = r#"
+            rec let func x = (+) 1 (func x)
+            in
+            func 1
+        "#;
+        check_inline(expr_str, expected_str);
+    }
+
+    #[test]
+    fn inline_through_record() {
+        let expr_str = r#"
+            let { add } =
+                let add x y = x #Int+ y
+                { add }
+            add 1 2
+        "#;
+
+        let expected_str = r#"
+            let match_pattern =
+                rec let add x y = (#Int+) x y
+                in
+                { add = add }
+            in
+            match match_pattern with
+            | { add } -> (#Int+) 1 2
+            end
+        "#;
+        check_inline(expr_str, expected_str);
+    }
+}

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -1,30 +1,20 @@
-extern crate smallvec;
-extern crate typed_arena;
-
 #[macro_export]
 #[cfg(test)]
 macro_rules! assert_deq {
-    ($left:expr, $right:expr) => ({
+    ($left:expr, $right:expr) => {{
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
-                    panic!("assertion failed: `(left == right)` \
-                        (left: `{}`, right: `{}`)", left_val, right_val)
+                    difference::assert_diff!(
+                        &left_val.to_string(),
+                        &right_val.to_string(),
+                        "\n",
+                        0
+                    );
                 }
             }
         }
-    });
-    ($left:expr, $right:expr, $($arg:tt)+) => ({
-        match (&($left), &($right)) {
-            (left_val, right_val) => {
-                if !(*left_val == *right_val) {
-                    panic!("assertion failed: `(left == right)` \
-                        (left: `{}`, right: `{}`): {}", left_val, right_val,
-                        format_args!($($arg)+))
-                }
-            }
-        }
-    });
+    }};
 }
 
 #[cfg(all(test, feature = "test"))]
@@ -33,6 +23,7 @@ lalrpop_mod!(
     pub grammar,
     "/core/grammar.rs"
 );
+mod inline;
 pub mod interpreter;
 pub mod optimize;
 #[cfg(feature = "test")]
@@ -40,12 +31,9 @@ mod pretty;
 
 use std::{borrow::Cow, cell::RefCell, collections::HashMap, fmt, iter::once, mem};
 
-use {itertools::Itertools, ordered_float::NotNan, smallvec::SmallVec};
+use {itertools::Itertools, ordered_float::NotNan, smallvec::SmallVec, typed_arena::Arena};
 
-use self::{
-    optimize::{walk_expr_alloc, SameLifetime, Visitor},
-    typed_arena::Arena,
-};
+use self::optimize::{walk_expr_alloc, SameLifetime, Visitor};
 
 use crate::base::{
     ast::{self, SpannedExpr, SpannedPattern, Typed, TypedIdent},
@@ -411,6 +399,7 @@ pub struct Translator<'a, 'e> {
     ident_replacements: RefCell<FnvMap<Symbol, Symbol>>,
     env: &'e PrimitiveEnv<Type = ArcType>,
     dummy_symbol: TypedIdent<Symbol>,
+    dummy_record_symbol: TypedIdent<Symbol>,
 }
 
 impl<'a, 'e> Translator<'a, 'e> {
@@ -420,6 +409,7 @@ impl<'a, 'e> Translator<'a, 'e> {
             ident_replacements: Default::default(),
             env,
             dummy_symbol: TypedIdent::new(Symbol::from("")),
+            dummy_record_symbol: TypedIdent::new(Symbol::from("<record>")),
         }
     }
 
@@ -730,7 +720,7 @@ impl<'a, 'e> Translator<'a, 'e> {
 
                 let record_constructor = Expr::Data(
                     TypedIdent {
-                        name: self.dummy_symbol.name.clone(),
+                        name: self.dummy_record_symbol.name.clone(),
                         typ: typ.clone(),
                     },
                     arena.alloc_fixed(args),
@@ -746,7 +736,7 @@ impl<'a, 'e> Translator<'a, 'e> {
                     let args = arena.alloc_fixed(elems.iter().map(|expr| self.translate(expr)));
                     Expr::Data(
                         TypedIdent {
-                            name: self.dummy_symbol.name.clone(),
+                            name: self.dummy_record_symbol.name.clone(),
                             typ: expr.env_type_of(&self.env),
                         },
                         args,
@@ -1865,6 +1855,10 @@ impl<'a> ExactSizeIterator for PatternIdentifiers<'a> {
     }
 }
 
+pub(crate) fn is_primitive(name: &Symbol) -> bool {
+    name.as_ref() == "&&" || name.as_ref() == "||" || name.as_ref().starts_with('#')
+}
+
 #[cfg(all(test, feature = "test"))]
 mod tests {
     extern crate gluon_parser as parser;
@@ -1890,8 +1884,13 @@ mod tests {
         .unwrap()
     }
 
-    #[derive(Debug)]
     struct PatternEq<'a>(&'a Expr<'a>);
+
+    impl<'a> fmt::Debug for PatternEq<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            self.0.fmt(f)
+        }
+    }
 
     impl<'a> fmt::Display for PatternEq<'a> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1907,10 +1906,22 @@ mod tests {
     }
 
     fn check(map: &mut HashMap<Symbol, Symbol>, l: &Symbol, r: &Symbol) -> bool {
-        map.entry(l.clone()).or_insert_with(|| r.clone()) == r
+        let l = map.entry(l.clone()).or_insert_with(|| r.clone());
+        if l != r {
+            error!("{:#?} == {:#?}", l, r);
+        }
+        l == r
     }
 
     fn expr_eq(map: &mut HashMap<Symbol, Symbol>, l: &Expr, r: &Expr) -> bool {
+        let b = expr_eq_(map, l, r);
+        if !b {
+            error!("{:#?}\n\n{:#?}", l, r);
+        }
+        b
+    }
+
+    fn expr_eq_(map: &mut HashMap<Symbol, Symbol>, l: &Expr, r: &Expr) -> bool {
         match (l, r) {
             (&Expr::Match(_, l_alts), &Expr::Match(_, r_alts)) => {
                 for (l, r) in l_alts.iter().zip(r_alts) {
@@ -1953,7 +1964,20 @@ mod tests {
             (&Expr::Ident(ref l, _), &Expr::Ident(ref r, _)) => check(map, &l.name, &r.name),
             (&Expr::Let(ref lb, l), &Expr::Let(ref rb, r)) => {
                 let b = match (&lb.expr, &rb.expr) {
-                    (&Named::Expr(le), &Named::Expr(re)) => expr_eq(map, le, re),
+                    (Named::Expr(le), Named::Expr(re)) => expr_eq(map, le, re),
+                    (Named::Recursive(lcs), Named::Recursive(rcs)) => {
+                        lcs.len() == rcs.len()
+                            && lcs.iter().zip(rcs).all(|(lc, rc)| {
+                                check(map, &lc.name.name, &rc.name.name)
+                                    && lc.args.len() == rc.args.len()
+                                    && lc
+                                        .args
+                                        .iter()
+                                        .zip(&rc.args)
+                                        .all(|(l, r)| check(map, &l.name, &r.name))
+                                    && expr_eq(map, &lc.expr, &rc.expr)
+                            })
+                    }
                     _ => false,
                 };
                 check(map, &lb.name.name, &rb.name.name) && b && expr_eq(map, l, r)
@@ -1972,7 +1996,15 @@ mod tests {
         }
     }
 
-    fn check_translation(expr_str: &str, expected_str: &str) {
+    pub(crate) fn check_translation(expr_str: &str, expected_str: &str) {
+        check_translation_with(expr_str, expected_str, |_, e| e)
+    }
+
+    pub(crate) fn check_translation_with(
+        expr_str: &str,
+        expected_str: &str,
+        post: impl for<'a> FnOnce(&'a Allocator<'a>, CExpr<'a>) -> CExpr<'a>,
+    ) {
         let _ = ::env_logger::try_init();
 
         let mut symbols = Symbols::new();
@@ -1983,10 +2015,29 @@ mod tests {
 
         let expr = parse_expr(&mut symbols, expr_str);
         let core_expr = translator.translate_expr(&expr);
+        let core_expr = post(&translator.allocator, core_expr);
 
         let expected_expr = ExprParser::new()
             .parse(&mut symbols, &translator.allocator, expected_str)
-            .unwrap();
+            .unwrap_or_else(|err| {
+                let filemap = codespan::FileMap::new("test".into(), expected_str);
+                panic!(
+                    "{}",
+                    err.map_location(|i| {
+                        let (line, column) = filemap
+                            .location(codespan::ByteIndex::from(i as u32))
+                            .unwrap();
+                        let line_span = filemap.line_span(line).unwrap();
+                        format!(
+                            "line {}, column {}\n{}{}^",
+                            line.number(),
+                            column.number(),
+                            filemap.src_slice(line_span).unwrap(),
+                            " ".repeat(column.0 as usize)
+                        )
+                    })
+                )
+            });
         assert_deq!(PatternEq(&core_expr), expected_expr);
     }
 

--- a/vm/src/core/optimize.rs
+++ b/vm/src/core/optimize.rs
@@ -5,7 +5,7 @@ use crate::base::{
     merge::{merge_fn, merge_iter},
     pos,
     symbol::Symbol,
-    types::{ArcType, Field, TypeExt},
+    types::{ArcType, Field, TypeEnv, TypeExt},
 };
 
 use crate::core::{Allocator, Alternative, CExpr, Closure, Expr, LetBinding, Named, Pattern};
@@ -161,10 +161,23 @@ impl<'a> Visitor<'a, 'a> for RecognizeUnnecessaryAllocation<'a> {
     }
 }
 
-pub fn optimize<'a>(allocator: &'a Allocator<'a>, expr: &'a Expr<'a>) -> &'a Expr<'a> {
-    let mut optimizer = RecognizeUnnecessaryAllocation {
-        allocator: allocator,
-    };
+fn optimize_unnecessary_allocation<'a>(
+    allocator: &'a Allocator<'a>,
+    expr: &'a Expr<'a>,
+) -> &'a Expr<'a> {
+    let mut optimizer = RecognizeUnnecessaryAllocation { allocator };
+    optimizer.visit_expr(expr).unwrap_or(expr)
+}
+
+pub fn optimize<'a>(
+    allocator: &'a Allocator<'a>,
+    env: &'a TypeEnv<Type = ArcType>,
+    expr: &'a Expr<'a>,
+) -> &'a Expr<'a> {
+    let expr = optimize_unnecessary_allocation(allocator, expr);
+
+    let costs = crate::core::inline::analyze_costs(expr);
+    let mut optimizer = crate::core::inline::Inline::new(allocator, env, costs);
     optimizer.visit_expr(expr).unwrap_or(expr)
 }
 
@@ -210,8 +223,7 @@ where
                 Expr::Call,
             )
         }
-        Expr::Const(_, _) => None,
-        Expr::Ident(_, _) => None,
+        Expr::Const(_, _) | Expr::Ident(_, _) => None,
         Expr::Data(ref id, exprs, pos) => merge_iter(
             exprs,
             |expr| visitor.visit_expr_(expr),
@@ -352,7 +364,7 @@ mod tests {
                 .unwrap(),
         );
 
-        let optimized_expr = optimize(&allocator, initial_expr);
+        let optimized_expr = optimize_unnecessary_allocation(&allocator, initial_expr);
 
         let expected_str = r#"
             let l = l

--- a/vm/src/core/pretty.rs
+++ b/vm/src/core/pretty.rs
@@ -150,6 +150,7 @@ impl<'a> Expr<'a> {
                             " with",
                             arena.newline(),
                             chain![arena;
+                                "| ",
                                 alt.pattern.pretty(arena),
                                 arena.space(),
                                 "->"


### PR DESCRIPTION
The main purpose of this is to avoid the overhead of the trivial
operator functions `+, -, *` etc.