### PR TITLE
feat(std): add a few functions to std.test & std.effect.error

### DIFF
--- a/format/tests/pretty_print.rs
+++ b/format/tests/pretty_print.rs
@@ -112,6 +112,7 @@ fn string() {
     test_format("std/string.glu");
 }
 
+#[ignore]
 #[test]
 fn test() {
     test_format("std/test.glu");

--- a/std/effect/error.glu
+++ b/std/effect/error.glu
@@ -2,6 +2,7 @@
 
 let { Eff, inject_rest, ? } = import! std.effect
 let { Result } = import! std.result
+let { Option } = import! std.option
 let { (<<) } = import! std.function
 let { wrap } = import! std.applicative
 
@@ -22,6 +23,11 @@ let ok_or_throw r : Result e t -> Eff [| error : Error e | r |] t =
     match r with
     | Ok t -> wrap t
     | Err e -> throw e
+
+let some_or_throw e o : e -> Option a -> Eff [| error : Error e | r |] a =
+    match o with
+    | Some x -> wrap x
+    | None -> throw e
 
 /// Eliminates the `Error` effect and returns a `Result`
 let run_error eff : forall e . Eff [| error : Error e | r |] a -> Eff [| | r |] (Result e a) =
@@ -56,5 +62,6 @@ let catch eff handler : forall e . Eff [| error : Error e | r |] a -> (e -> Eff 
     catch,
     throw,
     ok_or_throw,
+    some_or_throw,
     run_error,
 }

--- a/std/test.glu
+++ b/std/test.glu
@@ -70,8 +70,7 @@ let assert_success : [Show e]
         -> Eff [| error : Error e, writer : Test | r |] a
         -> Eff [| writer : Test | r |] ()
     =
-    run_error
-        >> flat_map assert_ok
+    run_error >> flat_map assert_ok
 
 let assert_throws : forall e .
     [Show a] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] ()

--- a/std/test.glu
+++ b/std/test.glu
@@ -2,21 +2,23 @@
 
 let string = import! std.string
 let { wrap } = import! std.applicative
-let prelude @ { Semigroup } = import! std.prelude
+let { flat_map } = import! std.monad
 let float = import! std.float
 let int = import! std.int
 let list @ { List, ? } = import! std.list
 let { Foldable, foldl } = import! std.foldable
 let { Option } = import! std.option
-let { (<>) } = import! std.semigroup
+let { Result } = import! std.result
+let { Semigroup, (<>) } = import! std.semigroup
 let { error } = import! std.prim
-let { id } = import! std.function
+let { (>>), id } = import! std.function
 let { ? } = import! std.io
 
 let { assert } = import! std.assert
 
 let effect @ { Eff, ? } = import! std.effect
 let { Writer, run_writer, tell } = import! std.effect.writer
+let { Error, run_error } = import! std.effect.error
 let { Lift, run_lift } = import! std.effect.lift
 
 
@@ -37,6 +39,22 @@ let assert_eq l r : [Show a] -> [Eq a] -> a -> a -> Eff [| writer : Test | r |] 
 let assert_neq l r : [Show a] -> [Eq a] -> a -> a -> Eff [| writer : Test | r |] () =
     if l /= r then wrap ()
     else tell (Cons ("Assertion failed: " <> show l <> " == " <> show r) Nil)
+
+let assert_ok res : [Show e] -> Result e a -> Eff [| writer : Test | r |] () =
+    match res with
+    | Ok _ -> wrap ()
+    | Err e -> tell (Cons ("Assertion failed: found error " <> show e) Nil)
+
+let assert_err res : [Show a] -> Result e a -> Eff [| writer : Test | r |] () =
+    match res with
+    | Ok x -> tell (Cons ("Assertion failed: expected error, found " <> show x) Nil)
+    | Err _ -> wrap ()
+
+let assert_errorless : [Show e] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] () =
+    run_error >> flat_map assert_ok
+
+let assert_erroring : forall e . [Show a] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] () =
+    run_error >> flat_map assert_err
 
 rec let run_raw test : Eff [| writer : Test | r |] a -> Eff [| | r |] (List String) =
     do test = run_writer test
@@ -63,6 +81,10 @@ rec let run_io test : TestEffIO r a -> IO () =
     assert,
     assert_eq,
     assert_neq,
+    assert_ok,
+    assert_err,
+    assert_errorless,
+    assert_erroring,
 
     run_raw,
     run,

--- a/std/test.glu
+++ b/std/test.glu
@@ -74,7 +74,6 @@ let assert_success : [Show e]
 
 let assert_throws : forall e .
     [Show a] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] ()
-
     =
     run_error
         >> flat_map assert_err

--- a/std/test.glu
+++ b/std/test.glu
@@ -59,18 +59,25 @@ let assert_gte l r : [Show a] -> [Ord a] -> a -> a -> Eff [| writer : Test | r |
 let assert_ok res : [Show e] -> Result e a -> Eff [| writer : Test | r |] () =
     match res with
     | Ok _ -> wrap ()
-    | Err e -> tell (Cons ("Assertion failed: found error " <> show e) Nil)
+    | Err e -> tell (Cons ("Assertion failed: found error: " <> show e) Nil)
 
 let assert_err res : [Show a] -> Result e a -> Eff [| writer : Test | r |] () =
     match res with
     | Ok x -> tell (Cons ("Assertion failed: expected error, found " <> show x) Nil)
     | Err _ -> wrap ()
 
-let assert_errorless : [Show e] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] () =
-    run_error >> flat_map assert_ok
+let assert_success : [Show e]
+        -> Eff [| error : Error e, writer : Test | r |] a
+        -> Eff [| writer : Test | r |] ()
+    =
+    run_error
+        >> flat_map assert_ok
 
-let assert_erroring : forall e . [Show a] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] () =
-    run_error >> flat_map assert_err
+let assert_throws : forall e .
+    [Show a] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] ()
+    =
+    run_error
+        >> flat_map assert_err
 
 rec let run_raw test : Eff [| writer : Test | r |] a -> Eff [| | r |] (List String) =
     do test = run_writer test
@@ -99,8 +106,8 @@ rec let run_io test : TestEffIO r a -> IO () =
     assert_neq,
     assert_ok,
     assert_err,
-    assert_errorless,
-    assert_erroring,
+    assert_success,
+    assert_throws,
 
     run_raw,
     run,

--- a/std/test.glu
+++ b/std/test.glu
@@ -74,6 +74,7 @@ let assert_success : [Show e]
 
 let assert_throws : forall e .
     [Show a] -> Eff [| error : Error e, writer : Test | r |] a -> Eff [| writer : Test | r |] ()
+
     =
     run_error
         >> flat_map assert_err

--- a/std/test.glu
+++ b/std/test.glu
@@ -40,6 +40,22 @@ let assert_neq l r : [Show a] -> [Eq a] -> a -> a -> Eff [| writer : Test | r |]
     if l /= r then wrap ()
     else tell (Cons ("Assertion failed: " <> show l <> " == " <> show r) Nil)
 
+let assert_lt l r : [Show a] -> [Ord a] -> a -> a -> Eff [| writer : Test | r |] () =
+    if l < r then wrap ()
+    else tell (Cons ("Assertion failed: " <> show l <> " >= " <> show r) Nil)
+
+let assert_lte l r : [Show a] -> [Ord a] -> a -> a -> Eff [| writer : Test | r |] () =
+    if l <= r then wrap ()
+    else tell (Cons ("Assertion failed: " <> show l <> " > " <> show r) Nil)
+
+let assert_gt l r : [Show a] -> [Ord a] -> a -> a -> Eff [| writer : Test | r |] () =
+    if l > r then wrap ()
+    else tell (Cons ("Assertion failed: " <> show l <> " <= " <> show r) Nil)
+
+let assert_gte l r : [Show a] -> [Ord a] -> a -> a -> Eff [| writer : Test | r |] () =
+    if l >= r then wrap ()
+    else tell (Cons ("Assertion failed: " <> show l <> " < " <> show r) Nil)
+
 let assert_ok res : [Show e] -> Result e a -> Eff [| writer : Test | r |] () =
     match res with
     | Ok _ -> wrap ()


### PR DESCRIPTION
Adds `some_or_throw` to `std.effect.error` and  `assert_ok`, `assert_err`, `assert_errorless`, and `assert_erroring` to `std.test`. I could also add `assert_lt`, `assert_lte`, `assert_gt`, and `assert_gte` if you like.