### PR TITLE
fix(repl): make the REPL respect --no-std

### DIFF
--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -264,7 +264,10 @@ fn run(
                 let mut runtime = Runtime::new()?;
                 let prompt = opt.prompt.clone();
                 let debug_level = opt.debug_level.clone();
-                runtime.block_on(future::lazy(move || repl::run(color, &prompt, debug_level)))?;
+                let use_std_lib = !opt.no_std;
+                runtime.block_on(
+                    future::lazy(move || repl::run(color, &prompt, debug_level, use_std_lib))
+                )?;
             } else if !opt.input.is_empty() {
                 run_files(compiler, &vm, &opt.input)?;
             } else {

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -630,11 +630,12 @@ pub fn run(
     color: Color,
     prompt: &str,
     debug_level: DebugLevel,
+    use_std_lib: bool,
 ) -> impl Future<Item = (), Error = Box<dyn StdError + Send + Sync + 'static>> {
     let vm = ::gluon::VmBuilder::new().build();
     vm.global_env().set_debug_level(debug_level);
 
-    let mut compiler = Compiler::new();
+    let mut compiler = Compiler::new().use_standard_lib(use_std_lib);
     try_future!(
         compile_repl(&mut compiler, &vm)
             .map_err(|err| err.emit_string(&compiler.code_map()).unwrap()),


### PR DESCRIPTION
I forgot to handle the REPL case when adding `--no-std` to the interpreter/REPL. This PR rectifies that oversight.