### PR TITLE
feat(std): Add Indexable interface

### DIFF
--- a/std/indexable.glu
+++ b/std/indexable.glu
@@ -1,0 +1,11 @@
+type Indexable ind = {
+    index : ind a -> Int -> a
+}
+
+let index ?ind : [Indexable ind] -> ind a -> Int -> a = ind.index
+
+{
+    Indexable,
+
+    index,
+}


### PR DESCRIPTION
## Description
Adds an `Indexable` interface which abstracts over collections whose elements can referred to by integer indexes, e.g. Strings, Arrays, and Lists.

## Related PRs

## Status
**In Development**

### Outstanding design questions:
*None currently*

### To Do
- [ ] Add useful functions?
- [ ] Add implementations for standard types
- [ ] Add inline documentation

### Prior Art
N/A

## Future Directions
