### PR TITLE
fix: Ensure that threads are dropped when using child threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_state 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,12 +1,14 @@
-extern crate env_logger;
-extern crate gluon;
-extern crate tempfile;
-extern crate tokio;
-
-use gluon::vm::api::{Hole, OpaqueValue, OwnedFunction, ValueRef, IO};
-use gluon::{new_vm, Compiler, Thread};
 use std::fs;
+
 use tempfile::NamedTempFile;
+
+use gluon::{
+    new_vm,
+    vm::api::{Hole, OpaqueValue, OwnedFunction, ValueRef, IO},
+    Compiler, Thread,
+};
+
+use tokio::runtime::current_thread::Runtime;
 
 #[macro_use]
 mod support;
@@ -164,7 +166,7 @@ fn spawn_on_twice() {
         action
     "#;
 
-    let mut runtime = self::tokio::runtime::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let vm = make_vm();
     let (result, _) = runtime
         .block_on(
@@ -210,7 +212,7 @@ fn spawn_on_runexpr() {
         wrap x.value
     "#;
 
-    let mut runtime = self::tokio::runtime::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let vm = make_vm();
     let (result, _) = runtime
         .block_on(
@@ -249,7 +251,7 @@ fn spawn_on_do_action_twice() {
         wrap (load counter)
     "#;
 
-    let mut runtime = self::tokio::runtime::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let vm = make_vm();
     let (result, _) = runtime
         .block_on(
@@ -282,7 +284,7 @@ fn spawn_on_force_action_twice() {
         wrap (load counter)
     "#;
 
-    let mut runtime = self::tokio::runtime::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let vm = make_vm();
     let (result, _) = runtime
         .block_on(
@@ -314,7 +316,7 @@ fn spawn_on_runexpr_in_catch() {
         (io.catch action wrap >>= io.println) *> wrap "123"
     "#;
 
-    let mut runtime = self::tokio::runtime::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     let vm = make_vm();
     let (result, _) = runtime
         .block_on(

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -7,18 +7,22 @@ extern crate walkdir;
 
 extern crate gluon;
 
-use std::fs::File;
-use std::io::Read;
+use std::{fs::File, io::Read};
 
 use futures::Future;
 
 use crate::serde::ser::SerializeState;
 
-use gluon::vm::api::{Hole, OpaqueValue};
-use gluon::vm::serialization::{DeSeed, SeSeed};
-use gluon::vm::thread::{RootedThread, RootedValue, Thread, ThreadInternal};
-use gluon::vm::Variants;
-use gluon::{new_vm, Compiler};
+use gluon::{
+    new_vm,
+    vm::{
+        api::{Hole, OpaqueValue, IO},
+        serialization::{DeSeed, SeSeed},
+        thread::{RootedThread, RootedValue, Thread},
+        Variants,
+    },
+    Compiler,
+};
 
 fn serialize_value(value: Variants) {
     let mut buffer = Vec::new();
@@ -30,10 +34,10 @@ fn serialize_value(value: Variants) {
     String::from_utf8(buffer).unwrap();
 }
 
-fn roundtrip<'t>(
-    thread: &'t RootedThread,
+fn roundtrip(
+    thread: &RootedThread,
     value: &OpaqueValue<&Thread, Hole>,
-) -> RootedValue<&'t Thread> {
+) -> RootedValue<RootedThread> {
     use std::str::from_utf8;
 
     let value = value.get_variant();
@@ -51,7 +55,6 @@ fn roundtrip<'t>(
     let deserialize_value = DeSeed::new(thread)
         .deserialize(&mut de)
         .unwrap_or_else(|err| panic!("{}\n{}", err, buffer));
-    let deserialize_value = thread.root_value(unsafe { Variants::new(&deserialize_value) });
 
     // We can't compare functions for equality so serialize again and check that for equality with
     // the first serialization
@@ -61,6 +64,7 @@ fn roundtrip<'t>(
         let ser_state = SeSeed::new();
         value.serialize_state(&mut ser, &ser_state).unwrap();
     }
+    eprintln!("{}", buffer);
     assert_eq!(buffer, from_utf8(&buffer2).unwrap());
 
     deserialize_value
@@ -199,11 +203,23 @@ fn roundtrip_lazy() {
 }
 
 #[test]
-fn roundtrip_thread() {
+fn roundtrip_std_thread() {
     let thread = new_vm();
     let expr = r#" import! std.thread "#;
     let (value, _) = Compiler::new()
         .run_expr::<OpaqueValue<&Thread, Hole>>(&thread, "test", &expr)
         .unwrap_or_else(|err| panic!("{}", err));
     roundtrip(&thread, &value);
+}
+
+#[test]
+#[ignore] // Unimplemented so far
+fn roundtrip_thread() {
+    let thread = new_vm();
+    let expr = r#" let t = import! std.thread in t.new_thread ()"#;
+    let (value, _) = Compiler::new()
+        .run_io(true)
+        .run_expr::<IO<OpaqueValue<&Thread, Hole>>>(&thread, "test", &expr)
+        .unwrap_or_else(|err| panic!("{}", err));
+    roundtrip(&thread, &Into::<Result<_, _>>::into(value).unwrap());
 }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -30,6 +30,7 @@ ordered-float = "1"
 pretty = "0.5"
 quick-error = "1.1.0"
 smallvec = "0.6"
+slab = "0.4"
 typed-arena = "1.2.0"
 
 serde = { version = "1.0.0", optional = true }

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -279,6 +279,15 @@ pub enum IO<T> {
     Exception(String),
 }
 
+impl<T> Into<StdResult<T, String>> for IO<T> {
+    fn into(self) -> StdResult<T, String> {
+        match self {
+            IO::Value(x) => Ok(x),
+            IO::Exception(x) => Err(x),
+        }
+    }
+}
+
 impl<T, E> From<StdResult<T, E>> for IO<T>
 where
     E: fmt::Display,

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -965,6 +965,8 @@ mod tests {
         }
         // Panic as it attempts to access past the lock
         StackFrame::frame(&mut stack, 1, State::Unknown);
+
+        unsafe { gc.clear() }
     }
 
     #[test]
@@ -984,6 +986,8 @@ mod tests {
         }
         // Panic as it attempts to pop a locked value
         stack.pop();
+
+        unsafe { gc.clear() }
     }
 
     #[test]
@@ -1010,6 +1014,8 @@ mod tests {
         stack.release_lock(lock);
         let mut frame = StackFrame::<State>::current(&mut stack);
         assert_eq!(frame.pop(), Value::from(Int(2)));
+
+        unsafe { gc.clear() }
     }
 
     #[test]

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -1637,6 +1637,8 @@ mod tests {
             ),
             "Cons 0 (Cons 123 Nil)"
         );
+
+        unsafe { gc.clear() }
     }
 
     #[test]
@@ -1660,6 +1662,8 @@ mod tests {
             ),
             "[1, 2, 3]"
         );
+
+        unsafe { gc.clear() }
     }
 
     #[test]


### PR DESCRIPTION
Uses a very naive approach to determine if there still exists thread
references by scanning every thread. Could be faster but this fixes the
immediate issue.