### PR TITLE
fix: Make the behaviour consistent for `Show Char`

### DIFF
--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -634,7 +634,9 @@ pub fn run(
 ) -> impl Future<Item = (), Error = gluon::Error> {
     let vm = ::gluon::VmBuilder::new().build();
     vm.global_env().set_debug_level(debug_level);
-    vm.get_database_mut().use_standard_lib(use_std_lib);
+    vm.get_database_mut()
+        .use_standard_lib(use_std_lib)
+        .run_io(true);
 
     try_future!(
         compile_repl(&vm).map_err(|err| err.emit_string(&vm.get_database().code_map()).unwrap()),


### PR DESCRIPTION
Now it prints a debug represnetation just like all the other `Show`
implementations. `string.from_char` and `string.append_char` are added
as replacements for turning a char to a readable string.

Fixes #784