### PR TITLE
Add `#[gluon_userdata(clone)]` attribute

### DIFF
--- a/codegen/src/attr.rs
+++ b/codegen/src/attr.rs
@@ -9,7 +9,10 @@ use syn::{
 
 fn get_gluon_meta_items(attr: &syn::Attribute) -> Option<Vec<syn::NestedMeta>> {
     if attr.path.segments.len() == 1
-        && (attr.path.segments[0].ident == "gluon" || attr.path.segments[0].ident == "gluon_trace")
+        && (   attr.path.segments[0].ident == "gluon"
+            || attr.path.segments[0].ident == "gluon_trace"
+            || attr.path.segments[0].ident == "gluon_userdata"
+        )
     {
         match attr.interpret_meta() {
             Some(List(ref meta)) => Some(meta.nested.iter().cloned().collect()),
@@ -31,6 +34,7 @@ pub struct Container {
     pub vm_type: Option<String>,
     pub newtype: bool,
     pub skip: bool,
+    pub clone: bool,
 }
 
 impl Container {
@@ -41,6 +45,7 @@ impl Container {
         let mut vm_type = None;
         let mut newtype = false;
         let mut skip = false;
+        let mut clone = false;
 
         for meta_items in item.attrs.iter().filter_map(get_gluon_meta_items) {
             for meta_item in meta_items {
@@ -69,6 +74,10 @@ impl Container {
                         skip = true;
                     }
 
+                    Meta(Word(ref w)) if w == "clone" => {
+                        clone = true;
+                    }
+
                     _ => panic!("unexpected gluon container attribute: {:?}", meta_item),
                 }
             }
@@ -79,6 +88,7 @@ impl Container {
             vm_type,
             newtype,
             skip,
+            clone,
         }
     }
 }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -192,7 +192,7 @@ pub fn vm_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 #[doc(hidden)]
-#[proc_macro_derive(Trace, attributes(gluon, gluon_trace))]
+#[proc_macro_derive(Trace, attributes(gluon, gluon_trace, gluon_userdata))]
 pub fn trace(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     trace::derive(input.into()).into()
 }

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     thread::{self, Context, RootedThread, ThreadInternal, VmRoot, VmRootInternal},
     types::{VmIndex, VmInt, VmTag},
     value::{
-        ArrayDef, ArrayRepr, Cloner, ClosureData, DataStruct, Def, GcStr, Value, ValueArray,
+        ArrayDef, ArrayRepr, ClosureData, DataStruct, Def, GcStr, Value, ValueArray,
         ValueRepr,
     },
     vm::{self, RootedValue, Status, Thread},
@@ -38,7 +38,7 @@ pub use self::{
     opaque::{Opaque, OpaqueRef, OpaqueValue},
     record::Record,
 };
-pub use crate::{thread::ActiveThread, value::Userdata};
+pub use crate::{thread::ActiveThread, value::Userdata, value::Cloner};
 
 macro_rules! count {
     () => { 0 };


### PR DESCRIPTION
If set and the deriving type implements `Clone`, the gluon type will be
cloneable.

Fixes #761