### PR TITLE
fix(std): export missing assertions in std.test

### DIFF
--- a/std/test.glu
+++ b/std/test.glu
@@ -101,8 +101,14 @@ rec let run_io test : TestEffIO r a -> IO () =
     group,
 
     assert,
+    
     assert_eq,
     assert_neq,
+    assert_lt,
+    assert_lte,
+    assert_gt,
+    assert_gte,
+ 
     assert_ok,
     assert_err,
     assert_success,


### PR DESCRIPTION
I forgot to export the ordering assertion functions in my previous PR.