### PR TITLE
feat(repl): add a --no-std option to the standalone interpreter / REPL

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -171,6 +171,7 @@ impl<I> Import<I> {
 
     fn get_unloaded_module(
         &self,
+        compiler: &mut Compiler,
         vm: &Thread,
         module: &str,
         filename: &str,
@@ -180,10 +181,11 @@ impl<I> Import<I> {
         // Retrieve the source, first looking in the standard library included in the
         // binary
 
-        let std_file = STD_LIBS.iter().find(|tup| tup.0 == module);
-        if let Some(tup) = std_file {
-            return Ok(UnloadedModule::Source(Cow::Borrowed(tup.1)));
-        }
+        let std_file = if compiler.settings.use_standard_lib {
+            STD_LIBS.iter().find(|tup| tup.0 == module)
+        } else {
+            None
+        };
         Ok(match std_file {
             Some(tup) => UnloadedModule::Source(Cow::Borrowed(tup.1)),
             None => {
@@ -309,7 +311,7 @@ impl<I> Import<I> {
         // Retrieve the source, first looking in the standard library included in the
         // binary
         let unloaded_module = self
-            .get_unloaded_module(vm, &modulename, &filename)
+            .get_unloaded_module(compiler, vm, &modulename, &filename)
             .map_err(|err| (None, err.into()))?;
 
         match unloaded_module {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,7 @@ struct Settings {
     emit_debug_info: bool,
     run_io: bool,
     full_metadata: bool,
+    use_standard_lib: bool,
 }
 
 impl Default for Settings {
@@ -265,6 +266,7 @@ impl Default for Settings {
             emit_debug_info: true,
             run_io: false,
             full_metadata: false,
+            use_standard_lib: true,
         }
     }
 }
@@ -343,6 +345,12 @@ impl Compiler {
         /// Sets whether full metadata is required
         /// (default: false)
         full_metadata set_full_metadata: bool
+    }
+
+    option_settings! {
+        /// Sets whether internal standard library is searched for requested modules
+        /// (default: true)
+        use_standard_lib set_use_standard_lib: bool
     }
 
     fn state(&self) -> MutexGuard<State> {


### PR DESCRIPTION
## Description
Adds a command-line switch `--no-std` to the standalone interpreter / REPL which causes it to ignore its internal standard library modules when searching for modules to import.

This should make less awkward to use the REPL to test changes to the standard library.

resolves #751 