### PR TITLE
[WIP] feat(std): Add a Streamlike interface

### DIFF
--- a/std/streamlike.glu
+++ b/std/streamlike.glu
@@ -1,33 +1,17 @@
 let { id } = import! std.function
-let { Lazy, lazy, force } = import! std.lazy
 
-let statet @ { StateT, StateOut } = import! std.statet
-let lazyt @ { LazyT } = import! std.lazyt
+let statet @ { StateT } = import! std.statet
 
-// StateT vs no (vs effect system?)
-// strict vs lazy
-// state-machine vs dynamic vs closures (vs impl Trait equivalent?)
 
-// handle adapter types with monomorphization or dynamic dispatch?
-// new type, Lazy (Option (a, srm)) as output type of all adapters, hiding special behavior behind closure?
-// should streamlike be monadic? (a, srm) looks like State. uncons looks kinda like wrap.
-
-// Streamlike as a composition of monads? State + Option + Lazy?
+type Streamer a srm = StateT srm Option a
 
 #[implicit]
 type Streamlike a srm = {
-    uncons : srm -> LazyT Option (a, srm)
+    uncons : Streamer a srm
 }
 
-let option_streamlike : [Streamlike a srm] -> Streamlike a (Option (a, srm)) =
-    { uncons = force }
-
-let uncons ?sl : [Streamlike a srm] -> srm -> Option (a, srm) =
+let uncons ?sl : [Streamlike a srm] -> Streamer a srm =
     sl.uncons
-
-let empty = lazy (\_ -> None)
-
-let singleton = lazy (\_ -> Some {value = x, state = empty}
 
 let next srm : [Streamlike a srm] -> srm -> Option a =
     map fst (uncons srm)
@@ -39,30 +23,10 @@ let take n xs : [Streamlike a srm] -> Int -> srm -> ? =
         | None -> empty
     else empty
 
-let functor ?sml : [Streamlike a srm] -> Functor (Lazy (Option (a, srm))) =
-    rec let map f smout =
-        match force smout with
-        | Some (a, srm') -> lazy (\_ -> Some (f a, map f (sml.uncons srm')))
-        | None -> lazy (\_ -> None)
-
-    { map }
-
-let applicative ?sml : [Streamlike a srm] -> Applicative (Lazy (Option (a, srm))) =
-    let wrap = sml.uncons
-    let apply mf smout = ?
-
-    { functor, apply, wrap }
-
-let monad ?sml : [Streamlike a srm] -> Monad (Lazy (Option (a, srm))) =
-    let flat_map f smout =
-        functor.map f (force smout)
-
-    { applicative, flat_map }
-
 let semigroup : [Streamlike a srm] -> Semigroup srm =
     let append xs ys =
         match uncons xs with
-        | Some (x, xs') -> lazy (\_ -> Some (x, (append xs' ys)))
+        | Some (x, xs') -> Some {value = x, state = append xs' ys}
         | None -> ys
 
     { append }
@@ -76,7 +40,6 @@ type Streamlike a srm = {
     uncons : srm -> Option (StateOut srm a)
 }
 
-type Streamer a srm = StateT srm Option a
 
 // state-machine adapters
 type Unfold acc = {

--- a/std/streamlike.glu
+++ b/std/streamlike.glu
@@ -1,0 +1,303 @@
+let { id } = import! std.function
+let { Lazy, lazy, force } = import! std.lazy
+
+let statet @ { StateT, StateOut } = import! std.statet
+let lazyt @ { LazyT } = import! std.lazyt
+
+// StateT vs no (vs effect system?)
+// strict vs lazy
+// state-machine vs dynamic vs closures (vs impl Trait equivalent?)
+
+// handle adapter types with monomorphization or dynamic dispatch?
+// new type, Lazy (Option (a, srm)) as output type of all adapters, hiding special behavior behind closure?
+// should streamlike be monadic? (a, srm) looks like State. uncons looks kinda like wrap.
+
+// Streamlike as a composition of monads? State + Option + Lazy?
+
+#[implicit]
+type Streamlike a srm = {
+    uncons : srm -> LazyT Option (a, srm)
+}
+
+let option_streamlike : [Streamlike a srm] -> Streamlike a (Option (a, srm)) =
+    { uncons = force }
+
+let uncons ?sl : [Streamlike a srm] -> srm -> Option (a, srm) =
+    sl.uncons
+
+let empty = lazy (\_ -> None)
+
+let singleton = lazy (\_ -> Some {value = x, state = empty}
+
+let next srm : [Streamlike a srm] -> srm -> Option a =
+    map fst (uncons srm)
+
+let take n xs : [Streamlike a srm] -> Int -> srm -> ? =
+    if n > 0 then
+        match uncons xs with
+        | Some (x, xs') -> Some {value = x, state = (take (n - 1) xs')}
+        | None -> empty
+    else empty
+
+let functor ?sml : [Streamlike a srm] -> Functor (Lazy (Option (a, srm))) =
+    rec let map f smout =
+        match force smout with
+        | Some (a, srm') -> lazy (\_ -> Some (f a, map f (sml.uncons srm')))
+        | None -> lazy (\_ -> None)
+
+    { map }
+
+let applicative ?sml : [Streamlike a srm] -> Applicative (Lazy (Option (a, srm))) =
+    let wrap = sml.uncons
+    let apply mf smout = ?
+
+    { functor, apply, wrap }
+
+let monad ?sml : [Streamlike a srm] -> Monad (Lazy (Option (a, srm))) =
+    let flat_map f smout =
+        functor.map f (force smout)
+
+    { applicative, flat_map }
+
+let semigroup : [Streamlike a srm] -> Semigroup srm =
+    let append xs ys =
+        match uncons xs with
+        | Some (x, xs') -> lazy (\_ -> Some (x, (append xs' ys)))
+        | None -> ys
+
+    { append }
+
+let monoid : [Streamlike a srm] -> Monoid srm =
+    { semigroup, empty }
+
+// StateT strict version
+#[implicit]
+type Streamlike a srm = {
+    uncons : srm -> Option (StateOut srm a)
+}
+
+type Streamer a srm = StateT srm Option a
+
+// state-machine adapters
+type Unfold acc = {
+    f : acc -> Option acc,
+    acc : acc
+}
+
+let unfold_streamlike : Streamlike acc (Unfold acc) =
+    let uncons unfold =
+        unfold.f unfold.acc |> map (\acc' ->
+            {value = acc', state = {f = unfold.f, acc = acc'}})
+    { uncons }
+
+let unfold f acc : (acc -> Option acc) -> acc -> Unfold acc =
+    {f , acc}
+
+// replaced with FilterMap
+/* // FIXME this seems wrong. Maybe leave mapping to stream processors somehow? */
+/* type MapSrm a b srm = { */
+/*     f : a -> b, */
+/*     xs : srm */
+/* } */
+
+/* let mapsrm_streamlike : [Streamlike a srm] -> Streamlike b (MapSrm a b srm) = */
+/*     let uncons mapsrm = */
+/*         uncons mapsrm.xs |> map \{value = x, state = xs'} */
+/*             {value = mapsrm.f x, state = {f = mapsrm.f, xs = xs'}} */
+/*     { uncons } */
+
+/* let map_srm f xs : (a -> b) -> srm -> MapSrm a b srm = */
+/*     {f, xs} */
+
+type FilterMap a b srm = {
+    pred : a -> Option b,
+    xs : srm
+}
+
+// FIXME Will not halt if fed an infinite stream of elements that fail the predicate
+let filter_map_streamlike : [Streamlike a srm] -> Streamlike b (FilterMap a b srm) =
+    rec let uncons filtermp =
+        uncons filtermp.xs |> map (\sout ->
+            let {value = x, state = xs'} = sout
+            match filtermp.pred x with
+            | Some x' -> {value = x', state = {pred = filtermp.pred, xs = xs'}}
+            | None -> uncons {pred = filtermp.pred, xs = xs'})
+
+let filter_map pred xs : [Streamlike a srm] -> (a -> Option b) -> srm -> FilterMap a b srm =
+    {pred, xs}
+
+// replaced with FilterMap
+/* // TODO Is it a problem for Filter and TakeWhile to have the same type signature/definition? */
+/* type Filter a srm = { */
+/*     pred : a -> Bool, */
+/*     xs : srm */
+/* } */
+
+/* // FIXME Will not halt if fed an infinite stream of elements that fail the predicate */
+/* let filter_streamlike : [Streamlike a srm] -> Streamlike a (Filter a srm) = */
+/*     rec let uncons filter = */
+/*         uncons filter.xs |> map \{value = Some x, state = xs'} -> */
+/*             if filter.pred x then */
+/*                 {value = x, state = {pred = filter.pred, xs = xs'}} */
+/*             else */
+/*                 uncons {pred = filter.pred, xs = xs'} */
+
+/* let filter pred xs : [Streamlike a srm] -> (a -> Bool) -> srm -> Filter a srm = */
+/*     {pred, xs} */
+
+/* type TakeWhile a srm = { */
+/*     pred : a -> Bool, */
+/*     xs : srm */
+/* } */
+
+/* let take_while_streamlike : [Streamlike a srm] -> Streamlike a (TakeWhile srm) = */
+/*     let uncons tw = */
+/*         uncons tw.xs >>= \sout -> */
+/*             let {value = x, state = xs'} = sout */
+/*             if tw.pred x then */
+/*                 Some {value = x, state = {pred = tw.pred, xs = xs'}} */
+/*             else */
+/*                 None */
+
+/*     { uncons } */
+
+/* let take_while pred xs : [Streamlike a srm] -> (a -> Bool) -> srm -> TakeWhile a srm = */
+/*     {pred, xs} */
+
+type TakeWhileMap a b srm = {
+    pred : a -> Option b,
+    xs : srm
+}
+
+let take_while_map_streamlike : [Streamlike a srm] -> Streamlike b (TakeWhileMap a b srm) =
+    let uncons tw =
+        uncons tw.xs >>= \sout ->
+            let {value = x, state = xs'} = sout
+            tw.pred x |> map (\x' ->
+                {value = x', state = {pred = tw.pred, xs = xs'}})
+
+    { uncons }
+
+let take_while_map pred xs : [Streamlike a srm] -> (a -> Option b) -> srm -> TakeWhileMap a b srm =
+    {pred, xs}
+
+// replaced with composition of Unfold and ZipWith
+/* type Take srm = { */
+/*     count : Int, */
+/*     xs : srm */
+/* } */
+
+/* let take_streamlike : [Streamlike a srm] -> Streamlike a (Take srm) = */
+/*     let uncons take = */
+/*         if take.count > 0 then */
+/*             uncons take.xs |> map (\sout -> */
+/*                 let {value = x, state = xs'} = sout */
+/*                 {value = x, state = {count = take.count - 1, xs = xs'}}) */
+/*         else */
+/*             None */
+/*     { uncons } */
+
+/* let take n xs : [Streamlike a srm] -> Int -> srm -> Take srm = */
+/*     {count = n, xs} */
+
+type ZipWith a b c srma srmb = {
+    f : (a -> b -> c),
+    xs : srma,
+    ys : srmb
+}
+
+let zip_with_streamlike : [Streamlike a srma] -> [Streamlike b srmb] -> Streamlike c (ZipWith a b c srma srmb) =
+    let uncons zipw = match (uncons zipw.xs, uncons zipw.ys) with
+        | (Some {value = x, state = xs'}, Some {value = y, state = ys'}) ->
+            Some {value = zipw.f x y, state = {f = zipw.f, xs = xs', ys = ys'}},
+        | _ -> None
+    { uncons }
+
+let zip_with f xs ys : [Streamlike a srma] -> [Streamlike b srmb] -> (a -> b -> c) -> srma -> srmb -> ZipWith a b c srma srmb =
+    {f, xs, ys}
+
+// rewrite as composition of Unfold and MapSrm?
+type Scan acc a srm = {
+    f : acc -> a -> Option acc,
+    acc : acc,
+    xs : srm
+}
+
+let scan_streamlike : [Streamlike a srm] -> Streamlike (Scan acc a srm) =
+    let uncons scan =
+        uncons scan.xs >>= \sout ->
+            let {value = x, state = xs'} = sout
+            scan.f scan.acc x |> map (\acc' ->
+                {value = acc', state = {f = scan.f, acc = acc', xs = xs'}})
+    { uncons }
+
+let scan f acc xs : [Streamlike a srm] -> (acc -> a -> acc) -> acc -> srm -> Scan acc a srm =
+    {f, acc, xs}
+
+type Flatten srm srms : {
+    xs : srm,
+    xss : srms
+}
+
+// FIXME Will not halt if fed an infinite stream of empties
+let flatten_streamlike : [Streamlike a srm] -> [Streamlike srm srms] -> Streamlike a (Flatten srm srms) =
+    rec let uncons flatten = match uncons flatten.xs with
+    | Some {value = x, state = xs'} ->
+        Some {value = x, state = {xs = xs', xss = flatten.xss}}
+    | None ->
+        uncons flatten.xss |> map (\sout ->
+            let {value = xs, state = xss'} = sout
+            uncons {xs, xss = xss'})
+
+    { uncons }
+
+let flatten srms : [Streamlike a srm] -> [Streamlike srm srms] -> srms -> Flatten srm srms =
+    {xs = empty, xss = srms}
+
+
+
+let count_from start : Int -> Unfold Int =
+    {f = (+) 1, acc = start}
+
+let count_from_by start step : Int -> Int -> Unfold Int =
+    {f = (+) step, acc = start}
+
+let take_while pred = take_while_map <| \x -> if pred x then Some x else None
+
+let take n = count_from 0 |> take_while ((>) n) |> zip_with (\_ x -> x)
+
+let repeat x : a -> Unfold a =
+    {f = Some, acc = x}
+
+let repeat_n n = take n << repeat
+    /* {f = \x _ -> Some x, */
+    /*  acc = x, */
+    /*  xs = count_from 0 |> take_while ((>) n)} */
+
+let map_srm f = filter_map (f >> Some)
+
+let filter pred = filter_map <| \x -> if pred x then Some x else None
+
+let cycle : [Streamlike a srm] -> srm -> Flatten srm (Unfold srm) =
+    flatten << repeat
+
+let cycle_n n = flatten << repeat_n n
+
+let zip = zip_with <| \xs ys -> (xs, ys)
+
+/* let unfold f acc = scan (|>) acc (repeat f) */
+
+// TODO test
+/* let scan f acc = */
+/*     let unf acc = */ 
+/*         uncons acc.state |> map (f acc.value) */
+/*     uncons >> unfold unf >> map_srm .value */
+
+
+// drop
+// drop_while
+// show?
+// singleton?
+// intercalate?
+// group/chunks_of?
+// split_at?


### PR DESCRIPTION
## Description
Adds a `Streamlike` (name TBD) interface which generalizes the concept of a collection from which values can be extracted.

## Related PRs
Similar concept to the Parsable interface (#687)

## Status
**In Development**

### Outstanding design questions:
*None currently*

### To Do
- [ ] Add useful functions
- [ ] Add implementations for standard types
- [ ] Add inline documentation
- [ ] Add documentation in the book?

### Prior Art
- [Streaming library](https://github.com/haskell-streaming/streaming)
- *Iterators and Streams in Rust and Haskell.*

## Future Directions
- Streamlike + "Finite" -> Foldable (& Traversable)
- Maybe a streaming library built like https://github.com/haskell-streaming/streaming, instead of this library's stream-processor-based design?
  - How would Streamlike adapters pass around Streamlikes? Rust-like? Haskell-like? Closure-based?