### PR TITLE
Added Clone trait for Hole

### DIFF
--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -252,6 +252,7 @@ impl<'a> Data<'a> {
 }
 
 /// Marker type representing a hole
+#[derive(Clone)]
 pub struct Hole(());
 
 impl VmType for Hole {


### PR DESCRIPTION
This is required for cloning OwnedFunction<Hole>. Cloning is necessary, because calling a function requires &mut.