### PR TITLE
feat: Automatically unroot values stored in `Gc` allocated values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -233,7 +233,7 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -245,7 +245,7 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -294,7 +294,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ dependencies = [
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfix 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -406,7 +406,7 @@ dependencies = [
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -420,6 +420,28 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -537,7 +559,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -794,10 +816,10 @@ dependencies = [
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_state 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tensile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -825,9 +847,9 @@ dependencies = [
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_state 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -876,7 +898,7 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -915,7 +937,7 @@ dependencies = [
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -979,7 +1001,7 @@ dependencies = [
  "rexpect 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -994,6 +1016,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "codespan 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "collect-mac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "frunk_core 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1013,10 +1036,10 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_state 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1213,7 +1236,7 @@ dependencies = [
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1300,7 +1323,7 @@ dependencies = [
  "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2064,7 +2087,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2164,12 +2187,12 @@ name = "serde"
 version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2179,12 +2202,12 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_state"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2199,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "serde_state"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2365,16 +2388,6 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3053,6 +3066,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0363053954f3e679645fc443321ca128b7b950a6fe288cf5f9335cc22ee58394"
 "checksum criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76f9212ddf2f4a9eb2d401635190600656a1f88a932ef53d06e7fa4c7e02fb8e"
+"checksum crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b14492071ca110999a20bf90e3833406d5d66bfd93b4e52ec9539025ff43fe0d"
+"checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
@@ -3219,10 +3234,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
-"checksum serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "101b495b109a3e3ca8c4cbe44cf62391527cdfb6ba15821c5ce80bcd5ea23f9f"
-"checksum serde_derive_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bda14ebc3faa312c4cd0e404feee881d0249e2ffcffb1abb2b51d16c19884264"
+"checksum serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)" = "c4cce6663696bd38272e90bf34a0267e1226156c33f52d3f3915a2dd5d802085"
+"checksum serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e1b73f7c2939f36fb2e5d72d42aedca7dc8ddae40688dd839daee052a17e2cb7"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
-"checksum serde_state 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "05b3abfddd6311df7155ad29ac17565b7f0db0eff7d7cf1b446b95f1fa1cb76a"
+"checksum serde_state 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1c5d7f83552515189fb422f4a2a51ecdf6d7176dd3f2cb33065593932ea33fd5"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
@@ -3243,7 +3258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
-"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,15 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "argon2rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,10 +77,10 @@ dependencies = [
 
 [[package]]
 name = "ascii-canvas"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -155,6 +164,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "blake2-rfc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "block-buffer"
@@ -329,6 +347,11 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cookie"
@@ -552,6 +575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "docopt"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ena"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -969,8 +1002,8 @@ dependencies = [
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gluon_base 0.11.2",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1026,8 +1059,8 @@ dependencies = [
  "gluon_codegen 0.11.2",
  "gluon_parser 0.11.2",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mopa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1221,17 +1254,17 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.16.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ascii-canvas 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ena 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lalrpop-util 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1239,13 +1272,13 @@ dependencies = [
  "serde_derive 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.16.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1954,6 +1987,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2178,11 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
@@ -2471,11 +2520,12 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3026,8 +3076,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum anymap 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 "checksum app_dirs 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d"
 "checksum arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4662175ead9cd84451d5c35070517777949a2ed84551764129cedb88384841"
+"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
-"checksum ascii-canvas 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b385d69402821a1c254533a011a312531cbcc0e3e24f19bbb4747a5a2daf37e2"
+"checksum ascii-canvas 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 "checksum backtrace 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "45934a579eff9fd0ff637ac376a4bd134f47f8fc603f0b211d696b54d61e35f1"
@@ -3039,6 +3090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
@@ -3058,6 +3110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum codespan-reporting 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2ae73f6c4b3803dc2a0fe08ed1ce40e8f3f94ecc8394a82e0696bbc86d4e4fc3"
 "checksum collect-mac 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f168712e49987bd2f51cb855c4585999e12b1a0abdff60fea4b81b41f2010264"
 "checksum compiletest_rs 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "f40ecc9332b68270998995c00f8051ee856121764a0d3230e64c9efd059d27b6"
+"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -3080,11 +3133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
 "checksum docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
-"checksum ena 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f56c93cc076508c549d9bb747f79aa9b4eb098be7b8cad8830c3137ef52d1e00"
+"checksum ena 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc01d68e08ca384955a3aeba9217102ca1aa85b6e168639bf27739f1d749d87"
 "checksum encode_unicode 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "28d65f1f5841ef7c6792861294b72beda34c664deb8be27970f36c306b7da1ce"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
@@ -3126,8 +3180,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2e80bee40b22bca46665b4ef1f3cd88ed0fb043c971407eac17a0712c02572"
-"checksum lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33b27d8490dbe1f9704b0088d61e8d46edc10d5673a8829836c6ded26a9912c7"
+"checksum lalrpop 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d111d79a3b76457aa1bcc699a736b6c623d14da0ec75737c01edb657469aef"
+"checksum lalrpop-util 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ab5dfdd35d987c6d328e371764cb6e4b6c63220db9364c291aa14d6fe50099a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
@@ -3209,6 +3263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8f0a0bcab2fd7d1d7c54fa9eae6f43eddeb9ce2e7352f8518a814a4f65d60c58"
@@ -3227,6 +3282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
+"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2"
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
@@ -3265,7 +3321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum tendril 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b"
 "checksum tensile 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3beabe8c8c063f8d3bdfc5d428e87cb92f9e1f91e7d1006bb353d99262078637"
-"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"

--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -853,17 +853,17 @@ pub use self::ref_::{walk_alias, walk_ast_type, walk_expr, walk_pattern, Visitor
 pub trait Typed {
     type Ident;
 
-    fn env_type_of(&self, env: &TypeEnv<Type = ArcType>) -> ArcType<Self::Ident> {
+    fn env_type_of(&self, env: &dyn TypeEnv<Type = ArcType>) -> ArcType<Self::Ident> {
         self.try_type_of(env).unwrap()
     }
 
-    fn try_type_of(&self, env: &TypeEnv<Type = ArcType>) -> Result<ArcType<Self::Ident>, String>;
+    fn try_type_of(&self, env: &dyn TypeEnv<Type = ArcType>) -> Result<ArcType<Self::Ident>, String>;
 }
 
 impl<Id: Clone> Typed for TypedIdent<Id> {
     type Ident = Id;
 
-    fn try_type_of(&self, _: &TypeEnv<Type = ArcType>) -> Result<ArcType<Id>, String> {
+    fn try_type_of(&self, _: &dyn TypeEnv<Type = ArcType>) -> Result<ArcType<Id>, String> {
         Ok(self.typ.clone())
     }
 }
@@ -871,7 +871,7 @@ impl<Id: Clone> Typed for TypedIdent<Id> {
 impl Typed for Literal {
     type Ident = Symbol;
 
-    fn try_type_of(&self, _: &TypeEnv<Type = ArcType>) -> Result<ArcType, String> {
+    fn try_type_of(&self, _: &dyn TypeEnv<Type = ArcType>) -> Result<ArcType, String> {
         Ok(match *self {
             Literal::Int(_) => Type::int(),
             Literal::Float(_) => Type::float(),
@@ -885,7 +885,7 @@ impl Typed for Literal {
 impl Typed for Expr<Symbol> {
     type Ident = Symbol;
 
-    fn try_type_of(&self, env: &TypeEnv<Type = ArcType>) -> Result<ArcType, String> {
+    fn try_type_of(&self, env: &dyn TypeEnv<Type = ArcType>) -> Result<ArcType, String> {
         match *self {
             Expr::Ident(ref id) => Ok(id.typ.clone()),
             Expr::Projection(_, _, ref typ)
@@ -916,14 +916,14 @@ impl Typed for Expr<Symbol> {
 impl<T: Typed> Typed for Spanned<T, BytePos> {
     type Ident = T::Ident;
 
-    fn try_type_of(&self, env: &TypeEnv<Type = ArcType>) -> Result<ArcType<T::Ident>, String> {
+    fn try_type_of(&self, env: &dyn TypeEnv<Type = ArcType>) -> Result<ArcType<T::Ident>, String> {
         self.value.try_type_of(env)
     }
 }
 
 impl Typed for Pattern<Symbol> {
     type Ident = Symbol;
-    fn try_type_of(&self, env: &TypeEnv<Type = ArcType>) -> Result<ArcType, String> {
+    fn try_type_of(&self, env: &dyn TypeEnv<Type = ArcType>) -> Result<ArcType, String> {
         // Identifier patterns might be a function so use the identifier's type instead
         match *self {
             Pattern::As(_, ref pat) => pat.try_type_of(env),
@@ -938,7 +938,7 @@ impl Typed for Pattern<Symbol> {
 }
 
 fn get_return_type(
-    env: &TypeEnv<Type = ArcType>,
+    env: &dyn TypeEnv<Type = ArcType>,
     alias_type: &ArcType,
     arg_count: usize,
 ) -> Result<ArcType, String> {

--- a/base/src/error.rs
+++ b/base/src/error.rs
@@ -308,7 +308,7 @@ where
     }
 }
 
-impl AsDiagnostic for Box<::std::error::Error + Send + Sync> {
+impl AsDiagnostic for Box<dyn ::std::error::Error + Send + Sync> {
     fn as_diagnostic(&self) -> Diagnostic {
         Diagnostic::new_error(self.to_string())
     }

--- a/base/src/resolve.rs
+++ b/base/src/resolve.rs
@@ -59,7 +59,7 @@ impl<T> AliasRemover<T> {
 
     pub fn canonical_alias<'t, F>(
         &mut self,
-        env: &TypeEnv<Type = T>,
+        env: &dyn TypeEnv<Type = T>,
         interner: &mut impl TypeContext<Symbol, T>,
         typ: &'t T,
         mut canonical: F,
@@ -98,7 +98,7 @@ impl<T> AliasRemover<T> {
 
     pub fn remove_aliases_to_concrete<'a>(
         &mut self,
-        env: &TypeEnv<Type = T>,
+        env: &dyn TypeEnv<Type = T>,
         interner: &mut impl TypeContext<Symbol, T>,
         mut typ: T,
     ) -> Result<T, Error>
@@ -135,7 +135,7 @@ impl<T> AliasRemover<T> {
 
     pub fn remove_aliases(
         &mut self,
-        env: &TypeEnv<Type = T>,
+        env: &dyn TypeEnv<Type = T>,
         interner: &mut impl TypeContext<Symbol, T>,
         mut typ: T,
     ) -> Result<T, Error>
@@ -152,7 +152,7 @@ impl<T> AliasRemover<T> {
 
     pub fn remove_alias(
         &mut self,
-        env: &TypeEnv<Type = T>,
+        env: &dyn TypeEnv<Type = T>,
         interner: &mut impl TypeContext<Symbol, T>,
         typ: &T,
     ) -> Result<Option<T>, Error>
@@ -172,7 +172,7 @@ impl<T> AliasRemover<T> {
 
     pub fn remove_alias_to_concrete<'a>(
         &mut self,
-        env: &'a TypeEnv<Type = T>,
+        env: &'a dyn TypeEnv<Type = T>,
         interner: &mut impl TypeContext<Symbol, T>,
         typ: &'a T,
     ) -> Result<Option<(T, Cow<'a, [T]>)>, Error>
@@ -232,7 +232,7 @@ impl<T> AliasRemover<T> {
 
 /// Removes type aliases from `typ` until it is an actual type
 pub fn remove_aliases<T>(
-    env: &TypeEnv<Type = T>,
+    env: &dyn TypeEnv<Type = T>,
     interner: &mut impl TypeContext<Symbol, T>,
     mut typ: T,
 ) -> T
@@ -246,7 +246,7 @@ where
 }
 
 pub fn remove_aliases_cow<'t, T>(
-    env: &TypeEnv<Type = T>,
+    env: &dyn TypeEnv<Type = T>,
 
     interner: &mut impl TypeContext<Symbol, T>,
     typ: &'t T,
@@ -263,7 +263,7 @@ where
 /// Resolves aliases until `canonical` returns `true` for an alias in which case it returns the
 /// type that directly contains that alias
 pub fn canonical_alias<'t, F, T>(
-    env: &TypeEnv<Type = T>,
+    env: &dyn TypeEnv<Type = T>,
     interner: &mut impl TypeContext<Symbol, T>,
     typ: &'t T,
     mut canonical: F,
@@ -298,7 +298,7 @@ where
 /// Expand `typ` if it is an alias that can be expanded and return the expanded type.
 /// Returns `None` if the type is not an alias or the alias could not be expanded.
 pub fn remove_alias<T>(
-    env: &TypeEnv<Type = T>,
+    env: &dyn TypeEnv<Type = T>,
     interner: &mut impl TypeContext<Symbol, T>,
     typ: &T,
 ) -> Result<Option<T>, Error>
@@ -320,7 +320,7 @@ where
 }
 
 pub fn peek_alias<'t, T>(
-    env: &'t TypeEnv<Type = T>,
+    env: &'t dyn TypeEnv<Type = T>,
     typ: &'t T,
 ) -> Result<Option<&'t AliasRef<Symbol, T>>, Error>
 where

--- a/base/src/types/mod.rs
+++ b/base/src/types/mod.rs
@@ -2178,11 +2178,11 @@ where
     A: Clone,
 {
     fn to_doc(&'a self, arena: &'a Arena<'a, A>, _: ()) -> DocBuilder<'a, Arena<'a, A>, A> {
-        self.to_doc(arena, &() as &Source)
+        self.to_doc(arena, &() as &dyn Source)
     }
 }
 
-impl<'a, I, A> ToDoc<'a, Arena<'a, A>, A, &'a Source> for ArcType<I>
+impl<'a, I, A> ToDoc<'a, Arena<'a, A>, A, &'a dyn Source> for ArcType<I>
 where
     I: AsRef<str>,
     A: Clone,
@@ -2190,7 +2190,7 @@ where
     fn to_doc(
         &'a self,
         arena: &'a Arena<'a, A>,
-        source: &'a Source,
+        source: &'a dyn Source,
     ) -> DocBuilder<'a, Arena<'a, A>, A> {
         let printer = Printer::new(arena, source);
         dt(Prec::Top, self).pretty(&printer)
@@ -2403,7 +2403,7 @@ where
         row: &'a T,
         printer: &Printer<'a, I, A>,
         open: &'static str,
-        pretty_field: &mut FnMut(&'a Field<I, T>) -> DocBuilder<'a, Arena<'a, A>, A>,
+        pretty_field: &mut dyn FnMut(&'a Field<I, T>) -> DocBuilder<'a, Arena<'a, A>, A>,
         close: &'static str,
     ) -> DocBuilder<'a, Arena<'a, A>, A>
     where
@@ -2452,7 +2452,7 @@ where
         &self,
         open: &str,
         printer: &Printer<'a, I, A>,
-        pretty_field: &mut FnMut(&'a Field<I, T>) -> DocBuilder<'a, Arena<'a, A>, A>,
+        pretty_field: &mut dyn FnMut(&'a Field<I, T>) -> DocBuilder<'a, Arena<'a, A>, A>,
     ) -> DocBuilder<'a, Arena<'a, A>, A>
     where
         A: Clone,

--- a/base/src/types/pretty_print.rs
+++ b/base/src/types/pretty_print.rs
@@ -84,9 +84,9 @@ where
 {
     width: usize,
     typ: &'a T,
-    filter: &'a Fn(&I) -> Filter,
-    symbol_text: &'a Fn(&I) -> &str,
-    annotate_symbol: &'a Fn(&I) -> Option<A>,
+    filter: &'a dyn Fn(&I) -> Filter,
+    symbol_text: &'a dyn Fn(&I) -> &str,
+    annotate_symbol: &'a dyn Fn(&I) -> Option<A>,
     _marker: PhantomData<I>,
 }
 
@@ -112,17 +112,17 @@ impl<'a, I, T, A> TypeFormatter<'a, I, T, A> {
         self
     }
 
-    pub fn filter(mut self, filter: &'a Fn(&I) -> Filter) -> Self {
+    pub fn filter(mut self, filter: &'a dyn Fn(&I) -> Filter) -> Self {
         self.filter = filter;
         self
     }
 
-    pub fn annotate_symbol(mut self, annotate_symbol: &'a Fn(&I) -> Option<A>) -> Self {
+    pub fn annotate_symbol(mut self, annotate_symbol: &'a dyn Fn(&I) -> Option<A>) -> Self {
         self.annotate_symbol = annotate_symbol;
         self
     }
 
-    pub fn symbol_text(mut self, symbol_text: &'a Fn(&I) -> &str) -> Self {
+    pub fn symbol_text(mut self, symbol_text: &'a dyn Fn(&I) -> &str) -> Self {
         self.symbol_text = symbol_text;
         self
     }
@@ -143,7 +143,7 @@ impl<'a, I, T, A> TypeFormatter<'a, I, T, A> {
         })
     }
 
-    pub fn build(&self, arena: &'a Arena<'a, A>, source: &'a Source) -> Printer<'a, I, A> {
+    pub fn build(&self, arena: &'a Arena<'a, A>, source: &'a dyn Source) -> Printer<'a, I, A> {
         Printer {
             arena,
             source,
@@ -176,14 +176,14 @@ where
 
 pub struct Printer<'a, I: 'a, A: 'a> {
     pub arena: &'a Arena<'a, A>,
-    pub source: &'a Source,
-    filter: &'a Fn(&I) -> Filter,
-    symbol_text: &'a Fn(&I) -> &str,
-    annotate_symbol: &'a Fn(&I) -> Option<A>,
+    pub source: &'a dyn Source,
+    filter: &'a dyn Fn(&I) -> Filter,
+    symbol_text: &'a dyn Fn(&I) -> &str,
+    annotate_symbol: &'a dyn Fn(&I) -> Option<A>,
 }
 
 impl<'a, I, A> Printer<'a, I, A> {
-    pub fn new(arena: &'a Arena<'a, A>, source: &'a Source) -> Printer<'a, I, A>
+    pub fn new(arena: &'a Arena<'a, A>, source: &'a dyn Source) -> Printer<'a, I, A>
     where
         I: AsRef<str>,
     {

--- a/book/src/marshalling-types.md
+++ b/book/src/marshalling-types.md
@@ -160,8 +160,8 @@ let val = match an_enum {
 
 #### Userdata
 
-Implementing `Userdata` is straight forward: there are no required methods, so we can simply
-use the default implementation. However, `Userdata` also requires the type to implement
+Implementing `Userdata` is straight forward: we can either `derive` the trait or use the default
+implementation since there are no required methods. However, `Userdata` also requires the type to implement
 `VmType` and `Trace`. We can use the minimal `VmType` implementation, it already
 provides the correct `make_type` function for us:
 
@@ -174,21 +174,24 @@ where
 }
 ```
 
-In our case, the `Trace` implementation can also be left empty. Only if a type contains
-types that are managed by Gluon's GC, it is necessary to implement the `traverse` method
-in order to call `traverse` on those types. This way the GC can find all the value it manages.
+The `Trace` implementation can be automatically derived in most cases as it will just call it's methods on every field
+of the type. However, this means that it expects that every field also implements `Trace`, if that is not the case you
+can opt out of tracing with the `#[gluon_trace(skip)]` attribute. This is fine in many cases but can cause reference
+cycles if your userdata stores values managed by Gluon's GC. However if it doesn't it is safe to just use `skip`.
 
 ```rust,ignore
-// empty impl for 'normal' types
-impl<T> Trace for GluonUser<T> {}
-
-// for a type that contains a Traversable type, we need to call
-// its traverse method
-impl Trace for ContainsGcPtr {
-    fn trace(&self, gc: &mut Gc) {
-        self.gc_ptr.traverse(gc);
-    }
+// Contains no gluon managed values so skipping the trace causes no issues
+#[derive(Trace)]
+#[gluon_trace(skip)]
+struct SimpleType {
+    name: String,
+    slot: Mutex<i32>,
 }
+
+// Here we store a `OpaqueValue` which is managed by gluon's GC. To avoid a reference cycle we must trace
+// the field so gluon can find it
+#[derive(Trace)]
+struct Callback(Mutex<OpaqueValue<RootedThread, fn (i32) -> String>>);
 ```
 
 ## Passing values to and from Gluon

--- a/book/src/marshalling-types.md
+++ b/book/src/marshalling-types.md
@@ -162,7 +162,7 @@ let val = match an_enum {
 
 Implementing `Userdata` is straight forward: there are no required methods, so we can simply
 use the default implementation. However, `Userdata` also requires the type to implement
-`VmType` and `Traverseable`. We can use the minimal `VmType` implementation, it already
+`VmType` and `Trace`. We can use the minimal `VmType` implementation, it already
 provides the correct `make_type` function for us:
 
 ```rust,ignore
@@ -174,18 +174,18 @@ where
 }
 ```
 
-In our case, the `Traverseable` implementation can also be left empty. Only if a type contains
+In our case, the `Trace` implementation can also be left empty. Only if a type contains
 types that are managed by Gluon's GC, it is necessary to implement the `traverse` method
 in order to call `traverse` on those types. This way the GC can find all the value it manages.
 
 ```rust,ignore
 // empty impl for 'normal' types
-impl<T> Traverseable for GluonUser<T> {}
+impl<T> Trace for GluonUser<T> {}
 
 // for a type that contains a Traversable type, we need to call
 // its traverse method
-impl Traverseable for ContainsGcPtr {
-    fn traverse(&self, gc: &mut Gc) {
+impl Trace for ContainsGcPtr {
+    fn trace(&self, gc: &mut Gc) {
         self.gc_ptr.traverse(gc);
     }
 }

--- a/book/src/marshalling-types.md
+++ b/book/src/marshalling-types.md
@@ -185,13 +185,13 @@ cycles if your userdata stores values managed by Gluon's GC. However if it doesn
 #[gluon_trace(skip)]
 struct SimpleType {
     name: String,
-    slot: Mutex<i32>,
+    slot: std::sync::Mutex<i32>,
 }
 
 // Here we store a `OpaqueValue` which is managed by gluon's GC. To avoid a reference cycle we must trace
-// the field so gluon can find it
+// the field so gluon can find it. `gc::Mutex` is a drop-in replacement for `std::sync::Mutex` which is GC aware.
 #[derive(Trace)]
-struct Callback(Mutex<OpaqueValue<RootedThread, fn (i32) -> String>>);
+struct Callback(gluon::vm::gc::Mutex<OpaqueValue<RootedThread, fn (i32) -> String>>);
 ```
 
 ## Passing values to and from Gluon

--- a/check/src/implicits.rs
+++ b/check/src/implicits.rs
@@ -738,7 +738,7 @@ impl<'a, 'b, 'c> MutVisitor<'c> for ResolveImplicitsVisitor<'a, 'b> {
 
 pub struct ImplicitResolver<'a> {
     pub(crate) metadata: &'a mut FnvMap<Symbol, Arc<Metadata>>,
-    environment: &'a TypecheckEnv<Type = RcType>,
+    environment: &'a dyn TypecheckEnv<Type = RcType>,
     pub(crate) implicit_bindings: ImplicitBindings,
     pub(crate) implicit_vars: ScopedMap<Symbol, Level>,
     visited: ScopedMap<Box<[Symbol]>, Box<[RcType]>>,
@@ -749,7 +749,7 @@ pub struct ImplicitResolver<'a> {
 
 impl<'a> ImplicitResolver<'a> {
     pub fn new(
-        environment: &'a TypecheckEnv<Type = RcType>,
+        environment: &'a dyn TypecheckEnv<Type = RcType>,
         metadata: &'a mut FnvMap<Symbol, Arc<Metadata>>,
     ) -> ImplicitResolver<'a> {
         ImplicitResolver {

--- a/check/src/kindcheck.rs
+++ b/check/src/kindcheck.rs
@@ -24,8 +24,8 @@ pub type Result<T> = StdResult<T, SpannedError<Symbol, RcType<Symbol>>>;
 /// Struct containing methods for kindchecking types
 pub struct KindCheck<'a> {
     variables: ScopedMap<Symbol, ArcKind>,
-    info: &'a (TypeEnv<Type = RcType> + 'a),
-    idents: &'a mut (ast::IdentEnv<Ident = Symbol> + 'a),
+    info: &'a (dyn TypeEnv<Type = RcType> + 'a),
+    idents: &'a mut (dyn ast::IdentEnv<Ident = Symbol> + 'a),
     subs: Substitution<ArcKind>,
     kind_cache: KindCache,
     /// A cached one argument kind function, `Type -> Type`
@@ -66,8 +66,8 @@ where
 
 impl<'a> KindCheck<'a> {
     pub fn new(
-        info: &'a (TypeEnv<Type = RcType> + 'a),
-        idents: &'a mut (ast::IdentEnv<Ident = Symbol> + 'a),
+        info: &'a (dyn TypeEnv<Type = RcType> + 'a),
+        idents: &'a mut (dyn ast::IdentEnv<Ident = Symbol> + 'a),
         kind_cache: KindCache,
     ) -> KindCheck<'a> {
         let typ = kind_cache.typ();

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -41,7 +41,7 @@ use crate::{substitution::Substitution, typ::RcType};
 
 /// Checks if `actual` can be assigned to a binding with the type signature `signature`
 pub fn check_signature(
-    env: &TypecheckEnv<Type = ArcType>,
+    env: &dyn TypecheckEnv<Type = ArcType>,
     signature: &ArcType,
     actual: &ArcType,
 ) -> bool {
@@ -52,7 +52,7 @@ pub fn check_signature(
 }
 
 fn check_signature_(
-    env: &TypeEnv<Type = RcType>,
+    env: &dyn TypeEnv<Type = RcType>,
     interner: &SharedInterner<Symbol, RcType>,
     signature: &RcType,
     actual: &RcType,

--- a/check/src/metadata.rs
+++ b/check/src/metadata.rs
@@ -10,7 +10,7 @@ use crate::base::symbol::{Name, Symbol};
 use crate::base::types::{row_iter, TypeExt};
 
 struct Environment<'b> {
-    env: &'b MetadataEnv,
+    env: &'b dyn MetadataEnv,
     stack: FnvMap<Symbol, Arc<Metadata>>,
 }
 
@@ -119,7 +119,7 @@ impl MaybeMetadata {
 
 /// Queries `expr` for the metadata which it contains.
 pub fn metadata(
-    env: &MetadataEnv,
+    env: &dyn MetadataEnv,
     expr: &SpannedExpr<Symbol>,
 ) -> (Arc<Metadata>, FnvMap<Symbol, Arc<Metadata>>) {
     struct MetadataVisitor<'b> {

--- a/check/src/typecheck/generalize.rs
+++ b/check/src/typecheck/generalize.rs
@@ -77,7 +77,7 @@ impl<'a, 'b> TypeGeneralizer<'a, 'b> {
     /// type variable in the `id 2` call.
     pub(crate) fn generalize_variables<'i>(
         &mut self,
-        args: &mut Iterator<Item = &'i mut SpannedIdent<Symbol>>,
+        args: &mut dyn Iterator<Item = &'i mut SpannedIdent<Symbol>>,
         expr: &mut SpannedExpr<Symbol>,
     ) {
         self.tc.environment.skolem_variables.enter_scope();

--- a/check/src/unify.rs
+++ b/check/src/unify.rs
@@ -301,7 +301,7 @@ mod test {
         where
             F: Walker<'a, Self>,
         {
-            fn traverse_<'t>(typ: &'t TType, f: &mut Walker<'t, TType>) {
+            fn traverse_<'t>(typ: &'t TType, f: &mut dyn Walker<'t, TType>) {
                 match *typ.0 {
                     Type::Arrow(ref a, ref r) => {
                         f.walk(a);

--- a/check/tests/metadata.rs
+++ b/check/tests/metadata.rs
@@ -16,7 +16,7 @@ use crate::base::{
     symbol::{Symbol, SymbolRef},
 };
 
-fn metadata(env: &MetadataEnv, expr: &mut SpannedExpr<Symbol>) -> Metadata {
+fn metadata(env: &dyn MetadataEnv, expr: &mut SpannedExpr<Symbol>) -> Metadata {
     Metadata::clone(&check::metadata::metadata(env, expr).0)
 }
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -140,8 +140,8 @@
 //!
 //! use std::sync::Arc;
 //!
-//! // Userdata requires Debug + Send + Sync
-//! #[derive(Userdata, Debug)]
+//! // Userdata requires Traverseable + Debug + Send + Sync
+//! #[derive(Userdata, Traverseable, Debug)]
 //! struct Ident {
 //!     group: Arc<str>,
 //!     name: Arc<str>,
@@ -192,7 +192,7 @@ pub fn vm_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 #[doc(hidden)]
-#[proc_macro_derive(Traverseable, attributes(gluon))]
+#[proc_macro_derive(Traverseable, attributes(gluon, gluon_trace))]
 pub fn traverseable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     traverseable::derive(input.into()).into()
 }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -125,7 +125,7 @@
 //!
 //! ### Userdata
 //!
-//! Derives `Userdata` and the required `Traverseable` and `VmType` for a rust type.
+//! Derives `Userdata` and the required `Trace` and `VmType` for a rust type.
 //! Note that you will still have to use `Thread::register_type` to register the
 //! rust type with the vm before it is used.
 //!
@@ -140,8 +140,8 @@
 //!
 //! use std::sync::Arc;
 //!
-//! // Userdata requires Traverseable + Debug + Send + Sync
-//! #[derive(Userdata, Traverseable, Debug)]
+//! // Userdata requires Trace + Debug + Send + Sync
+//! #[derive(Userdata, Trace, Debug)]
 //! struct Ident {
 //!     group: Arc<str>,
 //!     name: Arc<str>,
@@ -163,7 +163,7 @@ mod functor;
 mod getable;
 mod pushable;
 mod shared;
-mod traverseable;
+mod trace;
 mod userdata;
 mod vm_type;
 
@@ -192,9 +192,9 @@ pub fn vm_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 #[doc(hidden)]
-#[proc_macro_derive(Traverseable, attributes(gluon, gluon_trace))]
-pub fn traverseable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    traverseable::derive(input.into()).into()
+#[proc_macro_derive(Trace, attributes(gluon, gluon_trace))]
+pub fn trace(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    trace::derive(input.into()).into()
 }
 
 #[doc(hidden)]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -163,6 +163,7 @@ mod functor;
 mod getable;
 mod pushable;
 mod shared;
+mod traverseable;
 mod userdata;
 mod vm_type;
 
@@ -188,6 +189,12 @@ pub fn userdata(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 #[proc_macro_derive(VmType, attributes(gluon))]
 pub fn vm_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     vm_type::derive(input.into()).into()
+}
+
+#[doc(hidden)]
+#[proc_macro_derive(Traverseable, attributes(gluon))]
+pub fn traverseable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    traverseable::derive(input.into()).into()
 }
 
 #[doc(hidden)]

--- a/codegen/src/trace.rs
+++ b/codegen/src/trace.rs
@@ -143,16 +143,18 @@ fn gen_impl(
             unsafe impl #impl_generics _gluon_gc::Trace for #ident #ty_generics
                 #where_clause #(#trace_bounds,)*
             {
-                unsafe fn root(&self, gc: &mut _gluon_gc::Gc) {
-                    unsafe fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
-                        _gluon_gc::Trace::root(this, gc)
+                unsafe fn root(&self) {
+                    unsafe fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, _: ()) {
+                        _gluon_gc::Trace::root(this)
                     }
+                    let gc = ();
                     #push_impl
                 }
-                unsafe fn unroot(&self, gc: &mut _gluon_gc::Gc) {
-                    unsafe fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
-                        _gluon_gc::Trace::unroot(this, gc)
+                unsafe fn unroot(&self) {
+                    unsafe fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, _: ()) {
+                        _gluon_gc::Trace::unroot(this)
                     }
+                    let gc = ();
                     #push_impl
                 }
                 fn trace(&self, gc: &mut _gluon_gc:: Gc) {

--- a/codegen/src/trace.rs
+++ b/codegen/src/trace.rs
@@ -140,17 +140,17 @@ fn gen_impl(
 
             #[automatically_derived]
             #[allow(unused_attributes, unused_variables)]
-            impl #impl_generics _gluon_gc::Trace for #ident #ty_generics
+            unsafe impl #impl_generics _gluon_gc::Trace for #ident #ty_generics
                 #where_clause #(#trace_bounds,)*
             {
-                fn root(&self, gc: &mut _gluon_gc::Gc) {
-                    fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
+                unsafe fn root(&self, gc: &mut _gluon_gc::Gc) {
+                    unsafe fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
                         _gluon_gc::Trace::root(this, gc)
                     }
                     #push_impl
                 }
-                fn unroot(&self, gc: &mut _gluon_gc::Gc) {
-                    fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
+                unsafe fn unroot(&self, gc: &mut _gluon_gc::Gc) {
+                    unsafe fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
                         _gluon_gc::Trace::unroot(this, gc)
                     }
                     #push_impl

--- a/codegen/src/trace.rs
+++ b/codegen/src/trace.rs
@@ -112,7 +112,7 @@ fn gen_impl(
     push_impl: TokenStream,
 ) -> TokenStream {
     // generate bounds like T: Getable for every type parameter
-    let traverseable_bounds = create_traverseable_bounds(&generics);
+    let trace_bounds = create_trace_bounds(&generics);
 
     let (impl_generics, ty_generics, where_clause) = split_for_impl(&generics, &[]);
 
@@ -140,24 +140,24 @@ fn gen_impl(
 
             #[automatically_derived]
             #[allow(unused_attributes, unused_variables)]
-            impl #impl_generics _gluon_gc::Traverseable for #ident #ty_generics
-                #where_clause #(#traverseable_bounds,)*
+            impl #impl_generics _gluon_gc::Trace for #ident #ty_generics
+                #where_clause #(#trace_bounds,)*
             {
                 fn root(&self, gc: &mut _gluon_gc::Gc) {
-                    fn mark<T: ?Sized + _gluon_gc::Traverseable>(this: &T, gc: &mut _gluon_gc::Gc) {
-                        _gluon_gc::Traverseable::root(this, gc)
+                    fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
+                        _gluon_gc::Trace::root(this, gc)
                     }
                     #push_impl
                 }
                 fn unroot(&self, gc: &mut _gluon_gc::Gc) {
-                    fn mark<T: ?Sized + _gluon_gc::Traverseable>(this: &T, gc: &mut _gluon_gc::Gc) {
-                        _gluon_gc::Traverseable::unroot(this, gc)
+                    fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
+                        _gluon_gc::Trace::unroot(this, gc)
                     }
                     #push_impl
                 }
-                fn traverse(&self, gc: &mut _gluon_gc:: Gc) {
-                    fn mark<T: ?Sized + _gluon_gc::Traverseable>(this: &T, gc: &mut _gluon_gc::Gc) {
-                        _gluon_gc::Traverseable::traverse(this, gc)
+                fn trace(&self, gc: &mut _gluon_gc:: Gc) {
+                    fn mark<T: ?Sized + _gluon_gc::Trace>(this: &T, gc: &mut _gluon_gc::Gc) {
+                        _gluon_gc::Trace::trace(this, gc)
                     }
                     #push_impl
                 }
@@ -184,10 +184,10 @@ fn gen_variant_match(ident: &Ident, variant: &Variant) -> TokenStream {
     }
 }
 
-fn create_traverseable_bounds(generics: &Generics) -> Vec<TokenStream> {
+fn create_trace_bounds(generics: &Generics) -> Vec<TokenStream> {
     map_type_params(generics, |ty| {
         quote! {
-            #ty: _gluon_gc::Traverseable
+            #ty: _gluon_gc::Trace
         }
     })
 }

--- a/codegen/src/traverseable.rs
+++ b/codegen/src/traverseable.rs
@@ -1,0 +1,200 @@
+use std::borrow::Cow;
+
+use {
+    proc_macro2::{Span, TokenStream},
+    shared::{map_type_params, split_for_impl},
+    syn::{
+        self, Data, DataEnum, DataStruct, DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed,
+        Generics, Ident, Type, Variant,
+    },
+};
+
+use attr;
+
+pub fn derive(input: TokenStream) -> TokenStream {
+    let derive_input = syn::parse2(input).expect("Input is checked by rustc");
+
+    let container = attr::Container::from_ast(&derive_input);
+
+    let DeriveInput {
+        ident,
+        data,
+        generics,
+        ..
+    } = derive_input;
+
+    let tokens = match data {
+        Data::Struct(ast) => derive_struct(&container, ast, ident, generics),
+        Data::Enum(ast) => derive_enum(&container, ast, ident, generics),
+        Data::Union(_) => panic!("Unions are not supported"),
+    };
+
+    tokens.into()
+}
+
+fn derive_struct(
+    container: &attr::Container,
+    ast: DataStruct,
+    ident: Ident,
+    generics: Generics,
+) -> TokenStream {
+    let cons = match ast.fields {
+        Fields::Named(FieldsNamed { named, .. }) => gen_struct_cons(&ident, &named),
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => gen_tuple_struct_cons(&ident, &unnamed),
+        Fields::Unit => quote! { #ident },
+    };
+
+    gen_impl(container, ident, generics, cons)
+}
+
+fn gen_struct_cons<'a, I>(_ident: &Ident, fields: I) -> TokenStream
+where
+    I: IntoIterator<Item = &'a Field>,
+{
+    let fields = fields.into_iter().map(|field| &field.ident);
+    quote! {
+        #(mark(&self.#fields, gc);)*
+    }
+}
+
+fn gen_tuple_struct_cons<'a, I>(ident: &Ident, fields: I) -> TokenStream
+where
+    I: IntoIterator<Item = &'a Field>,
+{
+    let fields = fields
+        .into_iter()
+        .enumerate()
+        .map(|(idx, _)| Ident::new(&format!("_{}", idx), Span::call_site()))
+        .collect::<Vec<_>>();
+    let fields = &fields;
+    quote! {
+        match self {
+            #ident(#(#fields,)*) => {
+                #(mark(#fields, gc);)*
+            }
+        }
+    }
+}
+
+fn derive_enum(
+    container: &attr::Container,
+    ast: DataEnum,
+    ident: Ident,
+    generics: Generics,
+) -> TokenStream {
+    let cons;
+    {
+        let variants = ast
+            .variants
+            .iter()
+            .map(|variant| gen_variant_match(&ident, variant));
+
+        cons = quote! {
+
+            match self {
+                #(#variants,)*
+            }
+        };
+    }
+
+    gen_impl(container, ident, generics, cons)
+}
+
+fn gen_impl(
+    container: &attr::Container,
+    ident: Ident,
+    generics: Generics,
+    push_impl: TokenStream,
+) -> TokenStream {
+    // generate bounds like T: Getable for every type parameter
+    let traverseable_bounds = create_traverseable_bounds(&generics);
+
+    let (impl_generics, ty_generics, where_clause) = split_for_impl(&generics, &[]);
+
+    let dummy_const = Ident::new(
+        &format!("_IMPL_TRAVERSEABLE_FOR_{}", ident),
+        Span::call_site(),
+    );
+
+    let gluon = match container.crate_name {
+        attr::CrateName::Some(ref ident) => quote! {
+            use #ident::gc as _gluon_gc;
+        },
+        attr::CrateName::GluonVm => quote! {
+            use crate::gc as _gluon_gc;
+        },
+        attr::CrateName::None => quote! {
+            use gluon::vm::gc as _gluon_gc;
+        },
+    };
+
+    quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy_const: () = {
+            #gluon
+
+            #[automatically_derived]
+            #[allow(unused_attributes, unused_variables)]
+            impl #impl_generics _gluon_gc::Traverseable for #ident #ty_generics
+                #where_clause #(#traverseable_bounds,)*
+            {
+                fn traverse(&self, gc: &mut _gluon_gc:: Gc) {
+                    fn mark<T: ?Sized + _gluon_gc::Traverseable>(this: &T, gc: &mut _gluon_gc::Gc) {
+                        _gluon_gc::Traverseable::traverse(this, gc)
+                    }
+                    #push_impl
+                }
+            }
+        };
+    }
+}
+
+fn gen_variant_match(ident: &Ident, variant: &Variant) -> TokenStream {
+    let (field_idents, _field_types) = get_info_from_fields(&variant.fields);
+    let field_idents2 = &field_idents;
+    let variant_ident = &variant.ident;
+
+    let pattern = match &variant.fields {
+        Fields::Named(_) => quote! { #ident::#variant_ident{ #(#field_idents2),* } },
+        Fields::Unnamed(_) => quote! { #ident::#variant_ident( #(#field_idents2),* ) },
+        Fields::Unit => quote! { #ident::#variant_ident },
+    };
+
+    quote! {
+        #pattern => {
+            #(mark(#field_idents2);)*
+        }
+    }
+}
+
+fn create_traverseable_bounds(generics: &Generics) -> Vec<TokenStream> {
+    map_type_params(generics, |ty| {
+        quote! {
+            #ty: _gluon_api::Traverseable
+        }
+    })
+}
+
+fn get_info_from_fields(fields: &Fields) -> (Vec<Cow<Ident>>, Vec<&Type>) {
+    // get all the fields if there are any
+    let fields = match fields {
+        Fields::Named(FieldsNamed { named, .. }) => named,
+        Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => unnamed,
+        Fields::Unit => return (Vec::new(), Vec::new()),
+    };
+
+    fields
+        .iter()
+        .enumerate()
+        .map(|(idx, field)| {
+            // if the fields belong to a struct we use the field name,
+            // otherwise generate one from the index of the tuple element
+            let ident = match &field.ident {
+                Some(ident) => Cow::Borrowed(ident),
+                None => Cow::Owned(Ident::new(&format!("_{}", idx), Span::call_site())),
+            };
+
+            (ident, &field.ty)
+        })
+        .unzip()
+}

--- a/codegen/src/traverseable.rs
+++ b/codegen/src/traverseable.rs
@@ -45,7 +45,7 @@ fn derive_struct(
     let cons = match ast.fields {
         Fields::Named(FieldsNamed { named, .. }) => gen_struct_cons(&ident, &named),
         Fields::Unnamed(FieldsUnnamed { unnamed, .. }) => gen_tuple_struct_cons(&ident, &unnamed),
-        Fields::Unit => quote! { #ident },
+        Fields::Unit => quote! {},
     };
 
     gen_impl(container, ident, generics, cons)

--- a/codegen/src/userdata.rs
+++ b/codegen/src/userdata.rs
@@ -61,10 +61,6 @@ fn gen_impl(container: &Container, ident: Ident, generics: Generics) -> TokenStr
             #where_clause #(#trait_bounds,)* #(#lifetime_bounds),*
             {
             }
-
-            #[automatically_derived]
-            #[allow(unused_attributes, unused_variables)]
-            impl #impl_generics _gluon_gc::Traverseable for #ident #ty_generics {}
         };
     }
 }

--- a/codegen/tests/derive_userdata.rs
+++ b/codegen/tests/derive_userdata.rs
@@ -66,3 +66,7 @@ fn userdata() {
         panic!("{}", why);
     }
 }
+
+#[derive(Userdata, Traverseable, Debug, VmType)]
+#[gluon(vm_type = "Empty")]
+struct Empty;

--- a/codegen/tests/derive_userdata.rs
+++ b/codegen/tests/derive_userdata.rs
@@ -11,7 +11,7 @@ use gluon::{import, Compiler, Thread};
 use init::new_vm;
 use std::sync::Arc;
 
-#[derive(Userdata, Traverseable, Debug, VmType)]
+#[derive(Userdata, Trace, Debug, VmType)]
 #[gluon(vm_type = "WindowHandle")]
 struct WindowHandle {
     id: Arc<u64>,
@@ -67,6 +67,6 @@ fn userdata() {
     }
 }
 
-#[derive(Userdata, Traverseable, Debug, VmType)]
+#[derive(Userdata, Trace, Debug, VmType)]
 #[gluon(vm_type = "Empty")]
 struct Empty;

--- a/codegen/tests/derive_userdata.rs
+++ b/codegen/tests/derive_userdata.rs
@@ -11,7 +11,7 @@ use gluon::{import, Compiler, Thread};
 use init::new_vm;
 use std::sync::Arc;
 
-#[derive(Userdata, Debug, VmType)]
+#[derive(Userdata, Traverseable, Debug, VmType)]
 #[gluon(vm_type = "WindowHandle")]
 struct WindowHandle {
     id: Arc<u64>,

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -796,7 +796,7 @@ pub trait Extract<'a>: Sized {
 
 #[derive(Clone, Copy)]
 pub struct TypeAt<'a> {
-    pub env: &'a TypeEnv<Type = ArcType>,
+    pub env: &'a dyn TypeEnv<Type = ArcType>,
 }
 impl<'a> Extract<'a> for TypeAt<'a> {
     type Output = Either<ArcKind, ArcType>;
@@ -1552,7 +1552,7 @@ pub struct SignatureHelp {
 }
 
 pub fn signature_help(
-    env: &TypeEnv<Type = ArcType>,
+    env: &dyn TypeEnv<Type = ArcType>,
     source_span: Span<BytePos>,
     expr: &SpannedExpr<Symbol>,
     pos: BytePos,

--- a/doc/src/lib.rs
+++ b/doc/src/lib.rs
@@ -165,7 +165,7 @@ pub fn record(
     current_module: &str,
     typ: &ArcType,
     symbols: &FnvMap<&Symbol, completion::SpCompletionSymbol>,
-    source: &Source,
+    source: &dyn Source,
     meta: &Metadata,
 ) -> Record {
     let line_number = |meta: &Metadata| -> Option<u32> {
@@ -315,7 +315,7 @@ fn handlebars() -> Result<Handlebars> {
                   _: &Handlebars,
                   _context: &Context,
                   _rc: &mut RenderContext,
-                  out: &mut Output| {
+                  out: &mut dyn Output| {
                 let param = String::deserialize(h.param(0).unwrap().value())?;
                 out.write(&param.replace(".", "/"))?;
                 Ok(())
@@ -328,7 +328,7 @@ fn handlebars() -> Result<Handlebars> {
         _: &Handlebars,
         context: &Context,
         _rc: &mut RenderContext,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> ::std::result::Result<(), RenderError> {
         let current_module = &context.data()["name"].as_str().expect("name").to_string();
 
@@ -343,7 +343,7 @@ fn handlebars() -> Result<Handlebars> {
         _: &Handlebars,
         context: &Context,
         _rc: &mut RenderContext,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> ::std::result::Result<(), RenderError> {
         let current_module = &context.data()["name"].as_str().expect("name").to_string();
         let parent_breadcrumb = current_module.rsplit('.').nth(1);
@@ -364,7 +364,7 @@ fn handlebars() -> Result<Handlebars> {
         _: &Handlebars,
         context: &Context,
         _rc: &mut RenderContext,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> ::std::result::Result<(), RenderError> {
         let current_module = context.data()["name"].as_str().expect("name");
         let current_module_level = current_module.split('.').count();
@@ -399,7 +399,7 @@ fn handlebars() -> Result<Handlebars> {
         _: &Handlebars,
         context: &Context,
         _: &mut RenderContext,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> ::std::result::Result<(), RenderError> {
         let current_module = &context.data()["name"].as_str().expect("name").to_string();
         let relative_path = current_module.split('.').map(|_| "../").format("");
@@ -417,7 +417,7 @@ fn handlebars() -> Result<Handlebars> {
         _: &Handlebars,
         _: &Context,
         _: &mut RenderContext,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> ::std::result::Result<(), RenderError> {
         let param = String::deserialize(h.param(0).unwrap().value())?;
 
@@ -449,7 +449,7 @@ fn handlebars() -> Result<Handlebars> {
         _: &Handlebars,
         _: &Context,
         _: &mut RenderContext,
-        out: &mut Output,
+        out: &mut dyn Output,
     ) -> ::std::result::Result<(), RenderError> {
         let param = String::deserialize(h.param(0).unwrap().value())?;
 

--- a/examples/24.rs
+++ b/examples/24.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 }
 
-fn main_() -> Result<(), Box<std::error::Error>> {
+fn main_() -> Result<(), Box<dyn std::error::Error>> {
     let thread = gluon::new_vm();
 
     let mut source = String::new();

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -334,7 +334,7 @@ fn marshal_wrapper() -> Result<()> {
     Ok(())
 }
 
-#[derive(Userdata, Traverseable, Debug, Clone, VmType)]
+#[derive(Userdata, Trace, Debug, Clone, VmType)]
 #[gluon(vm_type = "WindowHandle")]
 struct WindowHandle {
     id: Arc<u64>,

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -334,7 +334,7 @@ fn marshal_wrapper() -> Result<()> {
     Ok(())
 }
 
-#[derive(Userdata, Debug, Clone, VmType)]
+#[derive(Userdata, Traverseable, Debug, Clone, VmType)]
 #[gluon(vm_type = "WindowHandle")]
 struct WindowHandle {
     id: Arc<u64>,

--- a/format/src/pretty_print.rs
+++ b/format/src/pretty_print.rs
@@ -61,7 +61,7 @@ where
 {
     pub(super) fn new(
         arena: &'a Arena<'a, A>,
-        source: &'a source::Source,
+        source: &'a dyn source::Source,
         formatter: crate::Formatter,
     ) -> Self {
         Printer {

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -21,7 +21,7 @@ travis-ci = { repository = "gluon-lang/gluon" }
 collect-mac = "0.1.0"
 itertools = "0.8"
 quick-error = "1.0.0"
-lalrpop-util = "0.16"
+lalrpop-util = "0.17"
 log = "0.4"
 pretty = "0.5"
 gluon_base = { path = "../base", version = "0.11.2" } # GLUON
@@ -35,4 +35,4 @@ difference = "2"
 pretty_assertions = "0.5"
 
 [build-dependencies]
-lalrpop = "0.16"
+lalrpop = "0.17"

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -17,7 +17,7 @@ use crate::ordered_float::NotNan;
 
 use crate::{Error, ErrorEnv, FieldExpr, FieldPattern, MutIdentEnv};
 
-grammar<'input, 'env, Id>(input: &'input crate::ParserSource, type_cache: &TypeCache<Id, ArcType<Id>>, env: MutIdentEnv<'env, Id>, errors: ErrorEnv<'env, 'input>)
+grammar<'input, 'env, Id>(input: &'input dyn crate::ParserSource, type_cache: &TypeCache<Id, ArcType<Id>>, env: MutIdentEnv<'env, Id>, errors: ErrorEnv<'env, 'input>)
     where Id: Clone + AsRef<str>;
 
 extern {
@@ -645,7 +645,7 @@ PlainValueBinding: Box<ValueBinding<Id>> = {
     "let" <name: Sp<Ident>> => {
         let span = pos::Span::new(name.span.end(), name.span.end());
         errors.push(::lalrpop_util::ParseError::UnrecognizedToken {
-            token: Some((span.start(), Token::In, span.end())),
+            token: (span.start(), Token::In, span.end()),
             expected: ["=", ":"].iter().map(|s| s.to_string()).collect(),
         });
         Box::new(ValueBinding {
@@ -851,7 +851,7 @@ DoBinding: Box<(SpannedPattern<Id>, SpannedExpr<Id>)> = {
     <id: Sp<Pattern>> "in" => {
         let span = pos::Span::new(id.span.end(), id.span.end());
         errors.push(::lalrpop_util::ParseError::UnrecognizedToken {
-            token: Some((span.start(), Token::In, span.end())),
+            token: (span.start(), Token::In, span.end()),
             expected: ["="].iter().map(|s| s.to_string()).collect(),
         });
         Box::new((id, pos::spanned(span, Expr::Error(None))))

--- a/parser/src/infix.rs
+++ b/parser/src/infix.rs
@@ -202,13 +202,13 @@ where
 
 pub struct Reparser<'s, Id: 's> {
     operators: OpTable<Id>,
-    symbols: &'s IdentEnv<Ident = Id>,
+    symbols: &'s dyn IdentEnv<Ident = Id>,
     errors: Errors<Spanned<Error, BytePos>>,
     _marker: PhantomData<Id>,
 }
 
 impl<'s, Id> Reparser<'s, Id> {
-    pub fn new(operators: OpTable<Id>, symbols: &'s IdentEnv<Ident = Id>) -> Reparser<'s, Id> {
+    pub fn new(operators: OpTable<Id>, symbols: &'s dyn IdentEnv<Ident = Id>) -> Reparser<'s, Id> {
         Reparser {
             operators: operators,
             symbols: symbols,
@@ -309,7 +309,7 @@ impl StdError for Error {
 /// [`Language.Haskell.Infix`]: https://hackage.haskell.org/package/infix-0.1.1/docs/src/Language-Haskell-Infix.html
 pub fn reparse<Id>(
     expr: SpannedExpr<Id>,
-    symbols: &IdentEnv<Ident = Id>,
+    symbols: &dyn IdentEnv<Ident = Id>,
     operators: &OpTable<Id>,
 ) -> Result<SpannedExpr<Id>, (Spanned<Error, BytePos>, Option<Expr<Id>>)>
 where
@@ -522,7 +522,7 @@ mod tests {
 
     fn reparse<Id>(
         expr: SpannedExpr<Id>,
-        symbols: &IdentEnv<Ident = Id>,
+        symbols: &dyn IdentEnv<Ident = Id>,
         operators: &OpTable<Id>,
     ) -> Result<SpannedExpr<Id>, Spanned<Error, BytePos>>
     where

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -315,7 +315,7 @@ pub enum Variant<Id> {
 }
 
 // Hack around LALRPOP's limited type syntax
-type MutIdentEnv<'env, Id> = &'env mut IdentEnv<Ident = Id>;
+type MutIdentEnv<'env, Id> = &'env mut dyn IdentEnv<Ident = Id>;
 type ErrorEnv<'err, 'input> = &'err mut Errors<LalrpopError<'input>>;
 
 pub type ParseErrors = Errors<Spanned<Error, BytePos>>;
@@ -385,7 +385,7 @@ impl ParserSource for codespan::FileMap {
 }
 
 pub fn parse_partial_expr<Id, S>(
-    symbols: &mut IdentEnv<Ident = Id>,
+    symbols: &mut dyn IdentEnv<Ident = Id>,
     type_cache: &TypeCache<Id, ArcType<Id>>,
     input: &S,
 ) -> Result<SpannedExpr<Id>, (Option<SpannedExpr<Id>>, ParseErrors)>
@@ -431,7 +431,7 @@ where
 }
 
 pub fn parse_expr(
-    symbols: &mut IdentEnv<Ident = Symbol>,
+    symbols: &mut dyn IdentEnv<Ident = Symbol>,
     type_cache: &TypeCache<Symbol, ArcType>,
     input: &str,
 ) -> Result<SpannedExpr<Symbol>, ParseErrors> {
@@ -445,7 +445,7 @@ pub enum ReplLine<Id> {
 }
 
 pub fn parse_partial_repl_line<Id, S>(
-    symbols: &mut IdentEnv<Ident = Id>,
+    symbols: &mut dyn IdentEnv<Ident = Id>,
     input: &S,
 ) -> Result<Option<ReplLine<Id>>, (Option<ReplLine<Id>>, ParseErrors)>
 where
@@ -499,7 +499,7 @@ where
 
 pub fn reparse_infix<Id>(
     metadata: &FnvMap<Id, Arc<Metadata>>,
-    symbols: &IdentEnv<Ident = Id>,
+    symbols: &dyn IdentEnv<Ident = Id>,
     expr: &mut SpannedExpr<Id>,
 ) -> Result<(), ParseErrors>
 where

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -178,7 +178,7 @@ fn error<T>(location: Location, code: Error) -> Result<T, SpError> {
 fn is_ident_start(ch: u8) -> bool {
     // TODO: Unicode?
     match ch {
-        b'_' | b'a'...b'z' | b'A'...b'Z' => true,
+        b'_' | b'a'..=b'z' | b'A'..=b'Z' => true,
         _ => false,
     }
 }
@@ -186,7 +186,7 @@ fn is_ident_start(ch: u8) -> bool {
 fn is_ident_continue(ch: u8) -> bool {
     // TODO: Unicode?
     match ch {
-        b'0'...b'9' | b'\'' => true,
+        b'0'..=b'9' | b'\'' => true,
         ch => is_ident_start(ch),
     }
 }

--- a/parser/tests/error_handling.rs
+++ b/parser/tests/error_handling.rs
@@ -360,7 +360,7 @@ fn missing_close_paren() {
     let (_expr, err) = result.unwrap_err();
 
     let error = Error::UnexpectedEof([")", ",", "]"].iter().map(|s| s.to_string()).collect());
-    let span = pos::span(BytePos::from(35), BytePos::from(35));
+    let span = pos::span(BytePos::from(30), BytePos::from(30));
     assert_eq!(err, ParseErrors::from(vec![pos::spanned(span, error)]));
 }
 

--- a/parser/tests/support/mod.rs
+++ b/parser/tests/support/mod.rs
@@ -87,7 +87,7 @@ where
 }
 
 pub fn parse_string<'env, 'input>(
-    symbols: &'env mut IdentEnv<Ident = String>,
+    symbols: &'env mut dyn IdentEnv<Ident = String>,
     input: &'input str,
 ) -> Result<SpannedExpr<String>, (Option<SpannedExpr<String>>, ParseErrors)> {
     parse_partial_expr(symbols, &TypeCache::default(), input)

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -190,7 +190,7 @@ macro_rules! impl_userdata {
     };
 }
 
-#[derive(Userdata, Traverseable, VmType)]
+#[derive(Userdata, Trace, VmType)]
 #[gluon(vm_type = "Editor")]
 #[gluon_trace(skip)]
 struct Editor {
@@ -199,7 +199,7 @@ struct Editor {
 
 impl_userdata! { Editor }
 
-#[derive(Userdata, Traverseable, VmType)]
+#[derive(Userdata, Trace, VmType)]
 #[gluon(vm_type = "CpuPool")]
 #[gluon_trace(skip)]
 struct CpuPool(self::futures_cpupool::CpuPool);

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -132,7 +132,6 @@ fn switch_debug_level(args: WithVM<&str>) -> IO<Result<String, String>> {
 }
 
 fn complete(thread: &Thread, name: &str, fileinput: &str, pos: usize) -> GluonResult<Vec<String>> {
-    use crate::base::pos::BytePos;
     use gluon::compiler_pipeline::*;
 
     let mut compiler = Compiler::new();
@@ -145,6 +144,7 @@ fn complete(thread: &Thread, name: &str, fileinput: &str, pos: usize) -> GluonRe
             Err((None, err)) => return Err(err.into()),
             Err((Some(expr), err)) => (expr, Err(err.into())),
         };
+    eprintln!("{:?}", expr);
 
     // Only need the typechecker to fill infer the types as best it can regardless of errors
     let _ = (&mut expr).typecheck(&mut compiler, thread, &name, fileinput);
@@ -155,7 +155,7 @@ fn complete(thread: &Thread, name: &str, fileinput: &str, pos: usize) -> GluonRe
         &*thread.get_env(),
         file_map.span(),
         &expr,
-        BytePos::from(pos as u32),
+        file_map.span().start() + pos::ByteOffset::from(pos as i64),
     );
     Ok(suggestions
         .into_iter()

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -144,7 +144,6 @@ fn complete(thread: &Thread, name: &str, fileinput: &str, pos: usize) -> GluonRe
             Err((None, err)) => return Err(err.into()),
             Err((Some(expr), err)) => (expr, Err(err.into())),
         };
-    eprintln!("{:?}", expr);
 
     // Only need the typechecker to fill infer the types as best it can regardless of errors
     let _ = (&mut expr).typecheck(&mut compiler, thread, &name, fileinput);

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -232,7 +232,7 @@ impl<'vm> Pushable<'vm> for ReadlineError {
     }
 }
 
-fn app_dir_root() -> Result<PathBuf, Box<StdError>> {
+fn app_dir_root() -> Result<PathBuf, Box<dyn StdError>> {
     Ok(::app_dirs::app_root(
         ::app_dirs::AppDataType::UserData,
         &crate::APP_INFO,
@@ -501,7 +501,7 @@ fn save_history(editor: &Editor) -> IO<()> {
             .unwrap()
             .save_history(&*path.join("history"))
             .map_err(|err| {
-                let err: Box<StdError> = Box::new(err);
+                let err: Box<dyn StdError> = Box::new(err);
                 err
             })
     });
@@ -571,7 +571,7 @@ pub fn run(
     color: Color,
     prompt: &str,
     debug_level: DebugLevel,
-) -> impl Future<Item = (), Error = Box<StdError + Send + Sync + 'static>> {
+) -> impl Future<Item = (), Error = Box<dyn StdError + Send + Sync + 'static>> {
     let vm = ::gluon::VmBuilder::new().build();
     vm.global_env().set_debug_level(debug_level);
 

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -190,16 +190,18 @@ macro_rules! impl_userdata {
     };
 }
 
-#[derive(Userdata, VmType)]
+#[derive(Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "Editor")]
+#[gluon_trace(skip)]
 struct Editor {
     editor: Mutex<rustyline::Editor<Completer>>,
 }
 
 impl_userdata! { Editor }
 
-#[derive(Userdata, VmType)]
+#[derive(Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "CpuPool")]
+#[gluon_trace(skip)]
 struct CpuPool(self::futures_cpupool::CpuPool);
 
 impl_userdata! { CpuPool }

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -9,7 +9,6 @@
 
 use std::borrow::{Borrow, BorrowMut};
 use std::mem;
-use std::ops::Deref;
 use std::result::Result as StdResult;
 use std::sync::Arc;
 
@@ -655,7 +654,7 @@ where
 /// Result of successful execution
 pub struct ExecuteValue<T, E>
 where
-    T: Deref<Target = Thread>,
+    T: for<'a> VmRoot<'a>,
 {
     pub id: Symbol,
     pub expr: E,

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -36,7 +36,7 @@ use crate::vm::thread::{RootedThread, RootedValue, Thread, ThreadInternal, VmRoo
 
 use crate::{Compiler, Error, Result};
 
-pub type BoxFuture<'vm, T, E> = Box<Future<Item = T, Error = E> + Send + 'vm>;
+pub type BoxFuture<'vm, T, E> = Box<dyn Future<Item = T, Error = E> + Send + 'vm>;
 
 macro_rules! try_future {
     ($e:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub enum Error {
         display("{}", err)
         from()
     }
-    Other(err: Box<StdError + Send + Sync>) {
+    Other(err: Box<dyn StdError + Send + Sync>) {
         description(err.description())
         display("{}", err)
         from()

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -104,7 +104,7 @@ impl<'vm, 'value> Getable<'vm, 'value> for Headers {
 #[gluon(vm_type = "std.http.types.Body")]
 #[gluon(crate_name = "::vm")]
 // Representation of a http body that is in the prograss of being read
-pub struct Body(Arc<Mutex<Box<Stream<Item = PushAsRef<Chunk, [u8]>, Error = vm::Error> + Send>>>);
+pub struct Body(Arc<Mutex<Box<dyn Stream<Item = PushAsRef<Chunk, [u8]>, Error = vm::Error> + Send>>>);
 
 // Types implementing `Userdata` requires a `std::fmt::Debug` implementation so it can be displayed
 impl fmt::Debug for Body {
@@ -241,7 +241,7 @@ fn listen(
         type ResBody = hyper::Body;
         type Error = vm::Error;
         type Future =
-            Box<Future<Item = http::Response<hyper::Body>, Error = Self::Error> + Send + 'static>;
+            Box<dyn Future<Item = http::Response<hyper::Body>, Error = Self::Error> + Send + 'static>;
 
         fn call(&mut self, request: http::Request<hyper::Body>) -> Self::Future {
             let (parts, body) = request.into_parts();

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -100,7 +100,7 @@ impl<'vm, 'value> Getable<'vm, 'value> for Headers {
 
 // By implementing `Userdata` on `Body` it can be automatically pushed and retrieved from gluon
 // threads
-#[derive(Userdata, Traverseable, VmType)]
+#[derive(Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.http.types.Body")]
 #[gluon(crate_name = "::vm")]
 #[gluon_trace(skip)]
@@ -131,7 +131,7 @@ fn read_chunk(
 }
 
 // A http body that is being written
-#[derive(Userdata, Traverseable, VmType)]
+#[derive(Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.http.types.ResponseBody")]
 #[gluon(crate_name = "::vm")]
 #[gluon_trace(skip)]
@@ -182,7 +182,7 @@ fn write_response(
     })
 }
 
-#[derive(Debug, Userdata, Traverseable, VmType)]
+#[derive(Debug, Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.http.types.Uri")]
 #[gluon(crate_name = "::vm")]
 #[gluon_trace(skip)]

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -100,11 +100,14 @@ impl<'vm, 'value> Getable<'vm, 'value> for Headers {
 
 // By implementing `Userdata` on `Body` it can be automatically pushed and retrieved from gluon
 // threads
-#[derive(Userdata, VmType)]
+#[derive(Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "std.http.types.Body")]
 #[gluon(crate_name = "::vm")]
+#[gluon_trace(skip)]
 // Representation of a http body that is in the prograss of being read
-pub struct Body(Arc<Mutex<Box<dyn Stream<Item = PushAsRef<Chunk, [u8]>, Error = vm::Error> + Send>>>);
+pub struct Body(
+    Arc<Mutex<Box<dyn Stream<Item = PushAsRef<Chunk, [u8]>, Error = vm::Error> + Send>>>,
+);
 
 // Types implementing `Userdata` requires a `std::fmt::Debug` implementation so it can be displayed
 impl fmt::Debug for Body {
@@ -128,9 +131,10 @@ fn read_chunk(
 }
 
 // A http body that is being written
-#[derive(Userdata, VmType)]
+#[derive(Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "std.http.types.ResponseBody")]
 #[gluon(crate_name = "::vm")]
+#[gluon_trace(skip)]
 pub struct ResponseBody(Arc<Mutex<Option<hyper::body::Sender>>>);
 
 impl fmt::Debug for ResponseBody {
@@ -178,9 +182,10 @@ fn write_response(
     })
 }
 
-#[derive(Debug, Userdata, VmType)]
+#[derive(Debug, Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "std.http.types.Uri")]
 #[gluon(crate_name = "::vm")]
+#[gluon_trace(skip)]
 struct Uri(http::Uri);
 
 // Next we define some record types which are marshalled to and from gluon. These have equivalent
@@ -240,8 +245,9 @@ fn listen(
         type ReqBody = hyper::Body;
         type ResBody = hyper::Body;
         type Error = vm::Error;
-        type Future =
-            Box<dyn Future<Item = http::Response<hyper::Body>, Error = Self::Error> + Send + 'static>;
+        type Future = Box<
+            dyn Future<Item = http::Response<hyper::Body>, Error = Self::Error> + Send + 'static,
+        >;
 
         fn call(&mut self, request: http::Request<hyper::Body>) -> Self::Future {
             let (parts, body) = request.into_parts();

--- a/src/std_lib/io.rs
+++ b/src/std_lib/io.rs
@@ -49,9 +49,10 @@ fn eprintln(s: &str) -> IO<()> {
     IO::Value(())
 }
 
-#[derive(Userdata, VmType)]
+#[derive(Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "std.io.File")]
 #[gluon(crate_name = "::vm")]
+#[gluon_trace(skip)]
 struct GluonFile(Mutex<Option<File>>);
 
 macro_rules! unwrap_file {

--- a/src/std_lib/io.rs
+++ b/src/std_lib/io.rs
@@ -49,7 +49,7 @@ fn eprintln(s: &str) -> IO<()> {
     IO::Value(())
 }
 
-#[derive(Userdata, Traverseable, VmType)]
+#[derive(Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.io.File")]
 #[gluon(crate_name = "::vm")]
 #[gluon_trace(skip)]

--- a/src/std_lib/random.rs
+++ b/src/std_lib/random.rs
@@ -13,9 +13,10 @@ use crate::vm::{
     ExternModule,
 };
 
-#[derive(Clone, Debug, Userdata, VmType)]
+#[derive(Clone, Debug, Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "std.random.XorShiftRng")]
 #[gluon(crate_name = "::vm")]
+#[gluon_trace(skip)]
 struct XorShiftRng(self::rand_xorshift::XorShiftRng);
 
 field_decl! { value, gen }

--- a/src/std_lib/random.rs
+++ b/src/std_lib/random.rs
@@ -13,7 +13,7 @@ use crate::vm::{
     ExternModule,
 };
 
-#[derive(Clone, Debug, Userdata, Traverseable, VmType)]
+#[derive(Clone, Debug, Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.random.XorShiftRng")]
 #[gluon(crate_name = "::vm")]
 #[gluon_trace(skip)]

--- a/src/std_lib/regex.rs
+++ b/src/std_lib/regex.rs
@@ -6,14 +6,16 @@ use crate::real_std::error::Error as StdError;
 
 use crate::vm::{self, api::Collect, thread::Thread, ExternModule};
 
-#[derive(Debug, Userdata, VmType)]
+#[derive(Debug, Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "std.regex.Regex")]
 #[gluon(crate_name = "vm")]
+#[gluon_trace(skip)]
 struct Regex(regex::Regex);
 
-#[derive(Debug, Userdata, VmType)]
+#[derive(Debug, Userdata, Traverseable, VmType)]
 #[gluon(vm_type = "std.regex.Error")]
 #[gluon(crate_name = "vm")]
+#[gluon_trace(skip)]
 struct Error(regex::Error);
 
 fn new(re: &str) -> Result<Regex, Error> {

--- a/src/std_lib/regex.rs
+++ b/src/std_lib/regex.rs
@@ -6,13 +6,13 @@ use crate::real_std::error::Error as StdError;
 
 use crate::vm::{self, api::Collect, thread::Thread, ExternModule};
 
-#[derive(Debug, Userdata, Traverseable, VmType)]
+#[derive(Debug, Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.regex.Regex")]
 #[gluon(crate_name = "vm")]
 #[gluon_trace(skip)]
 struct Regex(regex::Regex);
 
-#[derive(Debug, Userdata, Traverseable, VmType)]
+#[derive(Debug, Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.regex.Error")]
 #[gluon(crate_name = "vm")]
 #[gluon_trace(skip)]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -44,7 +44,7 @@ fn make_vm() -> RootedThread {
     vm
 }
 
-#[derive(Debug, Userdata, Traverseable)]
+#[derive(Debug, Userdata, Trace)]
 struct Test(VmInt);
 impl VmType for Test {
     type Type = Test;
@@ -537,13 +537,13 @@ fn scoped_mutable_reference() {
 fn cyclic_userdata() {
     let _ = ::env_logger::try_init();
 
-    #[derive(Clone, Debug, Default, Userdata, Traverseable)]
+    #[derive(Clone, Debug, Default, Userdata, Trace)]
     struct NoisyDrop(Arc<()>);
     impl VmType for NoisyDrop {
         type Type = NoisyDrop;
     }
 
-    #[derive(Debug, Userdata, Traverseable)]
+    #[derive(Debug, Userdata, Trace)]
     struct Cyclic(OpaqueValue<RootedThread, NoisyDrop>);
     impl VmType for Cyclic {
         type Type = Cyclic;

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -4,11 +4,11 @@ extern crate gluon_codegen;
 use gluon::import::add_extern_module;
 use gluon::new_vm;
 use gluon::vm::api::{primitive_f, Userdata, VmType};
-use gluon::vm::gc::{Gc, Traverseable};
+use gluon::vm::gc::{Gc, Trace};
 use gluon::vm::thread::{Status, Thread};
 use gluon::vm::ExternModule;
 
-#[derive(Debug, gluon_codegen::Traverseable)]
+#[derive(Debug, gluon_codegen::Trace)]
 struct Test;
 
 impl Userdata for Test {}

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -1,22 +1,20 @@
 extern crate gluon;
-use gluon::new_vm;
-use gluon::import::add_extern_module;
-use gluon::vm::ExternModule;
-use gluon::vm::thread::{Status, Thread};
-use gluon::vm::gc::{Gc, Traverseable};
-use gluon::vm::api::{primitive_f, Userdata, VmType};
+extern crate gluon_codegen;
 
-#[derive(Debug)]
+use gluon::import::add_extern_module;
+use gluon::new_vm;
+use gluon::vm::api::{primitive_f, Userdata, VmType};
+use gluon::vm::gc::{Gc, Traverseable};
+use gluon::vm::thread::{Status, Thread};
+use gluon::vm::ExternModule;
+
+#[derive(Debug, gluon_codegen::Traverseable)]
 struct Test;
 
 impl Userdata for Test {}
 
 impl VmType for Test {
     type Type = Test;
-}
-
-impl Traverseable for Test {
-    fn traverse(&self, _: &mut Gc) {}
 }
 
 extern "C" fn dummy(_: &Thread) -> Status {

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -7,11 +7,11 @@ use std::sync::Mutex;
 use gluon::import::add_extern_module;
 use gluon::new_vm;
 use gluon::vm::api::{primitive_f, Userdata, VmType};
-use gluon::vm::gc::Traverseable;
+use gluon::vm::gc::Trace;
 use gluon::vm::thread::{Status, Thread};
 use gluon::vm::ExternModule;
 
-#[derive(gluon_codegen::Traverseable)]
+#[derive(gluon_codegen::Trace)]
 #[gluon_trace(skip)]
 struct Test<'vm>(Mutex<&'vm str>);
 

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -1,14 +1,18 @@
 extern crate gluon;
+extern crate gluon_codegen;
+
 use std::fmt;
 use std::sync::Mutex;
 
-use gluon::new_vm;
 use gluon::import::add_extern_module;
-use gluon::vm::ExternModule;
-use gluon::vm::thread::{Status, Thread};
+use gluon::new_vm;
 use gluon::vm::api::{primitive_f, Userdata, VmType};
 use gluon::vm::gc::Traverseable;
+use gluon::vm::thread::{Status, Thread};
+use gluon::vm::ExternModule;
 
+#[derive(gluon_codegen::Traverseable)]
+#[gluon_trace(skip)]
 struct Test<'vm>(Mutex<&'vm str>);
 
 impl Userdata for Test<'static> {}
@@ -19,7 +23,6 @@ impl<'vm> fmt::Debug for Test<'vm> {
     }
 }
 
-impl<'vm> Traverseable for Test<'vm> {}
 impl<'vm> VmType for Test<'vm> {
     type Type = Test<'static>;
 }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -36,7 +36,7 @@ serde = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0.0", optional = true }
 serde_state = { version = "0.4.0", optional = true }
 serde_derive = { version = "1.0.0", optional = true }
-serde_derive_state = { version = "0.4.0", optional = true }
+serde_derive_state = { version = "0.4.6", optional = true }
 
 gluon_base = { path = "../base", version = "0.11.2" } # GLUON
 gluon_check = { path = "../check", version = "0.11.2" } # GLUON

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -43,7 +43,7 @@ gluon_check = { path = "../check", version = "0.11.2" } # GLUON
 gluon_codegen = { path = "../codegen", version = "0.11.2" } # GLUON
 
 [build-dependencies]
-lalrpop = { version = "0.16", optional = true }
+lalrpop = { version = "0.17", optional = true }
 
 [dev-dependencies]
 env_logger = "0.6"
@@ -53,7 +53,7 @@ pretty_assertions = "0.5"
 # (which requires gluon_vm to be published)
 gluon = { path = "..", version = ">=0.9" }
 
-lalrpop-util = "0.16"
+lalrpop-util = "0.17"
 regex = "1"
 serde_json = "1.0.0"
 

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -20,6 +20,7 @@ travis-ci = { repository = "gluon-lang/gluon" }
 bitflags = "1.0.0"
 codespan = "0.3"
 collect-mac = "0.1.0"
+crossbeam = "0.7"
 frunk_core = "0.2"
 futures = "0.1.0"
 itertools = "0.8"

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -199,7 +199,7 @@ where
 #[derive(Clone)]
 struct State<'de> {
     thread: &'de Thread,
-    env: &'de TypeEnv<Type = ArcType>,
+    env: &'de dyn TypeEnv<Type = ArcType>,
 }
 
 #[derive(Clone)]
@@ -212,7 +212,7 @@ struct Deserializer<'de, 't> {
 impl<'de, 't> Deserializer<'de, 't> {
     fn from_value(
         thread: &'de Thread,
-        env: &'de TypeEnv<Type = ArcType>,
+        env: &'de dyn TypeEnv<Type = ArcType>,
         input: Variants<'de>,
         typ: &'t ArcType,
     ) -> Self {

--- a/vm/src/api/function.rs
+++ b/vm/src/api/function.rs
@@ -312,9 +312,9 @@ where
 }
 
 macro_rules! vm_function_impl {
-    ($f:tt, $($args:ident),*) => {
+    ([$($f:tt)*] $($args:ident),*) => {
 
-impl <'vm, $($args,)* R> VmFunction<'vm> for $f ($($args),*) -> R
+impl <'vm, $($args,)* R> VmFunction<'vm> for $($f)* ($($args),*) -> R
 where $($args: Getable<'vm, 'vm> + 'vm,)*
       R: AsyncPushable<'vm> + VmType + 'vm
 {
@@ -373,8 +373,8 @@ impl <$($args: VmType,)* R: VmType> VmType for fn ($($args),*) -> R {
     }
 }
 
-vm_function_impl!(fn, $($args),*);
-vm_function_impl!(Fn, $($args),*);
+vm_function_impl!([fn] $($args),*);
+vm_function_impl!([dyn Fn] $($args),*);
 
 impl <'vm, $($args,)* R: VmType> FunctionType for fn ($($args),*) -> R {
     fn arguments() -> VmIndex {
@@ -382,13 +382,13 @@ impl <'vm, $($args,)* R: VmType> FunctionType for fn ($($args),*) -> R {
     }
 }
 
-impl <'s, $($args,)* R: VmType> FunctionType for Fn($($args),*) -> R + 's {
+impl <'s, $($args,)* R: VmType> FunctionType for dyn Fn($($args),*) -> R + 's {
     fn arguments() -> VmIndex {
         count!($($args),*) + R::extra_args()
     }
 }
 
-impl <'s, $($args: VmType,)* R: VmType> VmType for Fn($($args),*) -> R + 's {
+impl <'s, $($args: VmType,)* R: VmType> VmType for dyn Fn($($args),*) -> R + 's {
     type Type = fn ($($args::Type),*) -> R::Type;
 
     #[allow(non_snake_case)]
@@ -450,7 +450,7 @@ impl<T, $($args,)* R> Function<T, fn($($args),*) -> R>
     pub fn call_async(
         &mut self
         $(, $args: $args)*
-        ) -> Box<Future<Item = R, Error = Error> + Send + Sync + 'static>
+        ) -> Box<dyn Future<Item = R, Error = Error> + Send + Sync + 'static>
     {
         use crate::thread::Execute;
         use futures::IntoFuture;
@@ -477,7 +477,7 @@ impl<T, $($args,)* R> Function<T, fn($($args),*) -> R>
     pub fn call_fast_async(
         &mut self
         $(, $args: $args)*
-        ) -> Box<Future<Item = R, Error = Error> + Send + Sync + 'static>
+        ) -> Box<dyn Future<Item = R, Error = Error> + Send + Sync + 'static>
     {
         use crate::thread::Execute;
 

--- a/vm/src/api/function.rs
+++ b/vm/src/api/function.rs
@@ -11,7 +11,7 @@ use crate::base::types::ArcType;
 
 use crate::api::{ActiveThread, AsyncPushable, Getable, Pushable, RootedValue, VmType};
 use crate::compiler::{CompiledFunction, CompiledModule};
-use crate::gc::Move;
+use crate::gc::{Move, Trace};
 use crate::stack::{ExternState, StackFrame};
 use crate::thread::{RootedThread, Status, Thread, ThreadInternal, VmRoot, VmRootInternal};
 use crate::types::{Instruction, VmIndex};
@@ -182,6 +182,10 @@ where
 {
     value: RootedValue<T>,
     _marker: PhantomData<F>,
+}
+
+unsafe impl<T: VmRootInternal + Trace, F> Trace for Function<T, F> {
+    impl_trace! { self, gc, mark(&self.value, gc) }
 }
 
 #[cfg(feature = "serde")]

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -89,7 +89,7 @@ pub enum ValueRef<'a> {
     String(&'a str),
     Data(Data<'a>),
     Array(ArrayRef<'a>),
-    Userdata(&'a vm::Userdata),
+    Userdata(&'a dyn vm::Userdata),
     Thread(&'a Thread),
     Closure(Closure<'a>),
     Internal,
@@ -580,7 +580,7 @@ impl<'vm, T: vm::Userdata> Pushable<'vm> for T {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
         let thread = context.thread();
         let context = context.context();
-        let data: Box<vm::Userdata> = Box::new(self);
+        let data: Box<dyn vm::Userdata> = Box::new(self);
         let userdata = context.alloc_with(thread, Move(data))?;
         context.stack.push(ValueRepr::Userdata(userdata));
         Ok(())

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -6,7 +6,7 @@ use crate::base::{
 };
 use crate::{
     forget_lifetime,
-    gc::{DataDef, GcPtr, Move, Traverseable},
+    gc::{DataDef, GcPtr, Move, Trace},
     thread::{self, Context, RootedThread, ThreadInternal, VmRoot, VmRootInternal},
     types::{VmIndex, VmInt, VmTag},
     value::{
@@ -324,8 +324,8 @@ impl<'vm, T: VmType> Pushable<'vm> for Unrooted<T> {
     }
 }
 
-impl<T> Traverseable for Unrooted<T> {
-    impl_traverseable! { self, gc,
+impl<T> Trace for Unrooted<T> {
+    impl_trace! { self, gc,
         mark(&self.0, gc)
     }
 }
@@ -538,11 +538,11 @@ pub trait Pushable<'vm>: AsyncPushable<'vm> {
 
 impl<T> Userdata for std::sync::RwLock<T> where T: Userdata {}
 
-impl<T> Traverseable for std::sync::RwLock<T>
+impl<T> Trace for std::sync::RwLock<T>
 where
-    T: Traverseable,
+    T: Trace,
 {
-    impl_traverseable! { self, gc,
+    impl_trace! { self, gc,
         mark(&*self.read().unwrap(), gc)
     }
 }
@@ -1146,7 +1146,7 @@ where
 
 impl<'vm, 's, T> Pushable<'vm> for &'s [T]
 where
-    T: Traverseable + Pushable<'vm> + 's,
+    T: Trace + Pushable<'vm> + 's,
     &'s [T]: DataDef<Value = ValueArray>,
 {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -538,15 +538,6 @@ pub trait Pushable<'vm>: AsyncPushable<'vm> {
 
 impl<T> Userdata for std::sync::RwLock<T> where T: Userdata {}
 
-unsafe impl<T> Trace for std::sync::RwLock<T>
-where
-    T: Trace,
-{
-    impl_trace! { self, gc,
-        mark(&*self.read().unwrap(), gc)
-    }
-}
-
 /// Trait which allows rust values to be retrieved from the virtual machine
 pub trait Getable<'vm, 'value>: Sized {
     type Proxy: 'value;

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -536,8 +536,6 @@ pub trait Pushable<'vm>: AsyncPushable<'vm> {
     }
 }
 
-impl<T> Userdata for std::sync::RwLock<T> where T: Userdata {}
-
 /// Trait which allows rust values to be retrieved from the virtual machine
 pub trait Getable<'vm, 'value>: Sized {
     type Proxy: 'value;

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -324,7 +324,7 @@ impl<'vm, T: VmType> Pushable<'vm> for Unrooted<T> {
     }
 }
 
-impl<T> Trace for Unrooted<T> {
+unsafe impl<T> Trace for Unrooted<T> {
     impl_trace! { self, gc,
         mark(&self.0, gc)
     }
@@ -538,7 +538,7 @@ pub trait Pushable<'vm>: AsyncPushable<'vm> {
 
 impl<T> Userdata for std::sync::RwLock<T> where T: Userdata {}
 
-impl<T> Trace for std::sync::RwLock<T>
+unsafe impl<T> Trace for std::sync::RwLock<T>
 where
     T: Trace,
 {

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -4,7 +4,7 @@ use crate::base::types::ArcType;
 
 use crate::{
     api::{ArrayRef, Getable, Pushable, ValueRef, VmType},
-    gc::Traverseable,
+    gc::Trace,
     thread::{ActiveThread, RootedValue, Thread, ThreadInternal, VmRoot, VmRootInternal},
     types::{VmIndex, VmInt},
     value::{ArrayRepr, Value, ValueArray},
@@ -103,11 +103,11 @@ pub type OpaqueRef<'a, V> = Opaque<Variants<'a>, V>;
 
 pub type OpaqueValue<T, V> = Opaque<RootedValue<T>, V>;
 
-impl<T, V> Traverseable for Opaque<T, V>
+impl<T, V> Trace for Opaque<T, V>
 where
-    T: Traverseable,
+    T: Trace,
 {
-    impl_traverseable! { self, gc,
+    impl_trace! { self, gc,
         mark(&self.0, gc)
     }
 }

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -1,17 +1,15 @@
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::fmt;
-use std::marker::PhantomData;
-use std::ops::Deref;
+use std::{borrow::Borrow, cmp::Ordering, fmt, marker::PhantomData, ops::Deref};
 
 use crate::base::types::ArcType;
 
-use crate::api::{ArrayRef, Getable, Pushable, ValueRef, VmType};
-use crate::thread::{ActiveThread, RootedValue, Thread, ThreadInternal, VmRoot};
-use crate::types::{VmIndex, VmInt};
-use crate::value::{ArrayRepr, Value, ValueArray};
-use crate::vm;
-use crate::{Result, Variants};
+use crate::{
+    api::{ArrayRef, Getable, Pushable, ValueRef, VmType},
+    gc::Traverseable,
+    thread::{ActiveThread, RootedValue, Thread, ThreadInternal, VmRoot, VmRootInternal},
+    types::{VmIndex, VmInt},
+    value::{ArrayRepr, Value, ValueArray},
+    vm, Result, Variants,
+};
 
 #[cfg(feature = "serde")]
 use crate::thread::RootedThread;
@@ -30,7 +28,7 @@ mod private {
 
     impl<'value> Sealed for Variants<'value> {}
     impl<'s, 'value> Sealed for &'s Variants<'value> {}
-    impl<T> Sealed for RootedValue<T> where T: Deref<Target = Thread> {}
+    impl<T> Sealed for RootedValue<T> where T: VmRootInternal {}
 }
 
 pub trait AsValueRef: private::Sealed {
@@ -44,7 +42,7 @@ impl<'value> AsValueRef for Variants<'value> {
 }
 impl<T> AsValueRef for RootedValue<T>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
 {
     fn as_value_ref(&self) -> ValueRef {
         self.get_variant().as_ref()
@@ -80,7 +78,7 @@ impl<'v, 'value> AsVariant<'v, 'value> for &'v Variants<'value> {
 }
 impl<'value, T> AsVariant<'value, 'value> for RootedValue<T>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
 {
     fn get_variant(&'value self) -> Variants<'value> {
         self.get_variant()
@@ -104,6 +102,15 @@ where
 pub type OpaqueRef<'a, V> = Opaque<Variants<'a>, V>;
 
 pub type OpaqueValue<T, V> = Opaque<RootedValue<T>, V>;
+
+impl<T, V> Traverseable for Opaque<T, V>
+where
+    T: Traverseable,
+{
+    impl_traverseable! { self, gc,
+        mark(&self.0, gc)
+    }
+}
 
 impl<T, V> PartialEq for Opaque<T, V>
 where
@@ -278,7 +285,7 @@ where
 
 impl<T, V> OpaqueValue<T, V>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
     V: ?Sized,
 {
     pub fn vm(&self) -> &Thread {
@@ -409,7 +416,7 @@ where
 
 impl<T, V> OpaqueValue<T, [V]>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
 {
     pub fn get2<'value>(&'value self, index: VmInt) -> Option<V>
     where

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -103,7 +103,7 @@ pub type OpaqueRef<'a, V> = Opaque<Variants<'a>, V>;
 
 pub type OpaqueValue<T, V> = Opaque<RootedValue<T>, V>;
 
-impl<T, V> Trace for Opaque<T, V>
+unsafe impl<T, V> Trace for Opaque<T, V>
 where
     T: Trace,
 {

--- a/vm/src/api/scoped.rs
+++ b/vm/src/api/scoped.rs
@@ -11,7 +11,7 @@ use base::types::ArcType;
 
 use crate::{
     api::{Opaque, OpaqueValue, Pushable, VmType},
-    gc::{Gc, Traverseable},
+    gc::Traverseable,
     thread::{ActiveThread, RootedThread, Thread, ThreadInternal},
     value::Userdata,
     Result,
@@ -188,10 +188,10 @@ impl<T, M> Traverseable for Scoped<T, M>
 where
     T: Traverseable,
 {
-    fn traverse(&self, gc: &mut Gc) {
+    impl_traverseable! { self, gc,
         unsafe {
             if let Some(v) = *self.ptr.read().unwrap() {
-                v.as_ref().traverse(gc);
+                mark(v.as_ref(), gc);
             }
         }
     }

--- a/vm/src/api/scoped.rs
+++ b/vm/src/api/scoped.rs
@@ -184,11 +184,12 @@ impl<'vm, T: VmType, M> VmType for Scoped<T, M> {
     }
 }
 
-impl<T, M> Trace for Scoped<T, M>
+unsafe impl<T, M> Trace for Scoped<T, M>
 where
     T: Trace,
 {
     impl_trace! { self, gc,
+        #[allow(unused_unsafe)]
         unsafe {
             if let Some(v) = *self.ptr.read().unwrap() {
                 mark(v.as_ref(), gc);

--- a/vm/src/api/scoped.rs
+++ b/vm/src/api/scoped.rs
@@ -11,7 +11,7 @@ use base::types::ArcType;
 
 use crate::{
     api::{Opaque, OpaqueValue, Pushable, VmType},
-    gc::Traverseable,
+    gc::Trace,
     thread::{ActiveThread, RootedThread, Thread, ThreadInternal},
     value::Userdata,
     Result,
@@ -184,11 +184,11 @@ impl<'vm, T: VmType, M> VmType for Scoped<T, M> {
     }
 }
 
-impl<T, M> Traverseable for Scoped<T, M>
+impl<T, M> Trace for Scoped<T, M>
 where
-    T: Traverseable,
+    T: Trace,
 {
-    impl_traverseable! { self, gc,
+    impl_trace! { self, gc,
         unsafe {
             if let Some(v) = *self.ptr.read().unwrap() {
                 mark(v.as_ref(), gc);

--- a/vm/src/array.rs
+++ b/vm/src/array.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
-use crate::gc::Traverseable;
+use crate::gc::Trace;
 
 mod internal {
     pub struct CantConstruct(());
@@ -66,8 +66,8 @@ impl<T: fmt::Debug> fmt::Debug for Array<T> {
     }
 }
 
-impl<T: Traverseable> Traverseable for Array<T> {
-    impl_traverseable! { self, gc,
+impl<T: Trace> Trace for Array<T> {
+    impl_trace! { self, gc,
         mark(&**self, gc)
     }
 }

--- a/vm/src/array.rs
+++ b/vm/src/array.rs
@@ -66,7 +66,7 @@ impl<T: fmt::Debug> fmt::Debug for Array<T> {
     }
 }
 
-impl<T: Trace> Trace for Array<T> {
+unsafe impl<T: Trace> Trace for Array<T> {
     impl_trace! { self, gc,
         mark(&**self, gc)
     }

--- a/vm/src/array.rs
+++ b/vm/src/array.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
-use crate::gc::{Gc, Traverseable};
+use crate::gc::Traverseable;
 
 mod internal {
     pub struct CantConstruct(());
@@ -67,8 +67,8 @@ impl<T: fmt::Debug> fmt::Debug for Array<T> {
 }
 
 impl<T: Traverseable> Traverseable for Array<T> {
-    fn traverse(&self, gc: &mut Gc) {
-        (**self).traverse(gc)
+    impl_traverseable! { self, gc,
+        mark(&**self, gc)
     }
 }
 

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -20,7 +20,7 @@ use crate::{
         primitive, AsyncPushable, Function, FunctionRef, FutureResult, Generic, Getable, OpaqueRef,
         OpaqueValue, OwnedFunction, Pushable, Pushed, RuntimeResult, Unrooted, VmType, WithVM, IO,
     },
-    gc::{GcPtr, Traverseable},
+    gc::{GcPtr, Trace},
     stack::{ClosureState, ExternState, StackFrame, State},
     thread::{ActiveThread, ThreadInternal},
     types::{VmIndex, VmInt},
@@ -48,8 +48,8 @@ where
     }
 }
 
-impl<T> Traverseable for Sender<T> {
-    impl_traverseable! { self, _gc,
+impl<T> Trace for Sender<T> {
+    impl_trace! { self, _gc,
         // No need to traverse in Sender as values can only be accessed through Receiver
         {}
     }
@@ -61,8 +61,8 @@ impl<T> Sender<T> {
     }
 }
 
-impl<T> Traverseable for Receiver<T> {
-    impl_traverseable! { self, gc,
+impl<T> Trace for Receiver<T> {
+    impl_trace! { self, gc,
         mark(&*self.queue.lock().unwrap(), gc)
     }
 }
@@ -256,11 +256,11 @@ fn spawn_on<'vm>(
     {
     }
 
-    impl<F> Traverseable for SpawnFuture<F>
+    impl<F> Trace for SpawnFuture<F>
     where
         F: Future,
     {
-        impl_traverseable! { self, _gc, { } }
+        impl_trace! { self, _gc, { } }
     }
 
     impl<F> VmType for SpawnFuture<F>

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -48,7 +48,7 @@ where
     }
 }
 
-impl<T> Trace for Sender<T> {
+unsafe impl<T> Trace for Sender<T> {
     impl_trace! { self, _gc,
         // No need to traverse in Sender as values can only be accessed through Receiver
         {}
@@ -61,7 +61,7 @@ impl<T> Sender<T> {
     }
 }
 
-impl<T> Trace for Receiver<T> {
+unsafe impl<T> Trace for Receiver<T> {
     impl_trace! { self, gc,
         mark(&*self.queue.lock().unwrap(), gc)
     }
@@ -256,7 +256,7 @@ fn spawn_on<'vm>(
     {
     }
 
-    impl<F> Trace for SpawnFuture<F>
+    unsafe impl<F> Trace for SpawnFuture<F>
     where
         F: Future,
     {

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -432,7 +432,7 @@ impl CompilerEnv for TypeInfos {
 }
 
 pub struct Compiler<'a> {
-    globals: &'a (CompilerEnv<Type = ArcType> + 'a),
+    globals: &'a (dyn CompilerEnv<Type = ArcType> + 'a),
     vm: &'a GlobalVmState,
     symbols: SymbolModule<'a>,
     stack_types: ScopedMap<Symbol, Alias<Symbol, ArcType>>,
@@ -468,7 +468,7 @@ impl<'a, T: CompilerEnv> CompilerEnv for &'a T {
 
 impl<'a> Compiler<'a> {
     pub fn new(
-        globals: &'a (CompilerEnv<Type = ArcType> + 'a),
+        globals: &'a (dyn CompilerEnv<Type = ArcType> + 'a),
         vm: &'a GlobalVmState,
         mut symbols: SymbolModule<'a>,
         source: &'a ::codespan::FileMap,

--- a/vm/src/core/interpreter.rs
+++ b/vm/src/core/interpreter.rs
@@ -278,7 +278,7 @@ pub type GlobalBinding<'a> = Binding<CExpr<'a>, ClosureRef<'a>>;
 
 pub struct Compiler<'a, 'e> {
     allocator: &'e Allocator<'e>,
-    globals: &'a Fn(&Symbol) -> Option<GlobalBinding<'a>>,
+    globals: &'a dyn Fn(&Symbol) -> Option<GlobalBinding<'a>>,
     stack_constructors: ScopedMap<Symbol, ArcType>,
     stack_types: ScopedMap<Symbol, Alias<Symbol, ArcType>>,
     bindings: Vec<LetBinding<'e>>,
@@ -305,7 +305,7 @@ impl<'a, 'e> TypeEnv for Compiler<'a, 'e> {
 impl<'a, 'e> Compiler<'a, 'e> {
     pub fn new(
         allocator: &'e Allocator<'e>,
-        globals: &'a Fn(&Symbol) -> Option<GlobalBinding<'a>>,
+        globals: &'a dyn Fn(&Symbol) -> Option<GlobalBinding<'a>>,
     ) -> Compiler<'a, 'e> {
         Compiler {
             allocator,

--- a/vm/src/derive/eq.rs
+++ b/vm/src/derive/eq.rs
@@ -30,32 +30,33 @@ pub fn generate(
         },
     ));
 
-    let generate_and_chain =
-        |symbols: &mut Symbols,
-         iter: &mut Iterator<Item = (&(bool, TypedIdent<Symbol>), &TypedIdent<Symbol>)>| {
-            iter.fold(None, |acc, (&(self_type, ref l), r)| {
-                let equal_symbol = if self_type {
-                    eq.name.clone()
-                } else {
-                    symbols.symbol("==")
-                };
+    let generate_and_chain = |symbols: &mut Symbols,
+                              iter: &mut dyn Iterator<
+        Item = (&(bool, TypedIdent<Symbol>), &TypedIdent<Symbol>),
+    >| {
+        iter.fold(None, |acc, (&(self_type, ref l), r)| {
+            let equal_symbol = if self_type {
+                eq.name.clone()
+            } else {
+                symbols.symbol("==")
+            };
 
-                let eq_check = app(
-                    span,
-                    equal_symbol,
-                    vec![
-                        ident(span, l.name.clone()).into(),
-                        ident(span, r.name.clone()),
-                    ],
-                );
+            let eq_check = app(
+                span,
+                equal_symbol,
+                vec![
+                    ident(span, l.name.clone()).into(),
+                    ident(span, r.name.clone()),
+                ],
+            );
 
-                Some(match acc {
-                    Some(acc) => infix(span, acc, symbols.symbol("&&"), eq_check),
-                    None => eq_check,
-                })
+            Some(match acc {
+                Some(acc) => infix(span, acc, symbols.symbol("&&"), eq_check),
+                None => eq_check,
             })
-            .unwrap_or_else(|| ident(span, symbols.symbol("True")))
-        };
+        })
+        .unwrap_or_else(|| ident(span, symbols.symbol("True")))
+    };
 
     let comparison_expr = match **remove_forall(bind.alias.value.unresolved_type()) {
         Type::Variant(ref variants) => {

--- a/vm/src/derive/mod.rs
+++ b/vm/src/derive/mod.rs
@@ -42,7 +42,7 @@ fn sequence_actions(
     span: Span<BytePos>,
     field_symbols: &[TypedIdent<Symbol>],
     packed_expr: SpannedExpr<Symbol>,
-    action: &mut FnMut(&Symbol) -> SpannedExpr<Symbol>,
+    action: &mut dyn FnMut(&Symbol) -> SpannedExpr<Symbol>,
 ) -> SpannedExpr<Symbol> {
     let pack_record = pos::spanned(
         span,

--- a/vm/src/dynamic.rs
+++ b/vm/src/dynamic.rs
@@ -1,15 +1,14 @@
 use std::borrow::Cow;
-use std::ops::Deref;
 
 use crate::base::resolve;
 use crate::base::types::{ArcType, NullInterner, Type};
 
-use crate::thread::{RootedValue, Thread, VmRoot};
+use crate::thread::{RootedValue, Thread, VmRoot, VmRootInternal};
 
 #[derive(Debug)]
 pub struct FieldIter<'a, T>
 where
-    T: Deref<Target = Thread> + 'a,
+    T: VmRootInternal,
 {
     value: &'a RootedValue<T>,
     index: usize,

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -12,7 +12,7 @@ use std::{
     ptr::{self, NonNull},
     rc::Rc,
     result::Result as StdResult,
-    sync::{Arc, Mutex, RwLock},
+    sync::Arc,
 };
 
 use crate::base::fnv::FnvMap;
@@ -595,24 +595,6 @@ where
             Ok(x) => mark(x, gc),
             Err(x) => mark(x, gc),
         }
-    }
-}
-
-unsafe impl<T> Trace for Mutex<T>
-where
-    T: Trace,
-{
-    impl_trace! { self, gc,
-        mark(&*self.lock().unwrap(), gc)
-    }
-}
-
-unsafe impl<T> Trace for RwLock<T>
-where
-    T: Trace,
-{
-    impl_trace! { self, gc,
-        mark(&*self.read().unwrap(), gc)
     }
 }
 

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -572,7 +572,7 @@ macro_rules! empty_trace {
     }
 }
 
-empty_trace! { () u8 u16 u32 u64 usize i8 i16 i32 i64 isize f32 f64 str bool }
+empty_trace! { () u8 u16 u32 u64 usize i8 i16 i32 i64 isize f32 f64 str String bool }
 
 unsafe impl<T> Trace for Option<T>
 where

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -12,7 +12,7 @@ use std::{
     ptr::{self, NonNull},
     rc::Rc,
     result::Result as StdResult,
-    sync::Arc,
+    sync::{Arc, Mutex, RwLock},
 };
 
 use crate::base::fnv::FnvMap;
@@ -595,6 +595,24 @@ where
             Ok(x) => mark(x, gc),
             Err(x) => mark(x, gc),
         }
+    }
+}
+
+unsafe impl<T> Trace for Mutex<T>
+where
+    T: Trace,
+{
+    impl_trace! { self, gc,
+        mark(&*self.lock().unwrap(), gc)
+    }
+}
+
+unsafe impl<T> Trace for RwLock<T>
+where
+    T: Trace,
+{
+    impl_trace! { self, gc,
+        mark(&*self.read().unwrap(), gc)
     }
 }
 

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -454,21 +454,21 @@ impl<T: ?Sized> GcPtr<T> {
 
 impl<'a, T: Traverseable + Send + Sync + 'a> GcPtr<T> {
     /// Coerces `self` to a `Traverseable` trait object
-    pub fn as_traverseable(self) -> GcPtr<Traverseable + Send + Sync + 'a> {
+    pub fn as_traverseable(self) -> GcPtr<dyn Traverseable + Send + Sync + 'a> {
         unsafe {
-            let ptr: &(Traverseable + Send + Sync) = self.0.as_ref();
+            let ptr: &(dyn Traverseable + Send + Sync) = self.0.as_ref();
             GcPtr(NonNull::new_unchecked(ptr as *const _ as *mut _))
         }
     }
 }
 impl GcPtr<str> {
     /// Coerces `self` to a `Traverseable` trait object
-    pub fn as_traverseable_string(self) -> GcPtr<Traverseable + Send + Sync> {
+    pub fn as_traverseable_string(self) -> GcPtr<dyn Traverseable + Send + Sync> {
         // As there is nothing to traverse in a str we can safely cast it to *const u8 and use
         // u8's Traverseable impl
         unsafe {
             GcPtr(NonNull::new_unchecked(
-                self.as_ptr() as *const (Traverseable + Send + Sync) as *mut _,
+                self.as_ptr() as *const (dyn Traverseable + Send + Sync) as *mut _,
             ))
         }
     }
@@ -544,7 +544,7 @@ macro_rules! empty_traverse {
     }
 }
 
-empty_traverse! { () Any u8 u16 u32 u64 usize i8 i16 i32 i64 isize f32 f64 str }
+empty_traverse! { () u8 u16 u32 u64 usize i8 i16 i32 i64 isize f32 f64 str }
 
 impl<T: ?Sized> Traverseable for *const T {
     fn traverse(&self, _: &mut Gc) {}

--- a/vm/src/gc/mutex.rs
+++ b/vm/src/gc/mutex.rs
@@ -1,0 +1,271 @@
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+    sync,
+};
+
+use crate::gc::{Gc, Trace};
+
+pub use std::sync::{PoisonError, TryLockError};
+
+pub type TryLockResult<Guard> = Result<Guard, TryLockError<Guard>>;
+pub type LockResult<Guard> = Result<Guard, PoisonError<Guard>>;
+
+pub struct Mutex<T>
+where
+    T: ?Sized,
+{
+    // TODO Implement using atomics?
+    // `rooted` is always locked first to avoid dead locks
+    rooted: sync::Mutex<bool>,
+    mutex: sync::Mutex<T>,
+}
+
+impl<T> Default for Mutex<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Mutex::new(Default::default())
+    }
+}
+
+impl<T> fmt::Debug for Mutex<T>
+where
+    T: ?Sized + fmt::Debug + Trace,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.try_lock() {
+            Ok(guard) => f.debug_struct("Mutex").field("data", &&*guard).finish(),
+            Err(TryLockError::Poisoned(err)) => f
+                .debug_struct("Mutex")
+                .field("data", &&**err.get_ref())
+                .finish(),
+            Err(TryLockError::WouldBlock) => {
+                struct LockedPlaceholder;
+                impl fmt::Debug for LockedPlaceholder {
+                    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        f.write_str("<locked>")
+                    }
+                }
+
+                f.debug_struct("Mutex")
+                    .field("data", &LockedPlaceholder)
+                    .finish()
+            }
+        }
+    }
+}
+
+impl<T> Mutex<T> {
+    pub fn new(value: T) -> Self {
+        Mutex {
+            rooted: sync::Mutex::new(true),
+            mutex: sync::Mutex::new(value),
+        }
+    }
+}
+
+impl<T> Mutex<T>
+where
+    T: ?Sized + Trace,
+{
+    pub fn lock(&self) -> LockResult<MutexGuard<T>> {
+        let rooted = self.rooted.lock().unwrap();
+        match self.mutex.lock() {
+            Ok(lock) => Ok(self.new_guard(*rooted, lock)),
+            Err(err) => {
+                let lock = err.into_inner();
+                Err(PoisonError::new(self.new_guard(*rooted, lock)))
+            }
+        }
+    }
+
+    pub fn try_lock(&self) -> TryLockResult<MutexGuard<T>> {
+        let rooted = self.rooted.lock().unwrap();
+        match self.mutex.try_lock() {
+            Ok(lock) => Ok(self.new_guard(*rooted, lock)),
+            Err(sync::TryLockError::Poisoned(err)) => {
+                let lock = err.into_inner();
+                Err(TryLockError::Poisoned(PoisonError::new(
+                    self.new_guard(*rooted, lock),
+                )))
+            }
+            Err(sync::TryLockError::WouldBlock) => Err(sync::TryLockError::WouldBlock),
+        }
+    }
+
+    pub fn is_poisoned(&self) -> bool {
+        self.mutex.is_poisoned()
+    }
+
+    pub fn into_inner(self) -> LockResult<T>
+    where
+        T: Sized,
+    {
+        self.mutex.into_inner()
+    }
+
+    pub fn get_mut(&mut self) -> LockResult<&mut T> {
+        self.mutex.get_mut()
+    }
+
+    fn new_guard<'a>(&'a self, rooted: bool, value: sync::MutexGuard<'a, T>) -> MutexGuard<'a, T> {
+        if !rooted {
+            unsafe {
+                value.root();
+            }
+        }
+        MutexGuard {
+            value,
+            rooted: &self.rooted,
+        }
+    }
+}
+
+unsafe impl<T> Trace for Mutex<T>
+where
+    T: Trace,
+{
+    unsafe fn root(&self) {
+        let mut rooted = self.rooted.lock().unwrap();
+        assert!(!*rooted, "Mutex can't be rooted twice!");
+        *rooted = true;
+        match self.mutex.try_lock() {
+            Ok(lock) => lock.root(),
+            Err(TryLockError::WouldBlock) => (), // The value will be rooted when the lock is released
+            Err(TryLockError::Poisoned(err)) => err.into_inner().root(),
+        }
+    }
+    unsafe fn unroot(&self) {
+        let mut rooted = self.rooted.lock().unwrap();
+        assert!(*rooted, "Mutex can't be unrooted twice!");
+        *rooted = false;
+        match self.mutex.try_lock() {
+            Ok(lock) => lock.unroot(),
+            Err(TryLockError::WouldBlock) => (), // The value will be unrooted when the lock is released
+            Err(TryLockError::Poisoned(err)) => err.into_inner().unroot(),
+        }
+    }
+    fn trace(&self, gc: &mut Gc) {
+        match self.mutex.try_lock() {
+            Ok(lock) => lock.trace(gc),
+            Err(TryLockError::WouldBlock) => (), // The value is already rooted so we don't need to do anything here
+            Err(TryLockError::Poisoned(err)) => err.into_inner().trace(gc),
+        }
+    }
+}
+pub struct MutexGuard<'a, T>
+where
+    T: ?Sized + Trace,
+{
+    rooted: &'a sync::Mutex<bool>,
+    value: sync::MutexGuard<'a, T>,
+}
+
+impl<'a, T> Drop for MutexGuard<'a, T>
+where
+    T: ?Sized + Trace,
+{
+    fn drop(&mut self) {
+        let rooted = self.rooted.lock().unwrap();
+        if !*rooted {
+            unsafe {
+                self.value.unroot();
+            }
+        }
+    }
+}
+
+impl<'a, T> Deref for MutexGuard<'a, T>
+where
+    T: ?Sized + Trace,
+{
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<'a, T> DerefMut for MutexGuard<'a, T>
+where
+    T: ?Sized + Trace,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::cell::Cell;
+
+    struct Rooted<'a>(&'a Cell<bool>);
+
+    unsafe impl<'a> Trace for Rooted<'a> {
+        unsafe fn root(&self) {
+            assert!(!self.0.get());
+            self.0.set(true);
+        }
+        unsafe fn unroot(&self) {
+            assert!(self.0.get());
+            self.0.set(false);
+        }
+        fn trace(&self, _gc: &mut Gc) {}
+    }
+
+    #[test]
+    fn rooted() {
+        let rooted = Cell::new(true);
+        let mutex = Mutex::new(Rooted(&rooted));
+
+        assert!(rooted.get());
+        {
+            let _lock = mutex.lock().unwrap();
+            assert!(rooted.get());
+        }
+        assert!(rooted.get());
+    }
+
+    #[test]
+    fn unrooted() {
+        let rooted = Cell::new(true);
+        let mutex = Mutex::new(Rooted(&rooted));
+        // Emulate this `Mutex` being unrooted (stored in another root)
+        unsafe {
+            mutex.unroot();
+        }
+
+        assert!(!rooted.get());
+        {
+            let _lock = mutex.lock().unwrap();
+            assert!(rooted.get());
+        }
+        assert!(!rooted.get());
+    }
+
+    #[test]
+    fn unroot_during_lock() {
+        let rooted = Cell::new(true);
+        let mutex = Mutex::new(Rooted(&rooted));
+
+        assert!(rooted.get());
+        {
+            let _lock = mutex.lock().unwrap();
+            assert!(rooted.get());
+
+            // Emulate this `Mutex` being unrooted (stored in another root)
+            unsafe {
+                mutex.unroot();
+            }
+            assert!(!*mutex.rooted.lock().unwrap());
+            assert!(
+                rooted.get(),
+                "We should not be able to unroot the inner value since it is locked"
+            );
+        }
+        assert!(!rooted.get(), "Must be unrooted after the lock releases");
+    }
+}

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -14,7 +14,7 @@ pub struct InternedStr(GcStr);
 
 // InternedStr are explicitly scanned in the intern table so we can skip them when they are
 // encountered elsewhere
-impl Trace for InternedStr {
+unsafe impl Trace for InternedStr {
     impl_trace! { self, _gc, {} }
 }
 
@@ -91,7 +91,7 @@ pub struct Interner {
     indexes: FnvMap<&'static str, InternedStr>,
 }
 
-impl Trace for Interner {
+unsafe impl Trace for Interner {
     impl_trace! { self, gc,
         for (_, v) in self.indexes.iter() {
             mark::<GcStr>(&v.0, gc);

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -12,6 +12,12 @@ use crate::value::GcStr;
 #[derive(Copy, Clone, Eq)]
 pub struct InternedStr(GcStr);
 
+// InternedStr are explicitly scanned in the intern table so we can skip them when they are
+// encountered elsewhere
+impl Traverseable for InternedStr {
+    impl_traverseable! { self, _gc, {} }
+}
+
 impl PartialEq<InternedStr> for InternedStr {
     fn eq(&self, other: &InternedStr) -> bool {
         self.as_ptr() == other.as_ptr()
@@ -86,9 +92,9 @@ pub struct Interner {
 }
 
 impl Traverseable for Interner {
-    fn traverse(&self, gc: &mut Gc) {
+    impl_traverseable! { self, gc,
         for (_, v) in self.indexes.iter() {
-            v.0.traverse(gc);
+            mark::<GcStr>(&v.0, gc);
         }
     }
 }

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
-use crate::gc::{Gc, Traverseable};
+use crate::gc::{Gc, Trace};
 use crate::value::GcStr;
 
 /// Interned strings which allow for fast equality checks and hashing
@@ -14,8 +14,8 @@ pub struct InternedStr(GcStr);
 
 // InternedStr are explicitly scanned in the intern table so we can skip them when they are
 // encountered elsewhere
-impl Traverseable for InternedStr {
-    impl_traverseable! { self, _gc, {} }
+impl Trace for InternedStr {
+    impl_trace! { self, _gc, {} }
 }
 
 impl PartialEq<InternedStr> for InternedStr {
@@ -91,8 +91,8 @@ pub struct Interner {
     indexes: FnvMap<&'static str, InternedStr>,
 }
 
-impl Traverseable for Interner {
-    impl_traverseable! { self, gc,
+impl Trace for Interner {
+    impl_trace! { self, gc,
         for (_, v) in self.indexes.iter() {
             mark::<GcStr>(&v.0, gc);
         }

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -11,7 +11,7 @@ use crate::{
         generic::A, FunctionRef, Getable, OpaqueValue, Pushable, Pushed, Userdata, VmType, WithVM,
     },
     base::types::{self, ArcType},
-    gc::{Gc, GcPtr, Move, Traverseable},
+    gc::{GcPtr, Move, Traverseable},
     thread::{RootedThread, ThreadInternal},
     value::{Cloner, Value},
     vm::Thread,
@@ -63,11 +63,11 @@ enum Lazy_ {
 }
 
 impl<T> Traverseable for Lazy<T> {
-    fn traverse(&self, gc: &mut Gc) {
+    impl_traverseable! { self, gc,
         match *self.value.lock().unwrap() {
             Lazy_::Blackhole(..) => (),
-            Lazy_::Thunk(ref value) => value.traverse(gc),
-            Lazy_::Value(ref value) => value.traverse(gc),
+            Lazy_::Thunk(ref value) => mark(value, gc),
+            Lazy_::Value(ref value) => mark(value, gc),
         }
     }
 }

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -11,7 +11,7 @@ use crate::{
         generic::A, FunctionRef, Getable, OpaqueValue, Pushable, Pushed, Userdata, VmType, WithVM,
     },
     base::types::{self, ArcType},
-    gc::{GcPtr, Move, Traverseable},
+    gc::{GcPtr, Move, Trace},
     thread::{RootedThread, ThreadInternal},
     value::{Cloner, Value},
     vm::Thread,
@@ -62,8 +62,8 @@ enum Lazy_ {
     Value(Value),
 }
 
-impl<T> Traverseable for Lazy<T> {
-    impl_traverseable! { self, gc,
+impl<T> Trace for Lazy<T> {
+    impl_trace! { self, gc,
         match *self.value.lock().unwrap() {
             Lazy_::Blackhole(..) => (),
             Lazy_::Thunk(ref value) => mark(value, gc),

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -62,7 +62,7 @@ enum Lazy_ {
     Value(Value),
 }
 
-impl<T> Trace for Lazy<T> {
+unsafe impl<T> Trace for Lazy<T> {
     impl_trace! { self, gc,
         match *self.value.lock().unwrap() {
             Lazy_::Blackhole(..) => (),

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -30,14 +30,14 @@ impl<T> Userdata for Lazy<T>
 where
     T: Any + Send + Sync,
 {
-    fn deep_clone(&self, deep_cloner: &mut Cloner) -> Result<GcPtr<Box<Userdata>>> {
+    fn deep_clone(&self, deep_cloner: &mut Cloner) -> Result<GcPtr<Box<dyn Userdata>>> {
         let value = self.value.lock().unwrap();
         let cloned_value = match *value {
             Lazy_::Blackhole(..) => return Err(Error::Message("<<loop>>".into())),
             Lazy_::Thunk(ref value) => Lazy_::Thunk(deep_cloner.deep_clone(value)?),
             Lazy_::Value(ref value) => Lazy_::Value(deep_cloner.deep_clone(value)?),
         };
-        let data: Box<Userdata> = Box::new(Lazy {
+        let data: Box<dyn Userdata> = Box::new(Lazy {
             value: Mutex::new(cloned_value),
             thread: unsafe { GcPtr::from_raw(deep_cloner.thread()) },
             _marker: PhantomData::<A>,

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -49,7 +49,7 @@ macro_rules! try_future {
     };
 }
 
-pub type BoxFuture<'vm, T, E> = Box<futures::Future<Item = T, Error = E> + Send + 'vm>;
+pub type BoxFuture<'vm, T, E> = Box<dyn futures::Future<Item = T, Error = E> + Send + 'vm>;
 
 #[macro_use]
 #[cfg(feature = "serde")]

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -56,13 +56,15 @@ pub type BoxFuture<'vm, T, E> = Box<dyn futures::Future<Item = T, Error = E> + S
 pub mod serialization;
 
 #[macro_use]
+pub mod gc;
+
+#[macro_use]
 pub mod api;
 pub mod channel;
 pub mod compiler;
 pub mod core;
 pub mod debug;
 pub mod dynamic;
-pub mod gc;
 pub mod lazy;
 pub mod macros;
 pub mod primitives;
@@ -93,7 +95,8 @@ unsafe fn forget_lifetime<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
     ::std::mem::transmute(x)
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Traverseable)]
+#[gluon(gluon_vm)]
 #[repr(transparent)]
 pub struct Variants<'a>(ValueRepr, PhantomData<&'a Value>);
 
@@ -125,12 +128,6 @@ impl<'a> Variants<'a> {
     #[inline]
     pub fn as_ref(&self) -> ValueRef<'a> {
         unsafe { ValueRef::rooted_new(self.0) }
-    }
-}
-
-impl<'a> gc::Traverseable for Variants<'a> {
-    fn traverse(&self, gc: &mut gc::Gc) {
-        self.0.traverse(gc);
     }
 }
 

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -197,7 +197,7 @@ impl<'a> fmt::Display for Panic<'a> {
     }
 }
 
-pub type ExternLoader = Box<FnMut(&Thread) -> Result<ExternModule> + Send + Sync>;
+pub type ExternLoader = Box<dyn FnMut(&Thread) -> Result<ExternModule> + Send + Sync>;
 
 pub struct ExternModule {
     pub metadata: Metadata,

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -95,7 +95,7 @@ unsafe fn forget_lifetime<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
     ::std::mem::transmute(x)
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Traverseable)]
+#[derive(Copy, Clone, Debug, PartialEq, Trace)]
 #[gluon(gluon_vm)]
 #[repr(transparent)]
 pub struct Variants<'a>(ValueRepr, PhantomData<&'a Value>);

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -17,10 +17,10 @@ use crate::base::{
 
 use crate::thread::Thread;
 
-pub type Error = Box<StdError + Send + Sync>;
+pub type Error = Box<dyn StdError + Send + Sync>;
 pub type SpannedError = Spanned<Error, BytePos>;
 pub type Errors = BaseErrors<SpannedError>;
-pub type MacroFuture = Box<Future<Item = SpannedExpr<Symbol>, Error = Error> + Send>;
+pub type MacroFuture = Box<dyn Future<Item = SpannedExpr<Symbol>, Error = Error> + Send>;
 
 /// A trait which abstracts over macros.
 ///
@@ -36,13 +36,13 @@ where
     F: Fn(
         &mut MacroExpander,
         Vec<SpannedExpr<Symbol>>,
-    ) -> Box<Future<Item = SpannedExpr<Symbol>, Error = Error> + Send>,
+    ) -> Box<dyn Future<Item = SpannedExpr<Symbol>, Error = Error> + Send>,
 {
     fn expand(
         &self,
         env: &mut MacroExpander,
         args: Vec<SpannedExpr<Symbol>>,
-    ) -> Box<Future<Item = SpannedExpr<Symbol>, Error = Error> + Send> {
+    ) -> Box<dyn Future<Item = SpannedExpr<Symbol>, Error = Error> + Send> {
         self(env, args)
     }
 }
@@ -51,7 +51,7 @@ where
 /// it.
 #[derive(Default)]
 pub struct MacroEnv {
-    macros: RwLock<FnvMap<String, Arc<Macro>>>,
+    macros: RwLock<FnvMap<String, Arc<dyn Macro>>>,
 }
 
 impl MacroEnv {
@@ -71,7 +71,7 @@ impl MacroEnv {
     }
 
     /// Retrieves the macro bound to `symbol`
-    pub fn get(&self, name: &str) -> Option<Arc<Macro>> {
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Macro>> {
         self.macros.read().unwrap().get(name).cloned()
     }
 
@@ -89,7 +89,7 @@ impl MacroEnv {
 }
 
 pub struct MacroExpander<'a> {
-    pub state: FnvMap<String, Box<Any>>,
+    pub state: FnvMap<String, Box<dyn Any>>,
     pub vm: &'a Thread,
     pub errors: Errors,
     pub error_in_expr: bool,

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -10,17 +10,19 @@ use crate::real_std::{
 
 use crate::base::types::ArcType;
 
-use crate::api::{
-    generic::{self, A},
-    primitive, Array, Getable, OpaqueRef, Pushable, Pushed, RuntimeResult, ValueRef, VmType,
-    WithVM, IO,
+use crate::{
+    api::{
+        generic::{self, A},
+        primitive, Array, Getable, OpaqueRef, Pushable, Pushed, RuntimeResult, ValueRef, VmType,
+        WithVM, IO,
+    },
+    gc::{DataDef, Traverseable, WriteOnly},
+    stack::{ExternState, StackFrame},
+    types::VmInt,
+    value::{Def, GcStr, Repr, ValueArray, ValueRepr},
+    vm::{Status, Thread},
+    Error, ExternModule, Result, Variants,
 };
-use crate::gc::{DataDef, Gc, Traverseable, WriteOnly};
-use crate::stack::{ExternState, StackFrame};
-use crate::types::VmInt;
-use crate::value::{Def, GcStr, Repr, ValueArray, ValueRepr};
-use crate::vm::{Status, Thread};
-use crate::{Error, ExternModule, Result, Variants};
 
 #[doc(hidden)]
 pub mod array {
@@ -61,16 +63,12 @@ pub mod array {
             )));
         }
 
+        #[derive(Traverseable)]
+        #[gluon(gluon_vm)]
         struct Slice<'a> {
             start: usize,
             end: usize,
             array: &'a ValueArray,
-        }
-
-        impl<'a> Traverseable for Slice<'a> {
-            fn traverse(&self, gc: &mut Gc) {
-                self.array.traverse(gc);
-            }
         }
 
         unsafe impl<'a> DataDef for Slice<'a> {
@@ -119,6 +117,8 @@ pub mod array {
         lhs: Array<'vm, generic::A>,
         rhs: Array<'vm, generic::A>,
     ) -> RuntimeResult<Array<'vm, generic::A>, Error> {
+        #[derive(Traverseable)]
+        #[gluon(gluon_vm)]
         struct Append<'b> {
             lhs: &'b ValueArray,
             rhs: &'b ValueArray,
@@ -132,13 +132,6 @@ pub mod array {
                 } else {
                     self.lhs.repr()
                 }
-            }
-        }
-
-        impl<'b> Traverseable for Append<'b> {
-            fn traverse(&self, gc: &mut Gc) {
-                self.lhs.traverse(gc);
-                self.rhs.traverse(gc);
             }
         }
 
@@ -184,12 +177,12 @@ mod string {
     use crate::thread::ThreadInternal;
 
     pub fn append(lhs: WithVM<&str>, rhs: &str) -> RuntimeResult<String, Error> {
+        #[derive(Traverseable)]
+        #[gluon(gluon_vm)]
         struct StrAppend<'b> {
             lhs: &'b str,
             rhs: &'b str,
         }
-
-        impl<'b> Traverseable for StrAppend<'b> {}
 
         unsafe impl<'b> DataDef for StrAppend<'b> {
             type Value = ValueArray;
@@ -592,10 +585,18 @@ pub enum Component<'a> {
 #[gluon(gluon_vm)]
 pub struct Metadata(fs::Metadata);
 
+impl Traverseable for Metadata {
+    impl_traverseable! { self, _gc, { } }
+}
+
 #[derive(Userdata, Debug, VmType)]
 #[gluon(vm_type = "std.fs.DirEntry")]
 #[gluon(gluon_vm)]
 pub struct DirEntry(fs::DirEntry);
+
+impl Traverseable for DirEntry {
+    impl_traverseable! { self, _gc, { } }
+}
 
 pub fn load_fs(vm: &Thread) -> Result<ExternModule> {
     vm.register_type::<Metadata>("std.fs.Metadata", &[])?;

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -16,7 +16,7 @@ use crate::{
         primitive, Array, Getable, OpaqueRef, Pushable, Pushed, RuntimeResult, ValueRef, VmType,
         WithVM, IO,
     },
-    gc::{DataDef, Traverseable, WriteOnly},
+    gc::{DataDef, Trace, WriteOnly},
     stack::{ExternState, StackFrame},
     types::VmInt,
     value::{Def, GcStr, Repr, ValueArray, ValueRepr},
@@ -63,7 +63,7 @@ pub mod array {
             )));
         }
 
-        #[derive(Traverseable)]
+        #[derive(Trace)]
         #[gluon(gluon_vm)]
         struct Slice<'a> {
             start: usize,
@@ -117,7 +117,7 @@ pub mod array {
         lhs: Array<'vm, generic::A>,
         rhs: Array<'vm, generic::A>,
     ) -> RuntimeResult<Array<'vm, generic::A>, Error> {
-        #[derive(Traverseable)]
+        #[derive(Trace)]
         #[gluon(gluon_vm)]
         struct Append<'b> {
             lhs: &'b ValueArray,
@@ -177,7 +177,7 @@ mod string {
     use crate::thread::ThreadInternal;
 
     pub fn append(lhs: WithVM<&str>, rhs: &str) -> RuntimeResult<String, Error> {
-        #[derive(Traverseable)]
+        #[derive(Trace)]
         #[gluon(gluon_vm)]
         struct StrAppend<'b> {
             lhs: &'b str,
@@ -585,8 +585,8 @@ pub enum Component<'a> {
 #[gluon(gluon_vm)]
 pub struct Metadata(fs::Metadata);
 
-impl Traverseable for Metadata {
-    impl_traverseable! { self, _gc, { } }
+impl Trace for Metadata {
+    impl_trace! { self, _gc, { } }
 }
 
 #[derive(Userdata, Debug, VmType)]
@@ -594,8 +594,8 @@ impl Traverseable for Metadata {
 #[gluon(gluon_vm)]
 pub struct DirEntry(fs::DirEntry);
 
-impl Traverseable for DirEntry {
-    impl_traverseable! { self, _gc, { } }
+impl Trace for DirEntry {
+    impl_trace! { self, _gc, { } }
 }
 
 pub fn load_fs(vm: &Thread) -> Result<ExternModule> {

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -585,7 +585,7 @@ pub enum Component<'a> {
 #[gluon(gluon_vm)]
 pub struct Metadata(fs::Metadata);
 
-impl Trace for Metadata {
+unsafe impl Trace for Metadata {
     impl_trace! { self, _gc, { } }
 }
 
@@ -594,7 +594,7 @@ impl Trace for Metadata {
 #[gluon(gluon_vm)]
 pub struct DirEntry(fs::DirEntry);
 
-impl Trace for DirEntry {
+unsafe impl Trace for DirEntry {
     impl_trace! { self, _gc, { } }
 }
 

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -40,7 +40,7 @@ impl<T> fmt::Debug for Reference<T> {
     }
 }
 
-impl<T> Trace for Reference<T> {
+unsafe impl<T> Trace for Reference<T> {
     impl_trace! { self, gc,
         mark(&*self.value.lock().unwrap(), gc)
     }

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -22,10 +22,10 @@ impl<T> Userdata for Reference<T>
 where
     T: Any + Send + Sync,
 {
-    fn deep_clone(&self, deep_cloner: &mut Cloner) -> Result<GcPtr<Box<Userdata>>> {
+    fn deep_clone(&self, deep_cloner: &mut Cloner) -> Result<GcPtr<Box<dyn Userdata>>> {
         let value = self.value.lock().unwrap();
         let cloned_value = deep_cloner.deep_clone(&value)?;
-        let data: Box<Userdata> = Box::new(Reference {
+        let data: Box<dyn Userdata> = Box::new(Reference {
             value: Mutex::new(cloned_value),
             thread: unsafe { GcPtr::from_raw(deep_cloner.thread()) },
             _marker: PhantomData::<A>,

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -2,7 +2,7 @@ use crate::real_std::{any::Any, fmt, marker::PhantomData, sync::Mutex};
 
 use crate::{
     api::{generic::A, Generic, RuntimeResult, Unrooted, Userdata, WithVM},
-    gc::{GcPtr, Move, Traverseable},
+    gc::{GcPtr, Move, Trace},
     thread::ThreadInternal,
     value::{Cloner, Value},
     vm::Thread,
@@ -40,8 +40,8 @@ impl<T> fmt::Debug for Reference<T> {
     }
 }
 
-impl<T> Traverseable for Reference<T> {
-    impl_traverseable! { self, gc,
+impl<T> Trace for Reference<T> {
+    impl_trace! { self, gc,
         mark(&*self.value.lock().unwrap(), gc)
     }
 }

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -2,7 +2,7 @@ use crate::real_std::{any::Any, fmt, marker::PhantomData, sync::Mutex};
 
 use crate::{
     api::{generic::A, Generic, RuntimeResult, Unrooted, Userdata, WithVM},
-    gc::{Gc, GcPtr, Move, Traverseable},
+    gc::{GcPtr, Move, Traverseable},
     thread::ThreadInternal,
     value::{Cloner, Value},
     vm::Thread,
@@ -41,8 +41,8 @@ impl<T> fmt::Debug for Reference<T> {
 }
 
 impl<T> Traverseable for Reference<T> {
-    fn traverse(&self, gc: &mut Gc) {
-        self.value.lock().unwrap().traverse(gc)
+    impl_traverseable! { self, gc,
+        mark(&*self.value.lock().unwrap(), gc)
     }
 }
 

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -125,7 +125,7 @@ pub mod gc {
 
     impl<'de, T> DeserializeState<'de, DeSeed> for crate::gc::Move<T>
     where
-        T: crate::gc::Traverseable,
+        T: crate::gc::Trace,
         T: DeserializeState<'de, DeSeed>,
     {
         fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>
@@ -138,7 +138,7 @@ pub mod gc {
 
     impl<'de, T> DeserializeState<'de, DeSeed> for GcPtr<T>
     where
-        T: crate::gc::Traverseable + 'static,
+        T: crate::gc::Trace + 'static,
         T: DeserializeState<'de, DeSeed>,
     {
         fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 
 use crate::serde::de::{Deserialize, DeserializeSeed, DeserializeState, Error};
-use crate::serde::ser::{Seeded, SerializeSeq, SerializeState, Serializer};
+use crate::serde::ser::{Seeded, Serialize, SerializeSeq, SerializeState, Serializer};
 use crate::serde::Deserializer;
 
 use crate::base::serialization::{NodeMap, NodeToId};
@@ -426,6 +426,28 @@ pub mod typ {
         fn borrow(&self) -> &crate::base::serialization::SeSeed {
             &self.node_to_id
         }
+    }
+}
+
+pub mod atomic_cell {
+    use super::*;
+
+    use crossbeam::atomic::AtomicCell;
+
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<AtomicCell<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: Deserialize<'de>,
+    {
+        T::deserialize(deserializer).map(AtomicCell::new)
+    }
+
+    pub fn serialize<S, T>(t: &AtomicCell<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        T: Serialize + Copy,
+    {
+        t.load().serialize(serializer)
     }
 }
 

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -278,7 +278,7 @@ pub struct Stack {
     frames: Vec<Frame<State>>,
 }
 
-impl Trace for Stack {
+unsafe impl Trace for Stack {
     impl_trace! { self, gc,
         mark(&self.values, gc)
     }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::base::pos::Line;
 use crate::base::symbol::Symbol;
 
-use crate::gc::{GcPtr, Traverseable};
+use crate::gc::{GcPtr, Trace};
 use crate::types::VmIndex;
 use crate::value::{ClosureData, DataStruct, ExternFunction, Value, ValueRepr};
 use crate::Variants;
@@ -278,8 +278,8 @@ pub struct Stack {
     frames: Vec<Frame<State>>,
 }
 
-impl Traverseable for Stack {
-    impl_traverseable! { self, gc,
+impl Trace for Stack {
+    impl_trace! { self, gc,
         mark(&self.values, gc)
     }
 }

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::base::pos::Line;
 use crate::base::symbol::Symbol;
 
-use crate::gc::{Gc, GcPtr, Traverseable};
+use crate::gc::{GcPtr, Traverseable};
 use crate::types::VmIndex;
 use crate::value::{ClosureData, DataStruct, ExternFunction, Value, ValueRepr};
 use crate::Variants;
@@ -279,8 +279,8 @@ pub struct Stack {
 }
 
 impl Traverseable for Stack {
-    fn traverse(&self, gc: &mut Gc) {
-        self.values.traverse(gc);
+    impl_traverseable! { self, gc,
+        mark(&self.values, gc)
     }
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -66,7 +66,7 @@ where
         }
     }
 
-    pub fn root(&self) -> Execute<RootedThread> {
+    pub unsafe fn root(&self) -> Execute<RootedThread> {
         Execute {
             thread: self.thread.as_ref().map(|t| t.root_thread()),
         }
@@ -157,14 +157,14 @@ where
     value: Value,
 }
 
-impl<T> Trace for RootedValue<T>
+unsafe impl<T> Trace for RootedValue<T>
 where
     T: VmRootInternal,
 {
-    fn root(&self, _: &mut Gc) {
+    unsafe fn root(&self, _: &mut Gc) {
         self.root_();
     }
-    fn unroot(&self, _gc: &mut Gc) {
+    unsafe fn unroot(&self, _gc: &mut Gc) {
         self.unroot_();
     }
     fn trace(&self, gc: &mut Gc) {
@@ -317,11 +317,11 @@ struct Roots<'b> {
     vm: GcPtr<Thread>,
     stack: &'b Stack,
 }
-impl<'b> Trace for Roots<'b> {
-    fn unroot(&self, _gc: &mut Gc) {
+unsafe impl<'b> Trace for Roots<'b> {
+    unsafe fn unroot(&self, _gc: &mut Gc) {
         unreachable!()
     }
-    fn root(&self, _gc: &mut Gc) {
+    unsafe fn root(&self, _gc: &mut Gc) {
         unreachable!()
     }
 
@@ -450,11 +450,11 @@ impl VmType for Thread {
     type Type = Self;
 }
 
-impl Trace for Thread {
-    fn root(&self, _gc: &mut Gc) {
+unsafe impl Trace for Thread {
+    unsafe fn root(&self, _gc: &mut Gc) {
         // Thread is always behind a `GcPtr`
     }
-    fn unroot(&self, _gc: &mut Gc) {
+    unsafe fn unroot(&self, _gc: &mut Gc) {
         // Ditto
     }
     fn trace(&self, gc: &mut Gc) {
@@ -574,11 +574,11 @@ impl Clone for RootedThread {
     }
 }
 
-impl Trace for RootedThread {
-    fn root(&self, _gc: &mut Gc) {
+unsafe impl Trace for RootedThread {
+    unsafe fn root(&self, _gc: &mut Gc) {
         self.root_();
     }
-    fn unroot(&self, _gc: &mut Gc) {
+    unsafe fn unroot(&self, _gc: &mut Gc) {
         self.unroot_();
     }
     fn trace(&self, gc: &mut Gc) {

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -6,15 +6,19 @@ use std::{
     ops::{Add, Deref, DerefMut, Div, Mul, Sub},
     result::Result as StdResult,
     string::String as StdString,
-    sync::atomic::{self, AtomicBool},
-    sync::Arc,
-    sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{
+        atomic::{self, AtomicBool},
+        Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
+    },
     usize,
 };
 
-use futures::{
-    future::{self, Either, FutureResult},
-    try_ready, Async, Future, Poll,
+use {
+    crossbeam::atomic::AtomicCell,
+    futures::{
+        future::{self, Either, FutureResult},
+        try_ready, Async, Future, Poll,
+    },
 };
 
 use crate::base::{
@@ -146,33 +150,53 @@ pub enum Status {
 /// A rooted value
 pub struct RootedValue<T>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
 {
     vm: T,
+    rooted: AtomicCell<bool>,
     value: Value,
+}
+
+impl<T> Traverseable for RootedValue<T>
+where
+    T: VmRootInternal,
+{
+    fn root(&self, _: &mut Gc) {
+        self.root_();
+    }
+    fn unroot(&self, _gc: &mut Gc) {
+        self.unroot_();
+    }
+    fn traverse(&self, gc: &mut Gc) {
+        self.value.traverse(gc);
+    }
 }
 
 impl<T> Clone for RootedValue<T>
 where
-    T: Deref<Target = Thread> + Clone,
+    T: VmRootInternal + Clone,
 {
     fn clone(&self) -> Self {
-        self.vm
+        let value = RootedValue {
+            vm: self.vm.clone(),
+            rooted: AtomicCell::new(true),
+            value: self.value.clone(),
+        };
+        value
+            .vm
             .rooted_values
             .write()
             .unwrap()
             .push(self.value.clone());
-        RootedValue {
-            vm: self.vm.clone(),
-            value: self.value.clone(),
-        }
+
+        value
     }
 }
 
 impl<T, U> PartialEq<RootedValue<U>> for RootedValue<T>
 where
-    T: Deref<Target = Thread>,
-    U: Deref<Target = Thread>,
+    T: VmRootInternal,
+    U: VmRootInternal,
 {
     fn eq(&self, other: &RootedValue<U>) -> bool {
         self.value == other.value
@@ -181,21 +205,18 @@ where
 
 impl<T> Drop for RootedValue<T>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
 {
     fn drop(&mut self) {
-        let mut rooted_values = self.vm.rooted_values.write().unwrap();
-        let i = rooted_values
-            .iter()
-            .position(|p| p.obj_eq(&self.value))
-            .unwrap_or_else(|| ice!("Rooted value has already been dropped"));
-        rooted_values.swap_remove(i);
+        if *self.rooted.get_mut() {
+            self.unroot_();
+        }
     }
 }
 
 impl<T> fmt::Debug for RootedValue<T>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.value)
@@ -204,7 +225,7 @@ where
 
 impl<T> RootedValue<T>
 where
-    T: Deref<Target = Thread>,
+    T: VmRootInternal,
 {
     pub fn re_root<'vm, U>(&self, vm: U) -> Result<RootedValue<U>>
     where
@@ -212,7 +233,11 @@ where
     {
         let value = vm.deep_clone_value(&self.vm, self.value.get_variants())?;
         vm.rooted_values.write().unwrap().push(value.clone());
-        Ok(RootedValue { vm, value })
+        Ok(RootedValue {
+            vm,
+            rooted: AtomicCell::new(true),
+            value,
+        })
     }
 
     pub fn get_variant(&self) -> Variants {
@@ -261,6 +286,25 @@ where
     pub fn as_ref(&self) -> RootedValue<&Thread> {
         self.vm.root_value(self.get_variant())
     }
+
+    fn root_(&self) {
+        self.vm.root_vm();
+        let mut rooted_values = self.vm.rooted_values.write().unwrap();
+        assert!(!self.rooted.load());
+        self.rooted.store(true);
+        rooted_values.push(self.value.clone());
+    }
+
+    fn unroot_(&self) {
+        self.vm.unroot_vm();
+        let mut rooted_values = self.vm.rooted_values.write().unwrap();
+        self.rooted.store(false);
+        let i = rooted_values
+            .iter()
+            .position(|p| p.obj_eq(&self.value))
+            .unwrap_or_else(|| ice!("Rooted value has already been dropped"));
+        rooted_values.swap_remove(i);
+    }
 }
 
 impl<'vm> RootedValue<&'vm Thread> {
@@ -274,6 +318,13 @@ struct Roots<'b> {
     stack: &'b Stack,
 }
 impl<'b> Traverseable for Roots<'b> {
+    fn unroot(&self, _gc: &mut Gc) {
+        unreachable!()
+    }
+    fn root(&self, _gc: &mut Gc) {
+        unreachable!()
+    }
+
     fn traverse(&self, gc: &mut Gc) {
         // Since this vm's stack is already borrowed in self we need to manually mark it to prevent
         // it from being traversed normally
@@ -400,6 +451,12 @@ impl VmType for Thread {
 }
 
 impl Traverseable for Thread {
+    fn root(&self, _gc: &mut Gc) {
+        // Thread is always behind a `GcPtr`
+    }
+    fn unroot(&self, _gc: &mut Gc) {
+        // Ditto
+    }
     fn traverse(&self, gc: &mut Gc) {
         self.traverse_fields_except_stack(gc);
         self.context.lock().unwrap().stack.traverse(gc);
@@ -418,7 +475,7 @@ impl VmType for RootedThread {
 
 impl<'vm> Pushable<'vm> for RootedThread {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        context.push(ValueRepr::Thread(self.0));
+        context.push(ValueRepr::Thread(self.thread));
         Ok(())
     }
 }
@@ -437,37 +494,69 @@ impl<'vm, 'value> Getable<'vm, 'value> for RootedThread {
 /// An instance of `Thread` which is rooted. See the `Thread` type for documentation on interacting
 /// with the type.
 #[derive(Debug)]
-#[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
-#[cfg_attr(
-    feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
-)]
+#[cfg_attr(feature = "serde_derive", derive(SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
     serde(serialize_state = "crate::serialization::SeSeed")
 )]
-pub struct RootedThread(#[cfg_attr(feature = "serde_derive", serde(state))] GcPtr<Thread>);
+pub struct RootedThread {
+    #[cfg_attr(feature = "serde_derive", serde(state))]
+    thread: GcPtr<Thread>,
+    #[cfg_attr(
+        feature = "serde_derive",
+        serde(serialize_with = "crate::serialization::atomic_cell::serialize")
+    )]
+    rooted: AtomicCell<bool>,
+}
+
+// TODO Remove when crossbeam implements this for AtomicCell
+impl std::panic::RefUnwindSafe for RootedThread {}
+impl std::panic::UnwindSafe for RootedThread {}
+
+#[cfg(feature = "serde_derive")]
+impl<'de> serde::de::DeserializeState<'de, crate::serialization::DeSeed> for RootedThread {
+    fn deserialize_state<D>(
+        seed: &mut crate::serialization::DeSeed,
+        deserializer: D,
+    ) -> StdResult<Self, <D as serde::Deserializer<'de>>::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(DeserializeState)]
+        #[serde(deserialize_state = "crate::serialization::DeSeed")]
+        pub struct RootedThreadProxy {
+            #[serde(state)]
+            thread: GcPtr<Thread>,
+            #[serde(deserialize_with = "crate::serialization::atomic_cell::deserialize")]
+            rooted: AtomicCell<bool>,
+        }
+
+        let RootedThreadProxy { thread, rooted } =
+            RootedThreadProxy::deserialize_state(seed, deserializer)?;
+        let mut rooted_thread = RootedThread { thread, rooted };
+        if *rooted_thread.rooted.get_mut() {
+            rooted_thread.parent_threads().push(thread);
+        }
+
+        Ok(rooted_thread)
+    }
+}
 
 impl Drop for RootedThread {
     fn drop(&mut self) {
-        let is_empty = {
-            let mut roots = self.parent_threads();
-            let index = roots
-                .iter()
-                .position(|p| &**p as *const Thread == &*self.0 as *const Thread)
-                .expect("VM ptr");
-            roots.swap_remove(index);
-            roots.is_empty()
-        };
-        if self.parent.is_none() && is_empty {
-            // The last RootedThread was dropped, there is no way to refer to the global state any
-            // longer so drop everything
-            let mut gc_ref = self.0.global_state.gc.lock().unwrap();
-            let gc_to_drop = ::std::mem::replace(&mut *gc_ref, Gc::new(Generation::default(), 0));
-            // Make sure that the RefMut is dropped before the Gc itself as the RwLock is dropped
-            // when the Gc is dropped
-            drop(gc_ref);
-            drop(gc_to_drop);
+        if *self.rooted.get_mut() {
+            let is_empty = self.unroot_();
+            if self.parent.is_none() && is_empty {
+                // The last RootedThread was dropped, there is no way to refer to the global state any
+                // longer so drop everything
+                let mut gc_ref = self.thread.global_state.gc.lock().unwrap();
+                let gc_to_drop =
+                    ::std::mem::replace(&mut *gc_ref, Gc::new(Generation::default(), 0));
+                // Make sure that the RefMut is dropped before the Gc itself as the RwLock is dropped
+                // when the Gc is dropped
+                drop(gc_ref);
+                drop(gc_to_drop);
+            }
         }
     }
 }
@@ -475,7 +564,7 @@ impl Drop for RootedThread {
 impl Deref for RootedThread {
     type Target = Thread;
     fn deref(&self) -> &Thread {
-        &self.0
+        &self.thread
     }
 }
 
@@ -486,8 +575,14 @@ impl Clone for RootedThread {
 }
 
 impl Traverseable for RootedThread {
+    fn root(&self, _gc: &mut Gc) {
+        self.root_();
+    }
+    fn unroot(&self, _gc: &mut Gc) {
+        self.unroot_();
+    }
     fn traverse(&self, gc: &mut Gc) {
-        self.0.traverse(gc);
+        self.thread.traverse(gc);
     }
 }
 
@@ -525,7 +620,8 @@ impl RootedThread {
     /// Converts a `RootedThread` into a raw pointer allowing to be passed through a C api.
     /// The reference count for the thread is not modified
     pub fn into_raw(self) -> *const Thread {
-        let ptr: *const Thread = &*self.0;
+        assert!(self.rooted.load());
+        let ptr: *const Thread = &*self.thread;
         ::std::mem::forget(self);
         ptr
     }
@@ -534,7 +630,29 @@ impl RootedThread {
     /// The reference count for the thread is not modified so it is up to the caller to ensure that
     /// the count is correct.
     pub unsafe fn from_raw(ptr: *const Thread) -> RootedThread {
-        RootedThread(GcPtr::from_raw(ptr))
+        RootedThread {
+            thread: GcPtr::from_raw(ptr),
+            rooted: AtomicCell::new(true),
+        }
+    }
+
+    fn root_(&self) {
+        let mut parent_threads_lock = self.parent_threads();
+        assert!(!self.rooted.load());
+        self.rooted.store(true);
+        parent_threads_lock.push(self.thread);
+    }
+
+    fn unroot_(&self) -> bool {
+        assert!(self.rooted.load());
+        let mut roots = self.parent_threads();
+        self.rooted.store(false);
+        let index = roots
+            .iter()
+            .position(|p| &**p as *const Thread == &*self.thread as *const Thread)
+            .expect("VM ptr");
+        roots.swap_remove(index);
+        roots.is_empty()
     }
 }
 
@@ -564,9 +682,12 @@ impl Thread {
     /// `RootedThread` is droppped
     pub fn root_thread(&self) -> RootedThread {
         unsafe {
-            let vm = RootedThread(GcPtr::from_raw(self));
-            vm.parent_threads().push(vm.0);
-            vm
+            let thread = GcPtr::from_raw(self);
+            self.parent_threads().push(thread);
+            RootedThread {
+                thread,
+                rooted: AtomicCell::new(true),
+            }
         }
     }
 
@@ -814,8 +935,14 @@ impl Thread {
     }
 }
 
-pub trait VmRoot<'a>: Deref<Target = Thread> + Clone + 'a {
-    fn root(thread: &'a Thread) -> Self;
+pub trait VmRoot<'a>: VmRootInternal + 'a {
+    fn new_root(thread: &'a Thread) -> Self;
+}
+
+pub trait VmRootInternal: Deref<Target = Thread> + Clone {
+    fn root_vm(&self);
+
+    fn unroot_vm(&self);
 
     /// Roots a value
     fn root_value_with_self(self, value: Variants) -> RootedValue<Self> {
@@ -823,20 +950,37 @@ pub trait VmRoot<'a>: Deref<Target = Thread> + Clone + 'a {
         self.rooted_values.write().unwrap().push(value.clone());
         RootedValue {
             vm: self,
+            rooted: AtomicCell::new(true),
             value: value,
         }
     }
 }
 
 impl<'a> VmRoot<'a> for &'a Thread {
-    fn root(thread: &'a Thread) -> Self {
+    fn new_root(thread: &'a Thread) -> Self {
         thread
     }
 }
 
+impl<'a> VmRootInternal for &'a Thread {
+    fn root_vm(&self) {}
+
+    fn unroot_vm(&self) {}
+}
+
 impl<'a> VmRoot<'a> for RootedThread {
-    fn root(thread: &'a Thread) -> Self {
+    fn new_root(thread: &'a Thread) -> Self {
         thread.root_thread()
+    }
+}
+
+impl VmRootInternal for RootedThread {
+    fn root_vm(&self) {
+        self.root_();
+    }
+
+    fn unroot_vm(&self) {
+        self.unroot_();
     }
 }
 
@@ -867,7 +1011,7 @@ where
     where
         Self: Send + Sync,
     {
-        let self_ = RootedThread::root(self.borrow());
+        let self_ = RootedThread::new_root(self.borrow());
         let level = self_.context().stack.get_frames().len();
 
         Box::new(self.call_thunk(closure).or_else(move |mut err| {
@@ -891,7 +1035,7 @@ where
     where
         Self: Send + Sync,
     {
-        let self_ = RootedThread::root(self.borrow());
+        let self_ = RootedThread::new_root(self.borrow());
         let level = self_.context().stack.get_frames().len();
         Box::new(self.execute_io(value).or_else(move |mut err| {
             let mut context = self_.context();
@@ -945,7 +1089,8 @@ impl ThreadInternal for Thread {
         let value = value.get_value();
         self.rooted_values.write().unwrap().push(value.clone());
         RootedValue {
-            vm: T::root(self),
+            vm: T::new_root(self),
+            rooted: AtomicCell::new(true),
             value: value,
         }
     }

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1074,7 +1074,7 @@ impl ThreadInternal for Thread {
     }
 }
 
-pub type HookFn = Box<FnMut(&Thread, DebugInfo) -> Result<Async<()>> + Send + Sync>;
+pub type HookFn = Box<dyn FnMut(&Thread, DebugInfo) -> Result<Async<()>> + Send + Sync>;
 
 pub struct DebugInfo<'a> {
     stack: &'a Stack,
@@ -1206,7 +1206,7 @@ struct Hook {
 }
 
 struct PollFn {
-    poll_fn: Box<for<'vm> FnMut(&'vm Thread) -> super::Result<Async<OwnedContext<'vm>>> + Send>,
+    poll_fn: Box<dyn for<'vm> FnMut(&'vm Thread) -> super::Result<Async<OwnedContext<'vm>>> + Send>,
     frame_index: VmIndex,
 }
 

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -131,7 +131,7 @@ pub struct BytecodeFunction {
     pub debug_info: DebugInfo,
 }
 
-impl Trace for BytecodeFunction {
+unsafe impl Trace for BytecodeFunction {
     impl_trace! { self, gc,
         mark(&self.inner_functions, gc)
     }
@@ -302,7 +302,7 @@ unsafe impl<'b> DataDef for UninitializedRecord<'b> {
     }
 }
 
-impl<'b> Trace for UninitializedRecord<'b> {
+unsafe impl<'b> Trace for UninitializedRecord<'b> {
     impl_trace! {self, _gc, {} }
 }
 
@@ -849,7 +849,7 @@ unsafe impl<'b> DataDef for PartialApplicationDataDef<'b> {
     }
 }
 
-impl Trace for Value {
+unsafe impl Trace for Value {
     impl_trace! {self,  gc,
         mark(&self.get_repr(), gc)
     }
@@ -990,7 +990,7 @@ impl fmt::Debug for ExternFunction {
     }
 }
 
-impl Trace for ExternFunction {
+unsafe impl Trace for ExternFunction {
     impl_trace! { self, _gc, {} }
 }
 
@@ -1098,6 +1098,8 @@ impl Repr {
 macro_rules! on_array {
     ($array:expr, $f:expr) => {{
         let ref array = $array;
+        #[allow(unused_unsafe)]
+        // SAFETY We check the `repr` before casting to the inner type
         unsafe {
             match array.repr() {
                 Repr::Byte => $f(array.unsafe_array::<u8>()),
@@ -1157,7 +1159,7 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-impl Trace for ValueArray {
+unsafe impl Trace for ValueArray {
     impl_trace! { self, gc,
         on_array!(self, |array: &Array<_>| mark(array, gc))
     }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -132,8 +132,8 @@ pub struct Global {
 }
 
 impl Traverseable for Global {
-    fn traverse(&self, gc: &mut Gc) {
-        self.value.traverse(gc);
+    impl_traverseable! { self, gc,
+        mark(&self.value, gc)
     }
 }
 
@@ -183,14 +183,14 @@ pub struct GlobalVmState {
 }
 
 impl Traverseable for GlobalVmState {
-    fn traverse(&self, gc: &mut Gc) {
+    impl_traverseable! { self, gc, {
         for g in self.env.read().unwrap().globals.values() {
-            g.traverse(gc);
+            mark(g, gc);
         }
         // Also need to check the interned string table
-        self.interner.read().unwrap().traverse(gc);
-        self.generation_0_threads.read().unwrap().traverse(gc);
-    }
+        mark(&*self.interner.read().unwrap(), gc);
+        mark(&*self.generation_0_threads.read().unwrap(), gc);
+    } }
 }
 
 /// A borrowed structure which implements `CompilerEnv`, `TypeEnv` and `KindEnv` allowing the

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -23,7 +23,7 @@ use crate::base::{
 use crate::{
     api::{ValueRef, IO},
     compiler::{CompiledFunction, CompiledModule, CompilerEnv, Variable},
-    gc::{Gc, GcPtr, Generation, Move, Traverseable},
+    gc::{Gc, GcPtr, Generation, Move, Trace},
     interner::{InternedStr, Interner},
     lazy::Lazy,
     macros::MacroEnv,
@@ -131,8 +131,8 @@ pub struct Global {
     pub value: Value,
 }
 
-impl Traverseable for Global {
-    impl_traverseable! { self, gc,
+impl Trace for Global {
+    impl_trace! { self, gc,
         mark(&self.value, gc)
     }
 }
@@ -182,8 +182,8 @@ pub struct GlobalVmState {
     debug_level: RwLock<DebugLevel>,
 }
 
-impl Traverseable for GlobalVmState {
-    impl_traverseable! { self, gc, {
+impl Trace for GlobalVmState {
+    impl_trace! { self, gc, {
         for g in self.env.read().unwrap().globals.values() {
             mark(g, gc);
         }

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -131,7 +131,7 @@ pub struct Global {
     pub value: Value,
 }
 
-impl Trace for Global {
+unsafe impl Trace for Global {
     impl_trace! { self, gc,
         mark(&self.value, gc)
     }
@@ -182,7 +182,7 @@ pub struct GlobalVmState {
     debug_level: RwLock<DebugLevel>,
 }
 
-impl Trace for GlobalVmState {
+unsafe impl Trace for GlobalVmState {
     impl_trace! { self, gc, {
         for g in self.env.read().unwrap().globals.values() {
             mark(g, gc);


### PR DESCRIPTION
`RootedThread` and `RootedValue` are reference counted pointers so
storing them in a value allocated on the GC heap will create a cycle
which will never be dropped.

To avoid this we detect when such a value is allocated on the GC heap
and remove the value from the root list.

Fixes #746