### PR TITLE
refactor(vm): Track rooting better in the vm to reduce unsafety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_state 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -859,7 +859,7 @@ dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_state 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1047,7 +1047,7 @@ dependencies = [
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_state 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_state"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3305,7 +3305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5626ac617da2f2d9c48af5515a21d5a480dbd151e01bb1c355e26a3e68113"
 "checksum serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "01e69e1b8a631f245467ee275b8c757b818653c6d704cdbcaeb56b56767b529c"
-"checksum serde_derive_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e1b73f7c2939f36fb2e5d72d42aedca7dc8ddae40688dd839daee052a17e2cb7"
+"checksum serde_derive_state 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4191bb4663f222ad7838461b923d208bb70e023f82587259877cc446f1a51f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_state 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa2090da092b18994dae3c333d9df5aec47010b3bff292a974eba76b92e214c4"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ codespan = "0.3"
 codespan-reporting = "0.3"
 
 serde = { version = "1.0.0", optional = true }
-serde_state = { version = "0.4.0", optional = true }
-serde_derive_state = { version = "0.4.0", optional = true }
+serde_state = { version = "0.4", optional = true }
+serde_derive_state = { version = "0.4.7", optional = true }
 
 # Binding crates
 regex = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,3 +138,9 @@ path = "examples/lisp/main.rs"
 
 [package.metadata.docs.rs]
 features = ["docs_rs"]
+
+[profile.release]
+debug = true
+
+[profile.bench]
+debug = true

--- a/codegen/src/getable.rs
+++ b/codegen/src/getable.rs
@@ -212,7 +212,7 @@ fn gen_impl(
                 }
 
                 fn from_proxy(vm: &'__vm _gluon_thread::Thread, proxy: &'__value mut Self::Proxy) -> Self {
-                    Self::from_value(vm, *proxy)
+                    Self::from_value(vm, proxy.clone())
                 }
 
                 fn from_value(vm: &'__vm _gluon_thread::Thread, variants: _GluonVariants<'__value>) -> Self {

--- a/codegen/src/pushable.rs
+++ b/codegen/src/pushable.rs
@@ -176,13 +176,13 @@ fn gen_push_impl(
     let fields_len = field_idents.len();
     let new_data = match tag {
         Some(tag) => quote! {
-            ctx.context().push_new_data(vm, #tag as _gluon_types::VmTag, #fields_len)?
+            ctx.context().push_new_data(#tag as _gluon_types::VmTag, #fields_len)?
         },
         None => {
             let field_ident_strs = field_idents.iter().map(|i| i.to_string());
             quote! { {
                 let field_names = [#(vm.global_env().intern(#field_ident_strs)?),*];
-                ctx.context().push_new_record(vm, #fields_len, &field_names)?;
+                ctx.context().push_new_record(#fields_len, &field_names)?;
             } }
         }
     };

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -825,7 +825,10 @@ pub struct Precompiled<D>(pub D);
 )]
 #[cfg_attr(
     feature = "serde_derive_state",
-    serde(deserialize_state = "::vm::serialization::DeSeed")
+    serde(
+        deserialize_state = "::vm::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive_state",
@@ -864,7 +867,7 @@ where
     {
         use crate::vm::serialization::DeSeed;
 
-        let module: Module = try_future!(DeSeed::new(&vm)
+        let module: Module = try_future!(DeSeed::new(&vm, &mut vm.current_context())
             .deserialize(self.0)
             .map_err(|err| err.to_string()));
         let module_id = module.module.function.id.clone();
@@ -889,6 +892,7 @@ where
                 .map_err(Error::from),
         )
     }
+
     fn load_script<T>(
         self,
         compiler: &mut Compiler,
@@ -908,7 +912,7 @@ where
             typ,
             value,
             id: _,
-        } = try_future!(DeSeed::new(&vm)
+        } = try_future!(DeSeed::new(&vm, &mut vm.current_context())
             .deserialize(self.0)
             .map_err(|err| err.to_string()));
         let id = compiler.symbols.symbol(format!("@{}", name));

--- a/src/compiler_pipeline.rs
+++ b/src/compiler_pipeline.rs
@@ -916,7 +916,7 @@ where
             id,
             typ,
             mem::replace(Arc::make_mut(&mut metadata), Default::default()),
-            value,
+            &value,
         ));
         info!("Loaded module `{}`", name);
         Box::new(future::ok(()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 #[cfg(test)]
 extern crate env_logger;
 
-#[macro_use]
-extern crate collect_mac;
 pub extern crate either;
 #[macro_use]
 extern crate log;

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -1,4 +1,3 @@
-
 use crate::real_std::{
     fmt, fs,
     path::Path,
@@ -6,17 +5,17 @@ use crate::real_std::{
 };
 
 use {
-    
-collect_mac::collect,
-futures::{
-    future::{self, Either},
-    Async, Future, Stream,
-}
-    http::StatusCode, hyper::service::Service, hyper::Chunk, hyper::Server};
-
-
-
-use self::http::header::{HeaderMap, HeaderName, HeaderValue};
+    collect_mac::collect,
+    futures::{
+        future::{self, Either},
+        Async, Future, Stream,
+    },
+    http::{
+        header::{HeaderMap, HeaderName, HeaderValue},
+        StatusCode,
+    },
+    hyper::{service::Service, Chunk, Server},
+};
 
 use crate::base::types::{ArcType, Type};
 

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -1,8 +1,3 @@
-extern crate http;
-extern crate hyper;
-extern crate native_tls;
-extern crate tokio_tcp;
-extern crate tokio_tls;
 
 use crate::real_std::{
     fmt, fs,
@@ -10,12 +5,16 @@ use crate::real_std::{
     sync::{Arc, Mutex},
 };
 
-use self::{http::StatusCode, hyper::service::Service, hyper::Chunk, hyper::Server};
-
-use futures::{
+use {
+    
+collect_mac::collect,
+futures::{
     future::{self, Either},
     Async, Future, Stream,
-};
+}
+    http::StatusCode, hyper::service::Service, hyper::Chunk, hyper::Server};
+
+
 
 use self::http::header::{HeaderMap, HeaderName, HeaderValue};
 

--- a/src/std_lib/io.rs
+++ b/src/std_lib/io.rs
@@ -348,12 +348,13 @@ pub fn load(vm: &Thread) -> Result<ExternModule> {
         Call(1),     // [f, m_ret]       Call m ()
         PushInt(0),  // [f, m_ret, ()]   Add a dummy argument ()
         TailCall(2), /* [f_ret]          Call f m_ret () */
+        Return,
     ];
 
     type FlatMap = fn(fn(A) -> IO<B>, IO<A>) -> IO<B>;
     type Wrap = fn(A) -> IO<A>;
 
-    let wrap = vec![Pop(1)];
+    let wrap = vec![Pop(1), Return];
 
     // IO functions
     ExternModule::new(

--- a/tests/compile-fail/getable-reference-str.rs
+++ b/tests/compile-fail/getable-reference-str.rs
@@ -1,20 +1,23 @@
+#[macro_use]
+extern crate gluon_vm;
 extern crate gluon;
-use gluon::new_vm;
-use gluon::import::add_extern_module;
-use gluon::vm::ExternModule;
-use gluon::vm::thread::{Status, Thread};
-use gluon::vm::api::primitive_f;
+use gluon::{
+    import::add_extern_module,
+    new_vm,
+    vm::{
+        api::primitive_f,
+        thread::{Status, Thread},
+        ExternModule,
+    },
+};
 
-extern "C" fn dummy(_: &Thread) -> Status {
-    unimplemented!()
-}
 fn f(_: &'static str) {}
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     let vm = new_vm();
     add_extern_module(&vm, "test", |vm| {
-        ExternModule::new(vm, unsafe { primitive_f("f", dummy, f as fn (_)) })
+        ExternModule::new(vm, primitive!(1, f))
         //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
     });
 }

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -1,12 +1,18 @@
+#[macro_use]
+extern crate gluon_vm;
 extern crate gluon;
 extern crate gluon_codegen;
 
-use gluon::import::add_extern_module;
-use gluon::new_vm;
-use gluon::vm::api::{primitive_f, Userdata, VmType};
-use gluon::vm::gc::{Gc, Trace};
-use gluon::vm::thread::{Status, Thread};
-use gluon::vm::ExternModule;
+use gluon::{
+    import::add_extern_module,
+    new_vm,
+    vm::{
+        api::{primitive_f, Userdata, VmType},
+        gc::{Gc, Trace},
+        thread::{Status, Thread},
+        ExternModule,
+    },
+};
 
 #[derive(Debug, gluon_codegen::Trace)]
 struct Test;
@@ -17,16 +23,13 @@ impl VmType for Test {
     type Type = Test;
 }
 
-extern "C" fn dummy(_: &Thread) -> Status {
-    unimplemented!()
-}
 fn f(_: &'static Test) {}
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 fn main() {
     let vm = new_vm();
     add_extern_module(&vm, "test", |vm| {
-        ExternModule::new(vm, unsafe { primitive_f("f", dummy, f as fn (_)) })
+        ExternModule::new(vm, primitive!(1, f))
         //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
     });
 }

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -1,8 +1,9 @@
+#[macro_use]
+extern crate gluon_vm;
 extern crate gluon;
 extern crate gluon_codegen;
 
-use std::fmt;
-use std::sync::Mutex;
+use std::{fmt, sync::Mutex};
 
 use gluon::import::add_extern_module;
 use gluon::new_vm;
@@ -27,10 +28,6 @@ impl<'vm> VmType for Test<'vm> {
     type Type = Test<'static>;
 }
 
-extern "C" fn dummy(_: &Thread) -> Status {
-    unimplemented!()
-}
-
 fn f<'vm>(test: &'vm Test<'vm>, s: &'vm str) {
     *test.0.lock().unwrap() = s;
 }
@@ -39,7 +36,7 @@ fn f<'vm>(test: &'vm Test<'vm>, s: &'vm str) {
 fn main() {
     let vm = new_vm();
     add_extern_module(&vm, "test", |vm| {
-        ExternModule::new(vm, unsafe { primitive_f("f", dummy, f as fn (_, _)) })
+        ExternModule::new(vm, primitive!(2, f))
         //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
     });
 }

--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -52,7 +52,7 @@ fn roundtrip(
 
     let mut de = serde_json::Deserializer::from_str(buffer);
 
-    let deserialize_value = DeSeed::new(thread)
+    let deserialize_value = DeSeed::new(thread, &mut thread.current_context())
         .deserialize(&mut de)
         .unwrap_or_else(|err| panic!("{}\n{}", err, buffer));
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -236,7 +236,7 @@ let prelude @ { (==) } = import! std.prelude
 false
 }
 
-test_expr! { partial_application,
+test_expr! { partial_application1,
 r"
 let f x y = x #Int+ y in
 let g = f 10
@@ -934,7 +934,7 @@ fn deep_clone_partial_application() {
         Symbol::from("@test"),
         Type::hole(),
         Metadata::default(),
-        unsafe { result.unwrap().0.get_value() },
+        result.unwrap().0.get_value(),
     )
     .unwrap();
 

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -78,7 +78,7 @@ fn record() {
         ValueRef::Data(data) => {
             assert_eq!(data.get(0).unwrap(), ValueRef::Int(0));
             assert_eq!(data.get(1).unwrap(), ValueRef::Float(1.0));
-            match data.get(2).unwrap() {
+            match &data.get(2).unwrap() {
                 ValueRef::Data(data) if data.len() == 0 => (),
                 _ => panic!(),
             }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0.0", optional = true }
 serde_state = { version = "0.4.0", optional = true }
 serde_derive = { version = "1.0.0", optional = true }
-serde_derive_state = { version = "0.4.6", optional = true }
+serde_derive_state = { version = "0.4.7", optional = true }
 
 gluon_base = { path = "../base", version = "0.12.0" } # GLUON
 gluon_check = { path = "../check", version = "0.12.0" } # GLUON

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -507,7 +507,7 @@ impl<'de, 't, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de, 't> {
         };
         // If the type is not `Option` we just visit the value itself
         match option_inner_typ {
-            Some(typ) => match self.input.as_ref() {
+            Some(typ) => match &self.input.as_ref() {
                 ValueRef::Data(data) if data.tag() == 0 => visitor.visit_none(),
                 ValueRef::Data(data) if data.tag() == 1 => visitor.visit_some(&mut Deserializer {
                     state: self.state.clone(),
@@ -524,7 +524,7 @@ impl<'de, 't, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de, 't> {
     where
         V: Visitor<'de>,
     {
-        match self.input.as_ref() {
+        match &self.input.as_ref() {
             ValueRef::Data(data) if data.tag() == 0 => visitor.visit_unit(),
             _ => self.deserialize_any(visitor),
         }
@@ -558,7 +558,7 @@ impl<'de, 't, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de, 't> {
         V: Visitor<'de>,
     {
         let typ = resolve::remove_aliases_cow(self.state.env, &mut NullInterner, self.typ);
-        match (self.input.as_ref(), &**typ) {
+        match (&self.input.as_ref(), &**typ) {
             (ValueRef::Array(values), &Type::App(_, ref args)) if args.len() == 1 => visitor
                 .visit_seq(SeqDeserializer::new(
                     self.state.clone(),
@@ -826,7 +826,7 @@ impl<'de, 'a, 't> VariantAccess<'de> for Enum<'a, 'de, 't> {
         T: DeserializeSeed<'de>,
     {
         let typ = resolve::remove_aliases_cow(self.de.state.env, &mut NullInterner, self.de.typ);
-        match (self.de.input.as_ref(), &**typ) {
+        match (&self.de.input.as_ref(), &**typ) {
             (ValueRef::Data(data), &Type::Variant(ref row)) => {
                 match row.row_iter().nth(data.tag() as usize) {
                     Some(field) => seed.deserialize(&mut Deserializer {

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -562,7 +562,7 @@ impl<'de, 't, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de, 't> {
             (ValueRef::Array(values), &Type::App(_, ref args)) if args.len() == 1 => visitor
                 .visit_seq(SeqDeserializer::new(
                     self.state.clone(),
-                    values.iter().map(|variant| (variant, &args[0])),
+                    values.as_ref().iter().map(|variant| (variant, &args[0])),
                 )),
             (ValueRef::Data(data), &Type::Variant(ref row)) => {
                 match row.row_iter().nth(data.tag() as usize) {

--- a/vm/src/api/de.rs
+++ b/vm/src/api/de.rs
@@ -242,7 +242,7 @@ impl<'de, 't> Deserializer<'de, 't> {
     {
         let typ = resolve::remove_aliases_cow(self.state.env, &mut NullInterner, self.typ);
         if expected(&typ) {
-            visit(T::from_value(self.state.thread, self.input))
+            visit(T::from_value(self.state.thread, self.input.clone()))
         } else {
             Err(VmError::Message(format!(
                 "Unable to deserialize `{}`",
@@ -538,7 +538,7 @@ impl<'de, 't, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de, 't> {
             VALUE_TRANSFER.with(|t| {
                 let mut store = t.borrow_mut();
                 assert!(store.is_none());
-                *store = Some(self.state.thread.root_value(self.input));
+                *store = Some(self.state.thread.root_value(self.input.clone()));
             });
             visitor.visit_unit()
         } else {

--- a/vm/src/api/function.rs
+++ b/vm/src/api/function.rs
@@ -332,7 +332,7 @@ where $($args: Getable<'vm, 'vm> + 'vm,)*
 
             let stack = StackFrame::<ExternState>::current(context.stack());
             $(
-                let variants = Variants::with_root(stack[i].clone(), vm);
+                let variants = Variants::with_root(&stack[i], vm);
                 let mut proxy = match $args::to_proxy(vm, variants) {
                     Ok(x) => x,
                     Err(err) => {

--- a/vm/src/api/function.rs
+++ b/vm/src/api/function.rs
@@ -21,15 +21,15 @@ use crate::{Error, Result, Variants};
 pub type GluonFunction = extern "C" fn(&Thread) -> Status;
 
 pub struct Primitive<F> {
-    name: &'static str,
-    function: GluonFunction,
-    _typ: PhantomData<F>,
-}
-
-pub struct RefPrimitive<'vm, F> {
-    name: &'static str,
-    function: extern "C" fn(&'vm Thread) -> Status,
-    _typ: PhantomData<F>,
+    /// Exposed for macros
+    #[doc(hidden)]
+    pub name: &'static str,
+    /// Exposed for macros
+    #[doc(hidden)]
+    pub function: GluonFunction,
+    /// Exposed for macros
+    #[doc(hidden)]
+    pub _typ: PhantomData<F>,
 }
 
 #[inline]
@@ -47,15 +47,15 @@ where
 }
 
 #[inline]
-pub unsafe fn primitive_f<'vm, F>(
+pub fn primitive_f<F>(
     name: &'static str,
-    function: extern "C" fn(&'vm Thread) -> Status,
+    function: extern "C" fn(&Thread) -> Status,
     _: F,
-) -> RefPrimitive<'vm, F>
+) -> Primitive<F>
 where
-    F: VmFunction<'vm> + VmType,
+    for<'vm> F: VmFunction<'vm> + VmType,
 {
-    RefPrimitive {
+    Primitive {
         name: name,
         function: function,
         _typ: PhantomData,
@@ -90,35 +90,6 @@ where
     }
 }
 
-impl<'vm, F: VmType> VmType for RefPrimitive<'vm, F> {
-    type Type = F::Type;
-    fn make_type(vm: &Thread) -> ArcType {
-        F::make_type(vm)
-    }
-}
-
-impl<'vm, F> Pushable<'vm> for RefPrimitive<'vm, F>
-where
-    F: VmFunction<'vm> + FunctionType + VmType + 'vm,
-{
-    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        use std::mem::transmute;
-        let extern_function = unsafe {
-            // The VM guarantess that it only ever calls this function with itself which should
-            // make sure that ignoring the lifetime is safe
-            transmute::<extern "C" fn(&'vm Thread) -> Status, extern "C" fn(&Thread) -> Status>(
-                self.function,
-            )
-        };
-        Primitive {
-            function: extern_function,
-            name: self.name,
-            _typ: self._typ,
-        }
-        .push(context)
-    }
-}
-
 pub struct CPrimitive {
     function: GluonFunction,
     args: VmIndex,
@@ -137,20 +108,10 @@ impl CPrimitive {
 
 impl<'vm> Pushable<'vm> for CPrimitive {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        use std::mem::transmute;
-
-        let function = self.function;
-        let extern_function = unsafe {
-            // The VM guarantess that it only ever calls this function with itself which should
-            // make sure that ignoring the lifetime is safe
-            transmute::<extern "C" fn(&'vm Thread) -> Status, extern "C" fn(&Thread) -> Status>(
-                function,
-            )
-        };
         context.context().push_new_alloc(Move(ExternFunction {
             id: self.id,
             args: self.args,
-            function: extern_function,
+            function: self.function,
         }))?;
         Ok(())
     }

--- a/vm/src/api/json.rs
+++ b/vm/src/api/json.rs
@@ -189,7 +189,7 @@ impl<'de> de::DeserializeState<'de, ActiveThread<'de>> for JsonValue {
                 value.push(context).unwrap_or_else(|err| panic!("{}", err));
                 let thread = context.thread();
                 let value = context.pop();
-                JsonValue(thread.root_value(*value))
+                JsonValue(thread.root_value((*value).clone()))
             }
         }
 

--- a/vm/src/api/mac.rs
+++ b/vm/src/api/mac.rs
@@ -1,29 +1,29 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! primitive_cast {
-    (0, $name:expr) => {
-        $name as fn() -> _
+    (0) => {
+        fn() -> _
     };
-    (1, $name:expr) => {
-        $name as fn(_) -> _
+    (1) => {
+        fn(_) -> _
     };
-    (2, $name:expr) => {
-        $name as fn(_, _) -> _
+    (2) => {
+        fn(_, _) -> _
     };
-    (3, $name:expr) => {
-        $name as fn(_, _, _) -> _
+    (3) => {
+        fn(_, _, _) -> _
     };
-    (4, $name:expr) => {
-        $name as fn(_, _, _, _) -> _
+    (4) => {
+        fn(_, _, _, _) -> _
     };
-    (5, $name:expr) => {
-        $name as fn(_, _, _, _, _) -> _
+    (5) => {
+        fn(_, _, _, _, _) -> _
     };
-    (6, $name:expr) => {
-        $name as fn(_, _, _, _, _, _) -> _
+    (6) => {
+        fn(_, _, _, _, _, _) -> _
     };
-    (7, $name:expr) => {
-        $name as fn(_, _, _, _, _, _, _) -> _
+    (7) => {
+        fn(_, _, _, _, _, _, _) -> _
     };
 }
 
@@ -76,20 +76,36 @@ macro_rules! primitive {
     };
 
     ($arg_count:tt, $name:expr) => {
-        primitive!($arg_count, stringify_inner!($name), $name)
+        primitive!(impl primitive_cast!($arg_count), stringify_inner!($name), $name)
     };
-    ($arg_count:tt, $name:expr, async fn $func:expr) => {
-        primitive!($arg_count, $name, closure_wrapper!($arg_count, $func))
+
+    ($arg_count:tt, $name:expr, async fn $func:expr $(, [$($params: tt)*] [$($where_: tt)*] )?) => {
+        primitive!(
+            impl primitive_cast!($arg_count),
+            $name,
+            closure_wrapper!($arg_count, $func)
+            $(, [$($params)*] [$($where_)*])?
+        )
     };
     ($arg_count:tt, $name:expr, $func:expr) => {
+        $crate::primitive!(impl primitive_cast!($arg_count), $name, $func)
+    };
+
+    (impl $func_type:ty, $name:expr, $func:expr $(, [$($params: tt)*] [$($where_: tt)*] )?) => {
         unsafe {
-            extern "C" fn wrapper(thread: &$crate::thread::Thread) -> $crate::thread::Status {
+            extern "C" fn wrapper$(<$($params)*>)?(thread: &$crate::thread::Thread) -> $crate::thread::Status
+                $(where $($where_)*)?
+            {
                 $crate::api::VmFunction::unpack_and_call(
-                    &primitive_cast!($arg_count, $func),
+                    &($func as $func_type),
                     thread,
                 )
             }
-            $crate::api::primitive_f($name, wrapper, primitive_cast!($arg_count, $func))
+            $crate::api::primitive_f(
+                $name,
+                wrapper $( ::<$($params)*> )?,
+                $func as $func_type,
+            )
         }
     };
 }

--- a/vm/src/api/mac.rs
+++ b/vm/src/api/mac.rs
@@ -95,7 +95,7 @@ macro_rules! primitive {
 
     (impl $func_type:ty, $name:expr, $func:expr $(, [$($params: tt)*] [$($where_: tt)*] )?) => {
         {
-            extern "C" fn wrapper$(<$($params)*>)?(thread: &$crate::thread::Thread) -> $crate::thread::Status
+            extern "C" fn wrapper<'thread $(, $($params)*)?>(thread: &'thread $crate::thread::Thread) -> $crate::thread::Status
                 $(where $($where_)*)?
             {
                 $crate::api::VmFunction::unpack_and_call(

--- a/vm/src/api/mac.rs
+++ b/vm/src/api/mac.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! primitive_cast {
@@ -92,7 +94,7 @@ macro_rules! primitive {
     };
 
     (impl $func_type:ty, $name:expr, $func:expr $(, [$($params: tt)*] [$($where_: tt)*] )?) => {
-        unsafe {
+        {
             extern "C" fn wrapper$(<$($params)*>)?(thread: &$crate::thread::Thread) -> $crate::thread::Status
                 $(where $($where_)*)?
             {
@@ -101,13 +103,19 @@ macro_rules! primitive {
                     thread,
                 )
             }
-            $crate::api::primitive_f(
-                $name,
-                wrapper $( ::<$($params)*> )?,
-                $func as $func_type,
-            )
+
+            $crate::api::Primitive::<$func_type> {
+                name: $name,
+                function: wrapper $( ::<$($params)*> )?,
+                _typ: $crate::api::mac::phantom($func as $func_type),
+            }
         }
     };
+}
+
+#[doc(hidden)]
+pub fn phantom<F>(_: F) -> PhantomData<F> {
+    PhantomData
 }
 
 #[doc(hidden)]

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -244,10 +244,10 @@ impl<'a> Data<'a> {
     }
 
     #[doc(hidden)]
-    pub fn field_names(&self) -> Vec<crate::interner::InternedStr> {
+    pub fn field_names(&self) -> impl Iterator<Item = &crate::interner::InternedStr> {
         match &self.0 {
-            DataInner::Tag(_) => Vec::new(),
-            DataInner::Data(data) => data.field_map().keys().cloned().collect(),
+            DataInner::Tag(_) => itertools::Either::Left(None.into_iter()),
+            DataInner::Data(data) => itertools::Either::Right(data.field_map().keys()),
         }
     }
 }

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -683,7 +683,7 @@ where
                 },
                 |x| Ok(RefProxy::Ref(x)),
             ),
-            _ => ice!("ValueRef is not an Userdata"),
+            x => ice!("ValueRef is not an Userdata: {:?}", x),
         }
     }
     fn from_proxy(_vm: &'vm Thread, proxy: &'value mut Self::Proxy) -> Self {

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -6,7 +6,7 @@ use crate::base::{
 };
 use crate::{
     forget_lifetime,
-    gc::{DataDef, GcRef, Move, Trace},
+    gc::{CloneUnrooted, DataDef, GcRef, Move, Trace},
     thread::{RootedThread, ThreadInternal, VmRoot, VmRootInternal},
     types::{VmIndex, VmInt, VmTag},
     value::{ArrayDef, ArrayRepr, ClosureData, DataStruct, Value, ValueArray, ValueRepr},

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     gc::{DataDef, GcPtr, Move, Trace},
     thread::{RootedThread, ThreadInternal, VmRoot, VmRootInternal},
     types::{VmIndex, VmInt, VmTag},
-    value::{ArrayDef, ArrayRepr, ClosureData, DataStruct, GcStr, Value, ValueArray, ValueRepr},
+    value::{ArrayDef, ArrayRepr, ClosureData, DataStruct, Value, ValueArray, ValueRepr},
     vm::{self, RootedValue, Status, Thread},
     Error, Result, Variants,
 };
@@ -988,7 +988,7 @@ impl<'vm, 's> Pushable<'vm> for &'s String {
 impl<'vm, 's> Pushable<'vm> for &'s str {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
         let mut context = context.context();
-        let s = unsafe { alloc!(context, self)?.map_unrooted(|v| GcStr::from_utf8_unchecked(v)) };
+        let s = alloc!(context, self)?;
         context.stack.push(Variants::from(s));
         Ok(())
     }

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -61,7 +61,7 @@ pub trait AsVariant<'s, 'value>: private::Sealed {
 
 impl<'v, 'value> AsVariant<'v, 'value> for Variants<'value> {
     fn get_variant(&'v self) -> Self {
-        *self
+        self.clone()
     }
     fn get_value(&self) -> &Value {
         Value::from_ref(&self.0)
@@ -70,7 +70,7 @@ impl<'v, 'value> AsVariant<'v, 'value> for Variants<'value> {
 
 impl<'v, 'value> AsVariant<'v, 'value> for &'v Variants<'value> {
     fn get_variant(&'v self) -> Variants<'value> {
-        **self
+        (*self).clone()
     }
     fn get_value(&self) -> &Value {
         Value::from_ref(&self.0)

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -56,15 +56,15 @@ where
 /// self (and as such as its own lifetime already)
 pub trait AsVariant<'s, 'value>: private::Sealed {
     fn get_variant(&'s self) -> Variants<'value>;
-    fn get_value(self) -> Value;
+    fn get_value(&self) -> &Value;
 }
 
 impl<'v, 'value> AsVariant<'v, 'value> for Variants<'value> {
     fn get_variant(&'v self) -> Self {
         *self
     }
-    fn get_value(self) -> Value {
-        Value::from(self.0)
+    fn get_value(&self) -> &Value {
+        Value::from_ref(&self.0)
     }
 }
 
@@ -72,8 +72,8 @@ impl<'v, 'value> AsVariant<'v, 'value> for &'v Variants<'value> {
     fn get_variant(&'v self) -> Variants<'value> {
         **self
     }
-    fn get_value(self) -> Value {
-        Value::from(self.0)
+    fn get_value(&self) -> &Value {
+        Value::from_ref(&self.0)
     }
 }
 impl<'value, T> AsVariant<'value, 'value> for RootedValue<T>
@@ -83,7 +83,7 @@ where
     fn get_variant(&'value self) -> Variants<'value> {
         self.get_variant()
     }
-    fn get_value(self) -> Value {
+    fn get_value(&self) -> &Value {
         RootedValue::get_value(&self)
     }
 }
@@ -319,9 +319,8 @@ where
     T: AsVariant<'s, 'value>,
     V: ?Sized,
 {
-    /// Unsafe as `Value` are not rooted
-    pub unsafe fn get_value(&'s self) -> Value {
-        self.0.get_variant().get_value()
+    pub fn get_value(&'s self) -> &'s Value {
+        self.0.get_value()
     }
 
     pub fn get_variant(&'s self) -> Variants<'value> {

--- a/vm/src/api/record.rs
+++ b/vm/src/api/record.rs
@@ -182,7 +182,7 @@ where
     T: GetableFieldList<'vm, 'value>,
 {
     fn from_value(vm: &'vm Thread, values: &'value [Value]) -> Option<Self> {
-        let head = unsafe { H::from_value(vm, Variants::new(&values[0])) };
+        let head = H::from_value(vm, Variants::new(&values[0]));
         T::from_value(vm, &values[1..]).map(move |tail| h_cons((F::default(), head), tail))
     }
 }

--- a/vm/src/api/ser.rs
+++ b/vm/src/api/ser.rs
@@ -576,22 +576,14 @@ impl<'s, 'a, 'vm> ser::SerializeStructVariant for RecordSerializer<'s, 'a, 'vm> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::thread::RootedThread;
-    use crate::value::Value;
-
-    fn to_value<T>(thread: &Thread, value: &T) -> Result<Value>
-    where
-        T: ?Sized + Serialize,
-    {
-        let mut context = thread.current_context();
-        Ser(value).push(&mut context)?;
-        let variants = context.pop();
-        Ok(variants.get_value())
-    }
+    use crate::{thread::RootedThread, value::Value};
 
     #[test]
     fn bool() {
         let thread = RootedThread::new();
-        assert_eq!(to_value(&thread, &true).unwrap(), Value::tag(1));
+        assert_eq!(
+            true.marshal::<&Thread>(&thread).unwrap().get_value(),
+            &Value::tag(1)
+        );
     }
 }

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -21,7 +21,7 @@ use crate::{
         primitive, Function, FunctionRef, Generic, Getable, OpaqueRef, OpaqueValue, OwnedFunction,
         Pushable, Pushed, RuntimeResult, Unrooted, VmType, WithVM, IO,
     },
-    gc::{self, GcPtr, Trace},
+    gc::{self, CloneUnrooted, GcPtr, Trace},
     stack::{ClosureState, ExternState, State},
     thread::{ActiveThread, ThreadInternal},
     types::VmInt,

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -234,6 +234,7 @@ impl FunctionEnvs {
 
     fn end_function(&mut self, compiler: &mut Compiler, current_line: Option<Line>) -> FunctionEnv {
         compiler.stack_types.exit_scope();
+        self.function.instructions.push(Instruction::Return);
         let instructions = self.function.instructions.len();
 
         if compiler.emit_debug_info {

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -40,7 +40,10 @@ enum FieldAccess {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -59,7 +62,10 @@ pub struct UpvarInfo {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -79,7 +85,10 @@ pub struct DebugInfo {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive_state",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive_state",
@@ -103,7 +112,10 @@ pub struct CompiledModule {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive_state",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive_state",

--- a/vm/src/compiler.rs
+++ b/vm/src/compiler.rs
@@ -1198,6 +1198,7 @@ mod tests {
                 CloseData { index: 1 },
                 Push(1),
                 Slide(2),
+                Return,
             ]],
         )
     }
@@ -1245,9 +1246,10 @@ mod tests {
                     // body
                     Push(1),
                     Slide(2),
+                    Return,
                 ],
-                &[PushUpVar(0)],
-                &[PushUpVar(0)],
+                &[PushUpVar(0), Return],
+                &[PushUpVar(0), Return],
             ],
         )
     }

--- a/vm/src/debug.rs
+++ b/vm/src/debug.rs
@@ -14,11 +14,9 @@ fn show(a: Generic<A>) -> String {
 }
 
 fn tag(a: OpaqueRef<A>) -> Option<String> {
-    unsafe {
-        match a.get_value().get_repr() {
-            ValueRepr::Data(data) => data.poly_tag().map(|s| s.to_string()),
-            _ => None,
-        }
+    match a.get_value().get_repr() {
+        ValueRepr::Data(data) => data.poly_tag().map(|s| s.to_string()),
+        _ => None,
     }
 }
 

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -142,7 +142,10 @@ impl Generation {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -58,7 +58,7 @@ pub struct WriteOnly<'s, T: ?Sized + 's>(*mut T, PhantomData<&'s mut T>);
 
 impl<'s, T: ?Sized> WriteOnly<'s, T> {
     /// Unsafe as the lifetime must not be longer than the liftime of `t`
-    unsafe fn new(t: *mut T) -> WriteOnly<'s, T> {
+    pub unsafe fn new(t: *mut T) -> WriteOnly<'s, T> {
         WriteOnly(t, PhantomData)
     }
 
@@ -563,6 +563,10 @@ impl<T: ?Sized> GcPtr<T> {
             let header = p.offset(-(GcHeader::value_offset() as isize));
             &*(header as *const GcHeader)
         }
+    }
+
+    pub unsafe fn cast<U>(ptr: Self) -> GcPtr<U> {
+        GcPtr(ptr.0.cast())
     }
 }
 

--- a/vm/src/gc.rs
+++ b/vm/src/gc.rs
@@ -728,9 +728,9 @@ macro_rules! impl_trace {
 #[macro_export]
 macro_rules! construct_enum_gc {
     (impl $typ: ident $(:: $variant: ident)? [$($acc: tt)*] [$($ptr: ident)*] @ $expr: expr, $($rest: tt)*) => { {
-        let ptr = $expr;
+        let ref ptr = $expr;
         $crate::construct_enum_gc!(impl $typ $(:: $variant)?
-                      [$($acc)* unsafe { $crate::gc::CloneUnrooted::clone_unrooted(&ptr) },]
+                      [$($acc)* unsafe { $crate::gc::CloneUnrooted::clone_unrooted(ptr) },]
                       [$($ptr)* ptr]
                       $($rest)*
         )
@@ -745,9 +745,9 @@ macro_rules! construct_enum_gc {
     };
 
     (impl $typ: ident $(:: $variant: ident)? [$($acc: tt)*] [$($ptr: ident)*] @ $expr: expr) => { {
-        let ptr = $expr;
+        let ref ptr = $expr;
         $crate::construct_enum_gc!(impl $typ $(:: $variant)?
-                      [$($acc)* unsafe { $crate::gc::CloneUnrooted::clone_unrooted(&ptr) },]
+                      [$($acc)* unsafe { $crate::gc::CloneUnrooted::clone_unrooted(ptr) },]
                       [$($ptr)* ptr]
         )
     } };

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -75,7 +75,10 @@ impl InternedStr {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -112,7 +112,7 @@ impl Interner {
             None => (),
         }
         // SAFETY The interner is scanned
-        let gc_str = unsafe { InternedStr(GcStr::alloc(gc, s)?.unrooted()) };
+        let gc_str = unsafe { InternedStr(gc.alloc(s)?.unrooted()) };
         // The key will live as long as the value it refers to and the static str never escapes
         // outside interner so this is safe
         let key: &'static str = unsafe { ::std::mem::transmute::<&str, &'static str>(&gc_str) };

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -111,7 +111,8 @@ impl Interner {
             Some(interned_str) => return Ok(*interned_str),
             None => (),
         }
-        let gc_str = InternedStr(GcStr::alloc(gc, s)?);
+        // SAFETY The interner is scanned
+        let gc_str = unsafe { InternedStr(GcStr::alloc(gc, s)?.unrooted()) };
         // The key will live as long as the value it refers to and the static str never escapes
         // outside interner so this is safe
         let key: &'static str = unsafe { ::std::mem::transmute::<&str, &'static str>(&gc_str) };

--- a/vm/src/interner.rs
+++ b/vm/src/interner.rs
@@ -16,6 +16,9 @@ use crate::{
 #[derive(Eq)]
 pub struct InternedStr(GcStr);
 
+unsafe impl Send for InternedStr {}
+unsafe impl Sync for InternedStr {}
+
 unsafe impl CopyUnrooted for InternedStr {}
 impl CloneUnrooted for InternedStr {
     type Value = Self;
@@ -62,8 +65,6 @@ impl Hash for InternedStr {
         self.as_ptr().hash(hasher)
     }
 }
-
-unsafe impl Sync for InternedStr {}
 
 impl Deref for InternedStr {
     type Target = str;

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -11,7 +11,7 @@ use crate::{
         generic::A, FunctionRef, Getable, OpaqueValue, Pushable, Pushed, Userdata, VmType, WithVM,
     },
     base::types::{self, ArcType},
-    gc::{GcPtr, GcRef, Move, Trace},
+    gc::{CloneUnrooted, GcPtr, GcRef, Move, Trace},
     thread::{RootedThread, ThreadInternal},
     value::{Cloner, Value},
     vm::Thread,

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -105,11 +105,11 @@ impl<'a> Variants<'a> {
     /// value
     #[inline]
     pub unsafe fn new(value: &Value) -> Variants {
-        Variants::with_root(value.clone(), value)
+        Variants::with_root(value, value)
     }
 
     #[inline]
-    pub(crate) unsafe fn with_root<T: ?Sized>(value: Value, _root: &T) -> Variants {
+    pub(crate) unsafe fn with_root<'r, T: ?Sized>(value: &Value, _root: &'r T) -> Variants<'r> {
         Variants(value.get_repr(), PhantomData)
     }
 
@@ -119,8 +119,8 @@ impl<'a> Variants<'a> {
     }
 
     #[inline]
-    pub fn get_value(&self) -> Value {
-        self.0.into()
+    pub fn get_value(&self) -> &Value {
+        Value::from_ref(&self.0)
     }
 
     /// Returns an instance of `ValueRef` which allows users to safely retrieve the interals of a

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -88,14 +88,15 @@ mod value;
 
 use std::{self as real_std, fmt, marker::PhantomData};
 
-use crate::api::{ValueRef, VmType};
-use crate::base::metadata::Metadata;
-use crate::base::symbol::Symbol;
-use crate::base::types::ArcType;
-use crate::stack::Stacktrace;
-use crate::thread::{RootedThread, RootedValue, Thread};
-use crate::types::{VmIndex, VmInt};
-use crate::value::{Value, ValueRepr};
+use crate::{
+    api::{ValueRef, VmType},
+    gc::CloneUnrooted,
+    stack::Stacktrace,
+    thread::{RootedThread, RootedValue, Thread},
+    types::{VmIndex, VmInt},
+    value::{Value, ValueRepr},
+};
+use crate::{base::metadata::Metadata, base::symbol::Symbol, base::types::ArcType};
 
 unsafe fn forget_lifetime<'a, 'b, T: ?Sized>(x: &'a T) -> &'b T {
     ::std::mem::transmute(x)

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -53,7 +53,7 @@ pub type BoxFuture<'vm, T, E> = Box<dyn futures::Future<Item = T, Error = E> + S
 
 macro_rules! alloc {
     ($context: ident, $data: expr) => {
-        $crate::thread::alloc($context.gc, $context.thread, &$context.stack.stack, $data)
+        $crate::thread::alloc($context.gc, $context.thread, &$context.stack.stack(), $data)
     };
 }
 

--- a/vm/src/reference.rs
+++ b/vm/src/reference.rs
@@ -2,7 +2,7 @@ use crate::real_std::{any::Any, fmt, marker::PhantomData, sync::Mutex};
 
 use crate::{
     api::{generic::A, Generic, RuntimeResult, Unrooted, Userdata, WithVM},
-    gc::{GcPtr, GcRef, Move, Trace},
+    gc::{CloneUnrooted, GcPtr, GcRef, Move, Trace},
     thread::ThreadInternal,
     value::{Cloner, Value},
     vm::Thread,

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -872,7 +872,7 @@ mod tests {
             .deserialize(&mut de)
             .unwrap();
         match value.get_repr() {
-            ValueRepr::String(s) => assert_eq!(&*s, "test"),
+            ValueRepr::String(s) => assert_eq!(&s[..], "test"),
             _ => ice!(),
         }
     }

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -631,7 +631,7 @@ unsafe impl DataDef for PartialApplicationModel {
     type Value = PartialApplicationData;
 
     fn size(&self) -> usize {
-        PartialApplicationDataDef(self.function, &self.args).size()
+        PartialApplicationDataDef::size_of(self.args.len())
     }
 
     fn initialize<'w>(self, result: WriteOnly<'w, Self::Value>) -> &'w mut Self::Value {
@@ -834,16 +834,8 @@ impl<'de> DeserializeState<'de, DeSeed> for RootedValue<RootedThread> {
     where
         D: Deserializer<'de>,
     {
-        eprintln!("before value ");
         let value = Value::deserialize_state(seed, deserializer)?;
-        // TODO Prevent Value from being deserialized directly so we don't need to have this unsafe
-        eprintln!("after value ");
-        unsafe {
-            let x = Ok(seed.thread.root_value(Variants::new(&value)));
-
-            eprintln!("after value 2");
-            x
-        }
+        Ok(seed.thread.root_value(Variants::new(&value)))
     }
 }
 

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -14,35 +14,39 @@ use crate::base::serialization::{NodeMap, NodeToId};
 use crate::base::symbol::{Symbol, Symbols};
 use crate::base::types::ArcType;
 
-use crate::array::Array;
-use crate::gc::{DataDef, GcPtr, GcRef, OwnedGcRef, WriteOnly};
-use crate::thread::{RootedThread, RootedValue, Thread, ThreadInternal};
-use crate::types::VmIndex;
-use crate::value::{
-    BytecodeFunction, Callable, ClosureData, ExternFunction, PartialApplicationData,
-    PartialApplicationDataDef, Value, ValueArray, ValueRepr,
+use crate::{
+    array::Array,
+    gc::{DataDef, GcPtr, GcRef, OwnedGcRef, WriteOnly},
+    stack::State,
+    thread::{ActiveThread, ExecuteContext, RootedThread, RootedValue, Thread, ThreadInternal},
+    types::VmIndex,
+    value::{
+        BytecodeFunction, Callable, ClosureData, ExternFunction, PartialApplicationData,
+        PartialApplicationDataDef, Value, ValueArray, ValueRepr,
+    },
+    Variants,
 };
-use crate::Variants;
 
-#[derive(Clone)]
-pub struct DeSeed {
+pub struct DeSeed<'gc> {
     pub thread: RootedThread,
+    context: ExecuteContext<'gc, 'gc, State>,
     symbols: Rc<RefCell<Symbols>>,
     gc_map: NodeMap,
     base_seed: crate::base::serialization::Seed<Symbol, ArcType<Symbol>>,
 }
 
-impl DeSeed {
-    pub fn new(thread: &Thread) -> DeSeed {
+impl<'de, 'gc> DeSeed<'gc> {
+    pub fn new(thread: &Thread, context: &'gc mut ActiveThread) -> DeSeed<'gc> {
         DeSeed {
             thread: thread.root_thread(),
             symbols: Default::default(),
             gc_map: NodeMap::default(),
             base_seed: Default::default(),
+            context: context.context(),
         }
     }
 
-    pub fn deserialize<'de, D, T>(mut self, deserializer: D) -> Result<T, D::Error>
+    pub fn deserialize<D, T>(mut self, deserializer: D) -> Result<T, D::Error>
     where
         D: Deserializer<'de>,
         T: DeserializeState<'de, Self>,
@@ -51,7 +55,7 @@ impl DeSeed {
     }
 }
 
-impl AsMut<NodeMap> for DeSeed {
+impl AsMut<NodeMap> for DeSeed<'_> {
     fn as_mut(&mut self) -> &mut NodeMap {
         &mut self.gc_map
     }
@@ -75,28 +79,19 @@ impl SeSeed {
     }
 }
 
-pub struct Seed<T> {
-    pub state: DeSeed,
+pub struct Seed<'a, 'gc, T> {
+    pub state: &'a mut DeSeed<'gc>,
     _marker: PhantomData<T>,
 }
 
-impl<T> Clone for Seed<T> {
-    fn clone(&self) -> Seed<T> {
-        Seed {
-            state: self.state.clone(),
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<T> AsMut<NodeMap> for Seed<T> {
+impl<T> AsMut<NodeMap> for Seed<'_, '_, T> {
     fn as_mut(&mut self) -> &mut NodeMap {
         &mut self.state.gc_map
     }
 }
 
-impl<T> From<DeSeed> for Seed<T> {
-    fn from(value: DeSeed) -> Self {
+impl<'a, 'gc, T> From<&'a mut DeSeed<'gc>> for Seed<'a, 'gc, T> {
+    fn from(value: &'a mut DeSeed<'gc>) -> Self {
         Seed {
             state: value,
             _marker: PhantomData,
@@ -113,7 +108,6 @@ pub mod gc {
 
     use crate::{
         interner::InternedStr,
-        thread::ThreadInternal,
         types::VmTag,
         value::{DataStruct, GcStr, ValueArray},
     };
@@ -127,12 +121,12 @@ pub mod gc {
         }
     }
 
-    impl<'de, T> DeserializeState<'de, DeSeed> for crate::gc::Move<T>
+    impl<'de, 'gc, T> DeserializeState<'de, DeSeed<'gc>> for crate::gc::Move<T>
     where
         T: crate::gc::Trace + PostDeserialize,
-        T: DeserializeState<'de, DeSeed>,
+        T: DeserializeState<'de, DeSeed<'gc>>,
     {
-        fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>
+        fn deserialize_state<D>(seed: &mut DeSeed<'gc>, deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
@@ -140,20 +134,17 @@ pub mod gc {
         }
     }
 
-    impl<'de, T> DeserializeState<'de, DeSeed> for GcPtr<T>
+    impl<'de, 'gc, T> DeserializeState<'de, DeSeed<'gc>> for GcPtr<T>
     where
         T: crate::gc::Trace + PostDeserialize + 'static,
-        T: DeserializeState<'de, DeSeed>,
+        T: DeserializeState<'de, DeSeed<'gc>>,
     {
-        fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>
+        fn deserialize_state<D>(seed: &mut DeSeed<'gc>, deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
             use crate::gc::Move;
-            DeserializeSeed::deserialize(
-                Seed::<DataDefSeed<Move<T>>>::from(seed.clone()),
-                deserializer,
-            )
+            DeserializeSeed::deserialize(Seed::<DataDefSeed<Move<T>>>::from(seed), deserializer)
         }
     }
 
@@ -166,27 +157,27 @@ pub mod gc {
         }
     }
 
-    pub fn deserialize_array<'de, D>(
-        seed: &mut DeSeed,
+    pub fn deserialize_array<'de, 'gc, D>(
+        seed: &mut DeSeed<'gc>,
         deserializer: D,
     ) -> Result<GcPtr<ValueArray>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        DeserializeSeed::deserialize(
-            Seed::<DataDefSeed<Vec<Value>>>::from(seed.clone()),
-            deserializer,
-        )
+        DeserializeSeed::deserialize(Seed::<DataDefSeed<Vec<Value>>>::from(seed), deserializer)
     }
 
     #[derive(DeserializeState, SerializeState)]
-    #[serde(deserialize_state = "crate::serialization::DeSeed")]
+    #[serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )]
     #[serde(serialize_state = "crate::serialization::SeSeed")]
     #[serde(bound(
-        deserialize = "F: DeserializeState<'de, crate::serialization::DeSeed>,
+        deserialize = "F: DeserializeState<'de, crate::serialization::DeSeed<'gc>>,
                                  S: std::ops::Deref + std::any::Any + Clone
                                     + crate::base::serialization::Shared
-                                    + DeserializeState<'de, crate::serialization::DeSeed>",
+                                    + DeserializeState<'de, crate::serialization::DeSeed<'gc>>",
         serialize = "F: SerializeState<crate::serialization::SeSeed>,
                                S: std::ops::Deref + std::any::Any + Clone
                                     + crate::base::serialization::Shared,
@@ -200,12 +191,15 @@ pub mod gc {
     }
 
     #[derive(DeserializeState, SerializeState)]
-    #[serde(deserialize_state = "crate::serialization::DeSeed")]
+    #[serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )]
     #[serde(serialize_state = "crate::serialization::SeSeed")]
     #[serde(bound(
         deserialize = "S: std::ops::Deref + std::any::Any + Clone
                                     + crate::base::serialization::Shared
-                                    + DeserializeState<'de, crate::serialization::DeSeed>",
+                                    + DeserializeState<'de, crate::serialization::DeSeed<'gc>>",
         serialize = "S: std::ops::Deref + std::any::Any + Clone
                                     + crate::base::serialization::Shared,
                                S::Target: SerializeState<crate::serialization::SeSeed>"
@@ -234,8 +228,8 @@ pub mod gc {
         }
     }
 
-    pub fn deserialize_data<'de, D>(
-        seed: &mut DeSeed,
+    pub fn deserialize_data<'de, 'gc, D>(
+        seed: &mut DeSeed<'gc>,
         deserializer: D,
     ) -> Result<GcPtr<DataStruct>, D::Error>
     where
@@ -243,18 +237,18 @@ pub mod gc {
     {
         use crate::base::serialization::SharedSeed;
 
-        struct GcSeed<'a> {
-            state: &'a mut DeSeed,
+        struct GcSeed<'a, 'gc> {
+            state: &'a mut DeSeed<'gc>,
         }
-        impl<'a> AsMut<NodeMap> for GcSeed<'a> {
+        impl<'a> AsMut<NodeMap> for GcSeed<'a, '_> {
             fn as_mut(&mut self) -> &mut NodeMap {
                 &mut self.state.gc_map
             }
         }
 
-        impl<'de, 'a> DeserializeState<'de, GcSeed<'a>> for GcPtr<DataStruct> {
+        impl<'de, 'gc, 'a> DeserializeState<'de, GcSeed<'a, 'gc>> for GcPtr<DataStruct> {
             fn deserialize_state<D>(
-                seed: &mut GcSeed<'a>,
+                seed: &mut GcSeed<'a, 'gc>,
                 deserializer: D,
             ) -> Result<Self, D::Error>
             where
@@ -269,8 +263,7 @@ pub mod gc {
                 unsafe {
                     Ok(match def.tag {
                         DataTag::Record(fields) => seed
-                            .thread
-                            .context()
+                            .context
                             .gc
                             .alloc(RecordDef {
                                 elems: &def.fields,
@@ -279,8 +272,7 @@ pub mod gc {
                             .map_err(D::Error::custom)?
                             .unrooted(),
                         DataTag::Data(tag) => seed
-                            .thread
-                            .context()
+                            .context
                             .gc
                             .alloc(Def {
                                 tag: tag,
@@ -298,16 +290,15 @@ pub mod gc {
         DeserializeSeed::deserialize(SharedSeed::new(&mut seed), deserializer)
     }
 
-    impl<'de> DeserializeState<'de, DeSeed> for GcStr {
-        fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>
+    impl<'de, 'gc> DeserializeState<'de, DeSeed<'gc>> for GcStr {
+        fn deserialize_state<D>(seed: &mut DeSeed<'gc>, deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
             // FIXME
             unsafe {
                 Ok(Cow::<str>::deserialize(deserializer).and_then(|s| {
-                    seed.thread
-                        .context()
+                    seed.context
                         .gc
                         .alloc(&s[..])
                         .map(|v| v.unrooted())
@@ -348,7 +339,10 @@ pub mod symbol {
     use crate::serde::ser::{Serialize, Serializer};
     use crate::serde::{Deserialize, Deserializer};
 
-    pub fn deserialize<'de, D>(seed: &mut DeSeed, deserializer: D) -> Result<Symbol, D::Error>
+    pub fn deserialize<'de, 'gc, D>(
+        seed: &mut DeSeed<'gc>,
+        deserializer: D,
+    ) -> Result<Symbol, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -371,8 +365,8 @@ pub mod intern {
     use crate::serde::ser::{Serialize, SerializeState, Serializer};
     use crate::serde::{Deserialize, Deserializer};
 
-    impl<'de> DeserializeState<'de, DeSeed> for InternedStr {
-        fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>
+    impl<'de, 'gc> DeserializeState<'de, DeSeed<'gc>> for InternedStr {
+        fn deserialize_state<D>(seed: &mut DeSeed<'gc>, deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
@@ -427,12 +421,14 @@ pub mod typ {
     use crate::base::symbol::Symbol;
     use crate::base::types::ArcType;
 
-    impl std::borrow::Borrow<crate::base::serialization::Seed<Symbol, ArcType<Symbol>>> for DeSeed {
+    impl std::borrow::Borrow<crate::base::serialization::Seed<Symbol, ArcType<Symbol>>> for DeSeed<'_> {
         fn borrow(&self) -> &crate::base::serialization::Seed<Symbol, ArcType<Symbol>> {
             &self.base_seed
         }
     }
-    impl std::borrow::BorrowMut<crate::base::serialization::Seed<Symbol, ArcType<Symbol>>> for DeSeed {
+    impl std::borrow::BorrowMut<crate::base::serialization::Seed<Symbol, ArcType<Symbol>>>
+        for DeSeed<'_>
+    {
         fn borrow_mut(&mut self) -> &mut crate::base::serialization::Seed<Symbol, ArcType<Symbol>> {
             &mut self.base_seed
         }
@@ -530,8 +526,8 @@ impl SerializeState<SeSeed> for ClosureData {
 pub mod closure {
     use super::*;
 
-    pub fn deserialize<'de, D>(
-        seed: &mut DeSeed,
+    pub fn deserialize<'de, 'gc, D>(
+        seed: &mut DeSeed<'gc>,
         deserializer: D,
     ) -> Result<GcPtr<ClosureData>, D::Error>
     where
@@ -541,21 +537,21 @@ pub mod closure {
 
         use crate::serde::de::{SeqAccess, Visitor};
 
-        impl<'de> DeserializeSeed<'de> for Seed<ClosureData> {
+        impl<'de, 'gc> DeserializeSeed<'de> for Seed<'_, 'gc, ClosureData> {
             type Value = GcPtr<ClosureData>;
 
             fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
             where
                 D: Deserializer<'de>,
             {
-                impl<'de> Visitor<'de> for Seed<ClosureData> {
+                impl<'de, 'gc> Visitor<'de> for Seed<'_, 'gc, ClosureData> {
                     type Value = GcPtr<ClosureData>;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                         formatter.write_str("struct ClosureData")
                     }
 
-                    fn visit_seq<V>(mut self, mut seq: V) -> Result<Self::Value, V::Error>
+                    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
                     where
                         V: SeqAccess<'de>,
                     {
@@ -567,7 +563,7 @@ pub mod closure {
                                 GraphVariant::Marked(id) => {
                                     let function = seq
                                         .next_element_seed(crate::serde::de::Seed::new(
-                                            &mut self.state,
+                                            &mut *self.state,
                                         ))?
                                         .ok_or_else(|| V::Error::invalid_length(1, &self))?;
                                     let upvars = seq
@@ -576,8 +572,7 @@ pub mod closure {
 
                                     let mut closure: GcPtr<ClosureData> = self
                                         .state
-                                        .thread
-                                        .context()
+                                        .context
                                         .gc
                                         .alloc(ClosureDataModel {
                                             function: function,
@@ -590,7 +585,7 @@ pub mod closure {
                                     for i in 0..upvars {
                                         let value = seq
                                             .next_element_seed(crate::serde::de::Seed::new(
-                                                &mut self.state,
+                                                &mut *self.state,
                                             ))?
                                             .ok_or_else(|| {
                                                 V::Error::invalid_length(i + 2, &self)
@@ -616,7 +611,7 @@ pub mod closure {
             }
         }
 
-        DeserializeSeed::deserialize(Seed::<ClosureData>::from(seed.clone()), deserializer)
+        DeserializeSeed::deserialize(Seed::<ClosureData>::from(seed), deserializer)
     }
 
     pub fn serialize<S>(
@@ -632,7 +627,10 @@ pub mod closure {
 }
 
 #[derive(DeserializeState)]
-#[cfg_attr(feature = "serde_derive", serde(deserialize_state = "DeSeed"))]
+#[cfg_attr(
+    feature = "serde_derive",
+    serde(deserialize_state = "DeSeed<'gc>", de_parameters = "'gc")
+)]
 struct PartialApplicationModel {
     #[cfg_attr(feature = "serde_derive", serde(deserialize_state))]
     function: Callable,
@@ -652,15 +650,15 @@ unsafe impl DataDef for PartialApplicationModel {
     }
 }
 
-pub fn deserialize_application<'de, D>(
-    seed: &mut DeSeed,
+pub fn deserialize_application<'de, 'gc, D>(
+    seed: &mut DeSeed<'gc>,
     deserializer: D,
 ) -> Result<GcPtr<PartialApplicationData>, D::Error>
 where
     D: Deserializer<'de>,
 {
     DeserializeSeed::deserialize(
-        Seed::<DataDefSeed<PartialApplicationModel>>::from(seed.clone()),
+        Seed::<DataDefSeed<PartialApplicationModel>>::from(seed),
         deserializer,
     )
 }
@@ -708,11 +706,11 @@ impl PostDeserialize for Thread {
 
 struct DataDefSeed<T>(PhantomData<T>);
 
-impl<'de, T> DeserializeSeed<'de> for crate::serialization::Seed<DataDefSeed<T>>
+impl<'de, 'gc, T> DeserializeSeed<'de> for Seed<'_, 'gc, DataDefSeed<T>>
 where
     T: DataDef + 'static,
     <T as DataDef>::Value: Sized + PostDeserialize,
-    T: DeserializeState<'de, DeSeed>,
+    T: DeserializeState<'de, DeSeed<'gc>>,
 {
     type Value = GcPtr<<T as DataDef>::Value>;
 
@@ -722,29 +720,36 @@ where
     {
         use crate::base::serialization::SharedSeed;
 
-        struct GcSeed<T> {
+        struct GcSeed<'a, 'gc, T> {
             _marker: PhantomData<T>,
-            state: DeSeed,
+            state: &'a mut DeSeed<'gc>,
         }
-        impl<T> AsMut<NodeMap> for GcSeed<T> {
+        impl<T> AsMut<NodeMap> for GcSeed<'_, '_, T> {
             fn as_mut(&mut self) -> &mut NodeMap {
                 &mut self.state.gc_map
             }
         }
 
-        impl<'de, T> DeserializeState<'de, GcSeed<T>> for GcPtr<T::Value>
+        impl<'de, 'gc, T> DeserializeState<'de, GcSeed<'_, 'gc, T>> for GcPtr<T::Value>
         where
             T: DataDef + 'static,
             <T as DataDef>::Value: PostDeserialize + Sized,
-            T: DeserializeState<'de, DeSeed>,
+            T: DeserializeState<'de, DeSeed<'gc>>,
         {
-            fn deserialize_state<D>(seed: &mut GcSeed<T>, deserializer: D) -> Result<Self, D::Error>
+            fn deserialize_state<D>(
+                seed: &mut GcSeed<'_, 'gc, T>,
+                deserializer: D,
+            ) -> Result<Self, D::Error>
             where
                 D: Deserializer<'de>,
             {
                 let def = T::deserialize_state(&mut seed.state, deserializer)?;
-                let mut context = seed.state.thread.context();
-                let ptr = context.gc.alloc_owned(def).map_err(D::Error::custom)?;
+                let ptr = seed
+                    .state
+                    .context
+                    .gc
+                    .alloc_owned(def)
+                    .map_err(D::Error::custom)?;
                 unsafe { Ok(T::Value::init(&seed.state.thread, ptr).unrooted()) }
             }
         }
@@ -758,8 +763,8 @@ where
     }
 }
 
-impl<'de> DeserializeState<'de, DeSeed> for ExternFunction {
-    fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>
+impl<'de, 'gc> DeserializeState<'de, DeSeed<'gc>> for ExternFunction {
+    fn deserialize_state<D>(seed: &mut DeSeed<'gc>, deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -839,8 +844,8 @@ impl<'a> crate::serde::ser::SerializeState<crate::serialization::SeSeed> for Var
     }
 }
 
-impl<'de> DeserializeState<'de, DeSeed> for RootedValue<RootedThread> {
-    fn deserialize_state<D>(seed: &mut DeSeed, deserializer: D) -> Result<Self, D::Error>
+impl<'de, 'gc> DeserializeState<'de, DeSeed<'gc>> for RootedValue<RootedThread> {
+    fn deserialize_state<D>(seed: &mut DeSeed<'gc>, deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -858,7 +863,9 @@ mod tests {
     fn str_value() {
         let thread = RootedThread::new();
         let mut de = serde_json::Deserializer::from_str(r#" { "String": "test" } "#);
-        let value: Value = DeSeed::new(&thread).deserialize(&mut de).unwrap();
+        let value: Value = DeSeed::new(&thread, &mut thread.current_context())
+            .deserialize(&mut de)
+            .unwrap();
         match value.get_repr() {
             ValueRepr::String(s) => assert_eq!(&*s, "test"),
             _ => ice!(),
@@ -882,7 +889,9 @@ mod tests {
             }
         } "#,
         );
-        let value: Value = DeSeed::new(&thread).deserialize(&mut de).unwrap();
+        let value: Value = DeSeed::new(&thread, &mut thread.current_context())
+            .deserialize(&mut de)
+            .unwrap();
         match value.get_repr() {
             ValueRepr::Array(s) => assert_eq!(
                 s.iter().collect::<Vec<_>>(),

--- a/vm/src/serialization.rs
+++ b/vm/src/serialization.rs
@@ -306,7 +306,10 @@ pub mod gc {
             // FIXME
             unsafe {
                 Ok(Cow::<str>::deserialize(deserializer).and_then(|s| {
-                    GcStr::alloc(&mut seed.thread.context().gc, &s)
+                    seed.thread
+                        .context()
+                        .gc
+                        .alloc(&s[..])
                         .map(|v| v.unrooted())
                         .map_err(D::Error::custom)
                 })?)

--- a/vm/src/source_map.rs
+++ b/vm/src/source_map.rs
@@ -59,7 +59,10 @@ impl SourceMap {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -85,7 +88,10 @@ pub struct Local {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -96,7 +96,10 @@ impl StackPrimitive for Value {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -123,7 +126,10 @@ pub(crate) enum ExternCallState {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -193,7 +199,10 @@ impl StackState for ExternState {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -209,12 +218,15 @@ pub enum State {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
     serde(bound(
-        deserialize = "S: ::serde::de::DeserializeState<'de, crate::serialization::DeSeed>"
+        deserialize = "S: ::serde::de::DeserializeState<'de, crate::serialization::DeSeed<'gc>>"
     ))
 )]
 #[cfg_attr(
@@ -268,7 +280,10 @@ pub struct Lock(VmIndex);
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -169,7 +169,7 @@ impl StackState for ClosureState {
     fn from_state(state: State) -> Self {
         match state {
             State::Closure(state) => state,
-            _ => ice!("Expected closure: {:?}", state),
+            _ => ice!("Expected closure state, got {:?}", state),
         }
     }
     fn to_state(self) -> State {

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -592,7 +592,7 @@ pub struct StackFrame<'b, S = State>
 where
     S: StackState,
 {
-    pub stack: &'b mut Stack,
+    stack: &'b mut Stack,
     // Offset is needed for indexing which is frequent enough to warrant explicit caching. It
     // should never change as well while mutating a frame
     offset: VmIndex,
@@ -651,6 +651,10 @@ where
 {
     fn offset(&self) -> VmIndex {
         self.offset
+    }
+
+    pub(crate) fn stack(&self) -> &Stack {
+        &self.stack
     }
 
     pub fn frame(&self) -> FrameView<S> {

--- a/vm/src/stack.rs
+++ b/vm/src/stack.rs
@@ -314,14 +314,21 @@ where
     }
 }
 
-impl Frame<ClosureState> {
-    pub fn upvars(&self) -> &[Value] {
-        &self.state.closure.upvars
+impl<S> Frame<S> {
+    fn to_state(&self) -> gc::Borrow<Frame<State>>
+    where
+        S: StackState,
+    {
+        construct_gc!(Frame {
+            offset: self.offset,
+            @state: self.state.to_state(),
+            excess: self.excess,
+        })
     }
 }
 
-impl<'a> FrameView<'a, ClosureState> {
-    pub fn upvars(&self) -> &'a [Value] {
+impl Frame<ClosureState> {
+    pub fn upvars(&self) -> &[Value] {
         &self.state.closure.upvars
     }
 }
@@ -340,17 +347,42 @@ impl Frame<State> {
 }
 
 #[derive(Debug)]
-pub struct FrameView<'a, S> {
-    pub offset: VmIndex,
-    pub state: &'a S,
-    pub excess: bool,
+pub struct FrameViewMut<'a, S>
+where
+    S: StackState,
+{
+    frame: &'a mut Frame<S>,
+    stack: &'a mut Stack,
 }
 
-#[derive(Debug)]
-pub struct FrameViewMut<'a, S> {
-    pub offset: &'a mut VmIndex,
-    pub state: &'a mut S,
-    pub excess: &'a mut bool,
+impl<S> Deref for FrameViewMut<'_, S>
+where
+    S: StackState,
+{
+    type Target = Frame<S>;
+    fn deref(&self) -> &Self::Target {
+        self.frame
+    }
+}
+
+impl<S> DerefMut for FrameViewMut<'_, S>
+where
+    S: StackState,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.frame
+    }
+}
+
+impl<S> Drop for FrameViewMut<'_, S>
+where
+    S: StackState,
+{
+    fn drop(&mut self) {
+        unsafe {
+            *self.stack.frames.last_mut().unwrap() = self.frame.to_state().unrooted();
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -392,21 +424,18 @@ impl Stack {
     }
 
     fn assert_pop(&self, count: VmIndex) {
-        if let Some(frame) = self.frames.last() {
-            assert!(
-                self.len() >= frame.offset + count,
-                "Attempted to pop value which did not belong to the current frame"
-            );
-            if let State::Extern(ExternState {
-                locked: Some(args), ..
-            }) = *frame.state.to_state()
-            {
-                assert!(
-                    self.len() >= frame.offset + args + count,
-                    "Attempt to pop locked value"
-                );
-            }
-        }
+        let args = if let State::Extern(ExternState {
+            locked: Some(args), ..
+        }) = self.frames.last().unwrap().state
+        {
+            args
+        } else {
+            0
+        };
+        assert!(
+            self.len() >= count + args,
+            "Attempted to pop value which did not belong to the current frame"
+        );
     }
 
     pub fn pop(&mut self) -> Value {
@@ -429,6 +458,8 @@ impl Stack {
     }
 
     pub fn clear(&mut self) {
+        let count = self.values.len();
+        self.assert_pop(count);
         self.values.clear();
     }
 
@@ -493,8 +524,7 @@ impl Stack {
     {
         let frame: &Frame<S> = &*self.get_frames().last().expect("Frame").from_state();
         StackFrame {
-            _frame: PhantomData,
-            offset: frame.offset,
+            frame: unsafe { frame.clone_unrooted() },
             stack: self,
         }
     }
@@ -593,10 +623,7 @@ where
     S: StackState,
 {
     stack: &'b mut Stack,
-    // Offset is needed for indexing which is frequent enough to warrant explicit caching. It
-    // should never change as well while mutating a frame
-    offset: VmIndex,
-    _frame: PhantomData<Frame<S>>,
+    frame: Frame<S>,
 }
 
 impl<'b, S> fmt::Debug for StackFrame<'b, S>
@@ -616,21 +643,16 @@ impl<'a: 'b, 'b> StackFrame<'b, State> {
     where
         T: StackState,
     {
-        let frame = Frame::from_state::<T>(self.stack.frames.last().unwrap());
+        let frame = unsafe { Frame::from_state::<T>(self.stack.frames.last().unwrap()).unrooted() };
         StackFrame {
-            offset: frame.offset,
             stack: self.stack,
-            _frame: PhantomData,
+            frame,
         }
     }
 
     pub fn new_frame(stack: &'b mut Stack, args: VmIndex, state: State) -> StackFrame<'b> {
-        let frame = Self::add_new_frame(stack, args, gc::Borrow::new(&state));
-        StackFrame {
-            stack,
-            offset: frame.offset,
-            _frame: PhantomData,
-        }
+        let frame = unsafe { Self::add_new_frame(stack, args, gc::Borrow::new(&state)).unrooted() };
+        StackFrame { stack, frame }
     }
 }
 
@@ -638,9 +660,9 @@ impl<'a: 'b, 'b> StackFrame<'b, ExternState> {
     /// Lock the stack below the current offset
     pub fn into_lock(mut self) -> Lock {
         let len = self.len();
-        let frame = self.frame_mut();
+        let mut frame = self.frame_mut();
         frame.state.locked = Some(len);
-        let lock = Lock(*frame.offset);
+        let lock = Lock(frame.offset);
         lock
     }
 }
@@ -650,36 +672,21 @@ where
     S: StackState,
 {
     fn offset(&self) -> VmIndex {
-        self.offset
+        self.frame.offset
     }
 
     pub(crate) fn stack(&self) -> &Stack {
         &self.stack
     }
 
-    pub fn frame(&self) -> FrameView<S> {
-        let Frame {
-            offset,
-            ref state,
-            excess,
-        } = *self.stack.frames.last().unwrap();
-        FrameView {
-            offset,
-            state: S::from_state(state),
-            excess,
-        }
+    pub fn frame(&self) -> &Frame<S> {
+        &self.frame
     }
 
     pub fn frame_mut(&mut self) -> FrameViewMut<S> {
-        let Frame {
-            offset,
-            state,
-            excess,
-        } = self.stack.frames.last_mut().unwrap();
         FrameViewMut {
-            offset,
-            state: S::from_state_mut(state),
-            excess,
+            frame: &mut self.frame,
+            stack: self.stack,
         }
     }
 
@@ -699,16 +706,38 @@ where
         self.stack.values.last().expect("StackFrame: top")
     }
 
+    fn assert_pop(&self, count: VmIndex) {
+        let args = if let State::Extern(ExternState {
+            locked: Some(args), ..
+        }) = *self.frame().state.to_state()
+        {
+            args
+        } else {
+            0
+        };
+        assert!(
+            self.len() >= count + args,
+            "Attempted to pop value which did not belong to the current frame"
+        );
+    }
+
     pub fn pop(&mut self) -> Value {
-        self.stack.pop()
+        self.assert_pop(1);
+        self.stack.values.pop()
     }
 
     pub fn pop_value<'s>(&'s mut self) -> PopValue<'s> {
-        self.stack.pop_value()
+        self.assert_pop(1);
+        unsafe {
+            let value = self.stack.last().unwrap().get_repr().clone_unrooted();
+            PopValue(self, Variants(value, PhantomData))
+        }
     }
 
     pub fn pop_many(&mut self, count: VmIndex) {
-        self.stack.pop_many(count);
+        self.assert_pop(count);
+        let len = self.stack.values.len();
+        self.stack.values.truncate(len - count as usize);
     }
 
     pub fn clear(&mut self) {
@@ -765,19 +794,19 @@ where
         T: StackState,
     {
         let stack = self.stack;
-        let frame = Self::add_new_frame(stack, args, T::to_state(state));
-        StackFrame {
-            stack,
-            offset: frame.offset,
-            _frame: PhantomData,
-        }
+        let frame = unsafe {
+            Self::add_new_frame(stack, args, T::to_state(state))
+                .from_state::<T>()
+                .clone_unrooted()
+        };
+        StackFrame { stack, frame }
     }
 
     pub(crate) fn exit_scope(self) -> Result<StackFrame<'b, State>, &'b mut Stack>
     where
         S: StackState,
     {
-        if let State::Extern(ref ext) = *S::to_state(self.frame().state) {
+        if let State::Extern(ref ext) = *S::to_state(&self.frame().state) {
             if ext.is_locked() {
                 return Err(self.stack);
             }
@@ -787,9 +816,8 @@ where
         match stack.frames.last() {
             Some(frame) => {
                 let stack = StackFrame {
-                    offset: frame.offset,
+                    frame: unsafe { frame.clone_unrooted() },
                     stack,
-                    _frame: PhantomData,
                 };
                 debug!(
                     "<---- Restore {} {:?}",
@@ -848,6 +876,25 @@ where
 impl<'b> StackFrame<'b, ClosureState> {
     pub fn get_upvar(&self, index: VmIndex) -> Variants {
         Variants::new(&self.frame().upvars()[index as usize])
+    }
+
+    pub fn set_excess(&mut self, excess: bool) {
+        self.frame.excess = excess;
+        match self.stack.frames.last_mut() {
+            Some(frame) => frame.excess = excess,
+            _ => (),
+        }
+    }
+
+    pub fn set_instruction_index(&mut self, instruction_index: usize) {
+        self.frame.state.instruction_index = instruction_index;
+        match self.stack.frames.last_mut() {
+            Some(Frame {
+                state: State::Closure(closure),
+                ..
+            }) => closure.instruction_index = instruction_index,
+            _ => (),
+        }
     }
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1727,7 +1727,7 @@ impl<'b> OwnedContext<'b> {
                 return Err(Error::Interrupted);
             }
             trace!("STACK\n{:?}", context.stack.stack().get_frames());
-            let state = context.stack.frame().state;
+            let state = &context.stack.frame().state;
 
             if context.hook.flags.contains(HookFlags::CALL_FLAG) {
                 match state {
@@ -2086,7 +2086,7 @@ impl<'b, 'gc> ExecuteContext<'b, 'gc> {
             };
         }
 
-        let state = self.stack.frame().state;
+        let state = &self.stack.frame().state;
         let mut instruction_index = state.instruction_index;
         let function = unsafe { state.closure.function.clone_unrooted() };
         {
@@ -2134,7 +2134,7 @@ impl<'b, 'gc> ExecuteContext<'b, 'gc> {
                     self.stack.push(Float(f));
                 }
                 Call(args) => {
-                    self.stack.frame_mut().state.instruction_index = instruction_index + 1;
+                    self.stack.set_instruction_index(instruction_index + 1);
                     return self.do_call(args).map(|x| Async::Ready(Some(x)));
                 }
                 TailCall(mut args) => {
@@ -2612,7 +2612,7 @@ where
                         instruction_index: 0,
                     }),
                 );
-                *next.stack.frame_mut().excess = excess;
+                next.stack.set_excess(excess);
                 Ok(())
             }
             Callable::Extern(ext) => {

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -2309,7 +2309,7 @@ impl<'b, 'gc> ExecuteContext<'b, 'gc> {
                     let field = function.strings[i as usize];
                     match self.stack.pop().get_repr() {
                         Data(data) => {
-                            let v = data.get_field(field).unwrap_or_else(|| {
+                            let v = GcRef::new(data).get_field(field).unwrap_or_else(|| {
                                 error!("{}", self.stack.stack.stacktrace(0));
                                 ice!("Field `{}` does not exist", field)
                             });

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -424,7 +424,10 @@ impl<'b> Roots<'b> {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -533,16 +536,21 @@ impl std::panic::RefUnwindSafe for RootedThread {}
 impl std::panic::UnwindSafe for RootedThread {}
 
 #[cfg(feature = "serde_derive")]
-impl<'de> serde::de::DeserializeState<'de, crate::serialization::DeSeed> for RootedThread {
+impl<'de, 'gc> serde::de::DeserializeState<'de, crate::serialization::DeSeed<'gc>>
+    for RootedThread
+{
     fn deserialize_state<D>(
-        seed: &mut crate::serialization::DeSeed,
+        seed: &mut crate::serialization::DeSeed<'gc>,
         deserializer: D,
     ) -> StdResult<Self, <D as serde::Deserializer<'de>>::Error>
     where
         D: serde::Deserializer<'de>,
     {
         #[derive(DeserializeState)]
-        #[serde(deserialize_state = "crate::serialization::DeSeed")]
+        #[serde(
+            deserialize_state = "crate::serialization::DeSeed<'gc>",
+            de_parameters = "'gc"
+        )]
         pub struct RootedThreadProxy {
             #[serde(state)]
             thread: GcPtr<Thread>,
@@ -1461,7 +1469,10 @@ struct PollFn {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -208,7 +208,7 @@ where
     T: VmRootInternal,
 {
     fn drop(&mut self) {
-        if *self.rooted.get_mut() {
+        if self.rooted.load() {
             self.unroot_();
         }
     }
@@ -592,7 +592,7 @@ impl Drop for Thread {
 
 impl Drop for RootedThread {
     fn drop(&mut self) {
-        if *self.rooted.get_mut() {
+        if self.rooted.load() {
             let is_empty = self.unroot_();
             if is_empty {
                 // The last RootedThread was dropped, there is no way to refer to the global state any

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -97,7 +97,6 @@ where
             let value = context.stack.pop_value();
             self.thread.clone().unwrap().root_value_with_self(*value)
         };
-        self.thread.take();
 
         Ok(Async::Ready(value))
     }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -139,6 +139,8 @@ pub enum Instruction {
     DivideFloat,
     FloatLT,
     FloatEQ,
+
+    Return,
 }
 
 impl Instruction {
@@ -171,6 +173,7 @@ impl Instruction {
             AddInt | SubtractInt | MultiplyInt | DivideInt | IntLT | IntEQ | AddFloat | AddByte
             | SubtractByte | MultiplyByte | DivideByte | ByteLT | ByteEQ | SubtractFloat
             | MultiplyFloat | DivideFloat | FloatLT | FloatEQ => -1,
+            Return => 0,
         }
     }
 }

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -179,7 +179,10 @@ impl Instruction {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -121,7 +121,10 @@ unsafe impl DataDef for ClosureInitDef {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -374,7 +377,10 @@ pub use self::gc_str::GcStr;
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -437,7 +443,10 @@ pub(crate) enum ValueRepr {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -861,7 +870,10 @@ impl<'a, 't> InternalPrinter<'a, 't> {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",

--- a/vm/src/value.rs
+++ b/vm/src/value.rs
@@ -183,16 +183,16 @@ impl DataStruct {
     }
 }
 
-impl GcPtr<DataStruct> {
-    pub(crate) fn get(&self, vm: &Thread, field: &str) -> Result<Option<Variants>> {
+impl<'gc> GcRef<'gc, DataStruct> {
+    pub(crate) fn get(&self, vm: &Thread, field: &str) -> Result<Option<Variants<'gc>>> {
         let field = vm.global_env().intern(field)?;
         Ok(self.get_field(field))
     }
 
-    pub(crate) fn get_field(&self, field: InternedStr) -> Option<Variants> {
+    pub(crate) fn get_field(&self, field: InternedStr) -> Option<Variants<'gc>> {
         self.field_map()
             .get(&field)
-            .map(|offset| Variants::new(&self.fields[*offset as usize]))
+            .map(|offset| Variants::new(&self.as_ref().fields[*offset as usize]))
     }
 }
 

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -354,14 +354,11 @@ impl VmEnv {
 
         if remaining_fields.as_str().is_empty() {
             // No fields left
-            return Ok((
-                unsafe { Variants::new(&global.value) },
-                Cow::Borrowed(&global.typ),
-            ));
+            return Ok((Variants::new(&global.value), Cow::Borrowed(&global.typ)));
         }
 
         let mut typ = Cow::Borrowed(&global.typ);
-        let mut value = unsafe { Variants::new(&global.value) };
+        let mut value = Variants::new(&global.value);
 
         for mut field_name in remaining_fields.components() {
             if field_name.starts_with('(') && field_name.ends_with(')') {

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -23,7 +23,7 @@ use crate::base::{
 use crate::{
     api::{ValueRef, IO},
     compiler::{CompiledFunction, CompiledModule, CompilerEnv, Variable},
-    gc::{Gc, GcPtr, GcRef, Generation, Move, Trace},
+    gc::{CloneUnrooted, Gc, GcPtr, GcRef, Generation, Move, Trace},
     interner::{InternedStr, Interner},
     lazy::Lazy,
     macros::MacroEnv,

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -62,10 +62,9 @@ fn new_bytecode(
 
     let globals = module_globals
         .into_iter()
-        .map(|index| env.globals[index.definition_name()].value.clone())
-        .collect::<Vec<_>>();
+        .map(|index| &env.globals[index.definition_name()].value);
 
-    gc.alloc(ClosureDataDef(bytecode_function, &globals))
+    gc.alloc(ClosureDataDef(bytecode_function, globals))
 }
 
 fn new_bytecode_function(

--- a/vm/src/vm.rs
+++ b/vm/src/vm.rs
@@ -123,7 +123,10 @@ fn new_bytecode_function<'gc>(
 )]
 #[cfg_attr(
     feature = "serde_derive_state",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive_state",
@@ -154,7 +157,10 @@ unsafe impl Trace for Global {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",
@@ -213,7 +219,10 @@ unsafe impl Trace for GlobalVmState {
 #[cfg_attr(feature = "serde_derive", derive(DeserializeState, SerializeState))]
 #[cfg_attr(
     feature = "serde_derive",
-    serde(deserialize_state = "crate::serialization::DeSeed")
+    serde(
+        deserialize_state = "crate::serialization::DeSeed<'gc>",
+        de_parameters = "'gc"
+    )
 )]
 #[cfg_attr(
     feature = "serde_derive",


### PR DESCRIPTION
Changes `GcPtr` (and types which contain it) to no longer be clonable safely since that introduces an unrooted value which aren't scanned during garbage collection. Allocating such a pointer also gets tied with a lifetime to the garbage collector to prevent collection from being run until the pointer is stored in the root set.