### PR TITLE
Version 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+<a name="v0.14.0"></a>
+## v0.14.0 (2020-04-14)
+
+
+#### Bug Fixes
+
+*   Rework how hanging lambda/parens are handled ([732f09f3](https://github.com/gluon-lang/gluon/commit/732f09f3c4c866f8b1b1be231a39604b8e2128e8))
+*   Accept filenames that start with `.`/`..` as modules ([01e450bb](https://github.com/gluon-lang/gluon/commit/01e450bbc2f0737ecc80fde112174f52585c3445))
+*   Don't deadlock when collecting and cloning a thread concurrently ([5886f59f](https://github.com/gluon-lang/gluon/commit/5886f59ff68cbfe029fc6a1697784d2800f42b0a))
+* **check:**  Reject programs which misspecifies the number of patterns ([248387d9](https://github.com/gluon-lang/gluon/commit/248387d9c8d8121ab0f25645f79f7a47aeedfb25), closes [#807](https://github.com/gluon-lang/gluon/issues/807))
+* **doc:**  Correct the style.css path ([4e629ab5](https://github.com/gluon-lang/gluon/commit/4e629ab5afb923ec0e097935f02f42717a2b51d5))
+* **format:**  Improve tuple multiline formatting ([5122fe38](https://github.com/gluon-lang/gluon/commit/5122fe38f4c1360c13bf2ff483b6a7d35f2e7d2d))
+
+#### Features
+
+*   Add AstClone to clone arena allocated ASTs ([3ee7bd28](https://github.com/gluon-lang/gluon/commit/3ee7bd28bdc7126f5f4401e6fbe3368da94aa921))
+*   Compile modules in parallel using salsa-async ([e0ab1811](https://github.com/gluon-lang/gluon/commit/e0ab18115a99115e54294b7240bb5d0360d4043a))
+*   Compile modules in parallel ([57fca165](https://github.com/gluon-lang/gluon/commit/57fca165df50ff61ba87fb81d34dc4087f7ebc60))
+*   Add Function::call_any ([2c06104f](https://github.com/gluon-lang/gluon/commit/2c06104fe2454f6636d811e77384945b4744a4bf))
+*   Export Array from the prelude ([16eb3456](https://github.com/gluon-lang/gluon/commit/16eb3456ca864b7f6c12d7145d15a1c07fb683dc))
+*   Allow serde_json::Value to be marshalled to std.json.Value ([aabdec86](https://github.com/gluon-lang/gluon/commit/aabdec86f49bda922fa01c9c1c84f32fdf2e3011))
+* **check:**
+  *  Avoid propagating errors on lift_io! misuse ([3dbabe53](https://github.com/gluon-lang/gluon/commit/3dbabe5355aeb6b4f61dfa8bdae95b6593f5575c))
+  *  Avoid generating more errors from a type that could not be imported ([752e2bce](https://github.com/gluon-lang/gluon/commit/752e2bce68f6ef7726f0cc92a5b0e194648eb743))
+
+#### Performance
+
+*   Avoid some unnecessary allocations ([089bae4c](https://github.com/gluon-lang/gluon/commit/089bae4c4578d36163ec9a84ee83bbfc6e41ab04))
+*   Shrink the size of Pattern ([75fb8840](https://github.com/gluon-lang/gluon/commit/75fb8840001f3e4d17ada88077b111024d673cf9))
+*   Avoid hashing symbols twice ([0cfb52c8](https://github.com/gluon-lang/gluon/commit/0cfb52c871e80272a087311f230c11a5ad218c39))
+*   Allocate all temporaries into the same Vec ([af945c4a](https://github.com/gluon-lang/gluon/commit/af945c4ad177839aa881d88aefa199b0c9f79aac))
+* **compiler:**  Hoist a remove_alias call out from match alternatives ([c13172e2](https://github.com/gluon-lang/gluon/commit/c13172e2c9ee1fabbf267d83101458af47231436))
+
+
+
 <a name="v0.13.1"></a>
 ### v0.13.1 (2019-10-29)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gluon"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_base"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anymap",
  "bitflags 1.2.1",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_c-api"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "futures 0.3.1",
  "gluon",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_check"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_codegen"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "env_logger 0.7.1",
  "gluon",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_completion"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "codespan",
  "collect-mac",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_doc"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "cargo-deadlinks",
  "clap",
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_format"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "codespan",
  "difference",
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_parser"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_repl"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_vm"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "bitflags 1.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 keywords = ["script", "scripting", "language"]
 build = "build.rs"
@@ -26,12 +26,12 @@ name = "gluon"
 path = "src/lib.rs"
 
 [dependencies]
-gluon_base = { path = "base", version = "0.13.1" } # GLUON
-gluon_check = { path = "check", version = "0.13.1" } # GLUON
-gluon_parser = { path = "parser", version = "0.13.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.13.1" } # GLUON
-gluon_vm = { path = "vm", version = "0.13.1", default-features = false } # GLUON
-gluon_format = { path = "format", version = "0.13.1", default-features = false } # GLUON
+gluon_base = { path = "base", version = "0.14.0" } # GLUON
+gluon_check = { path = "check", version = "0.14.0" } # GLUON
+gluon_parser = { path = "parser", version = "0.14.0" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.14.0" } # GLUON
+gluon_vm = { path = "vm", version = "0.14.0", default-features = false } # GLUON
+gluon_format = { path = "format", version = "0.14.0", default-features = false } # GLUON
 
 async-trait = "0.1"
 log = "0.4"
@@ -68,7 +68,7 @@ rand = { version = "0.7", optional = true }
 rand_xorshift = { version = "0.2", optional = true }
 
 [build-dependencies]
-gluon_base = { path = "base", version = "0.13.1" } # GLUON
+gluon_base = { path = "base", version = "0.14.0" } # GLUON
 
 itertools = "0.8"
 little-skeptic = { version = "0.15.0", optional = true }
@@ -95,8 +95,8 @@ bincode = "1"
 
 pulldown-cmark = "0.6"
 
-gluon_completion = { path = "completion", version = "0.13.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.13.1" } # GLUON
+gluon_completion = { path = "completion", version = "0.14.0" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.14.0" } # GLUON
 
 [features]
 default = ["regex", "random"]

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Gluon requires a recent Rust compiler to build (1.9.0 or later) and is available
 
 ```toml
 [dependencies]
-gluon = "0.13.1"
+gluon = "0.14.0"
 ```
 
 ### Other languages

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_base"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -33,7 +33,7 @@ either = "1"
 vec_map = "0.8"
 typed-arena = "1"
 
-gluon_codegen = { version = "0.13.1", path = "../codegen" } # GLUON
+gluon_codegen = { version = "0.14.0", path = "../codegen" } # GLUON
 
 serde = { version = "1.0.0", features = ["rc"], optional = true }
 serde_state = { version = "0.4.0", features = ["rc"], optional = true }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/gluon_base/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_base/0.14.0")] // # GLUON
 #![allow(unknown_lints)]
 //! The base crate contains pervasive types used in the compiler such as type representations, the
 //! AST and some basic containers.

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_c-api"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -19,7 +19,7 @@ travis-ci = { repository = "gluon-lang/gluon" }
 crate-type = ["cdylib"]
 
 [dependencies]
-gluon = { version = "0.13.1", path = ".." } # GLUON
+gluon = { version = "0.14.0", path = ".." } # GLUON
 futures = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,5 +1,5 @@
 //! A (WIP) C API allowing use of gluon in other langauges than Rust.
-#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.14.0")] // # GLUON
 
 use std::{slice, str};
 

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_check"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -30,13 +30,13 @@ codespan-reporting = "0.3"
 
 strsim = "0.9.0"
 
-gluon_base = { path = "../base", version = "0.13.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.13.1" } # GLUON
+gluon_base = { path = "../base", version = "0.14.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.14.0" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.7"
 
-gluon_parser = { path = "../parser", version = "0.13.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.14.0" } # GLUON
 gluon_format = { path = "../format", version = ">=0.9" }
 
 collect-mac = "0.1.0"

--- a/check/src/implicits.rs
+++ b/check/src/implicits.rs
@@ -372,10 +372,6 @@ impl<'a, 'b, 'ast> ResolveImplicitsVisitor<'a, 'b, 'ast> {
                     Some(Ok(replacement)) => Some(replacement),
                     Some(Err(err)) => {
                         debug!("UnableToResolveImplicit {:?} {}", id.name, id.typ);
-                        error!(
-                            "UnableToResolveImplicit {:?} {} {:#?}",
-                            id.name, id.typ, expr
-                        );
 
                         self.tc.errors.push(Spanned {
                             span: expr.span,

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -3,7 +3,7 @@
 //! If an AST passes the checks in `Typecheck::typecheck_expr` (which runs all of theses checks
 //! the expression is expected to compile succesfully (if it does not it should be considered an
 //! internal compiler error.
-#![doc(html_root_url = "https://docs.rs/gluon_check/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_check/0.14.0")] // # GLUON
 
 #[macro_use]
 extern crate collect_mac;

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_codegen"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 
 edition = "2018"

--- a/completion/Cargo.toml
+++ b/completion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_completion"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,12 +17,12 @@ itertools = "0.8"
 walkdir = "2"
 codespan = "0.3"
 
-gluon_base = { path = "../base", version = "0.13.1" } # GLUON
+gluon_base = { path = "../base", version = "0.14.0" } # GLUON
 
 [dev-dependencies]
 collect-mac = "0.1.0"
 env_logger = "0.7"
 quick-error = "1"
 
-gluon_check = { path = "../check", version = "0.13.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.13.1" } # GLUON
+gluon_check = { path = "../check", version = "0.14.0" } # GLUON
+gluon_parser = { path = "../parser", version = "0.14.0" } # GLUON

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -1,5 +1,5 @@
 //! Primitive auto completion and type quering on ASTs
-#![doc(html_root_url = "https://docs.rs/gluon_completion/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_completion/0.14.0")] // # GLUON
 
 extern crate codespan;
 extern crate either;

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_doc"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -32,8 +32,8 @@ serde = "1.0.0"
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 
-gluon = { version = "0.13.1", path = ".." } # GLUON
-completion = { package = "gluon_completion", version = "0.13.1", path = "../completion" } # GLUON
+gluon = { version = "0.14.0", path = ".." } # GLUON
+completion = { package = "gluon_completion", version = "0.14.0", path = "../completion" } # GLUON
 
 
 [dev-dependencies]

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_format"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ pretty = "0.10"
 itertools = "0.8"
 codespan = "0.3"
 
-gluon_base = { path = "../base", version = "0.13.1" } # GLUON
+gluon_base = { path = "../base", version = "0.14.0" } # GLUON
 
 [dev-dependencies]
 difference = "2"
@@ -27,7 +27,7 @@ pretty_assertions = "0.6"
 tokio = { version = "0.2", features = ["macros", "rt-core"] }
 walkdir = "2"
 
-gluon_base = { path = "../base", version = "0.13.1" } # GLUON
+gluon_base = { path = "../base", version = "0.14.0" } # GLUON
 gluon = { path = "..", version = ">=0.9" }
 
 tensile = { version = "0.6", features = ["tokio"] }

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,5 +1,5 @@
 //! Code formatter.
-#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.14.0")] // # GLUON
 
 extern crate codespan;
 #[macro_use]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_parser"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -24,7 +24,7 @@ quick-error = "1.0.0"
 lalrpop-util = "0.17.2"
 log = "0.4"
 pretty = "0.9"
-gluon_base = { path = "../base", version = "0.13.1" } # GLUON
+gluon_base = { path = "../base", version = "0.14.0" } # GLUON
 ordered-float = "1"
 codespan = "0.3"
 codespan-reporting = "0.3"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,7 +1,7 @@
 //! The parser is a bit more complex than it needs to be as it needs to be fully specialized to
 //! avoid a recompilation every time a later part of the compiler is changed. Due to this the
 //! string interner and therefore also garbage collector needs to compiled before the parser.
-#![doc(html_root_url = "https://docs.rs/gluon_parser/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_parser/0.14.0")] // # GLUON
 
 extern crate codespan;
 extern crate codespan_reporting;

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_repl"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -20,12 +20,12 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-gluon = { version = "0.13.1", path = "..", features = ["serialization"] } # GLUON
-gluon_vm = { version = "0.13.1", path = "../vm", features = ["serialization"] } # GLUON
-gluon_completion = { path = "../completion", version = "0.13.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.13.1" } # GLUON
-gluon_format = { version = "0.13.1", path = "../format" } # GLUON
-gluon_doc = { version = "0.13.1", path = "../doc" } # GLUON
+gluon = { version = "0.14.0", path = "..", features = ["serialization"] } # GLUON
+gluon_vm = { version = "0.14.0", path = "../vm", features = ["serialization"] } # GLUON
+gluon_completion = { path = "../completion", version = "0.14.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.14.0" } # GLUON
+gluon_format = { version = "0.14.0", path = "../format" } # GLUON
+gluon_doc = { version = "0.14.0", path = "../doc" } # GLUON
 
 app_dirs = "1.0.0"
 futures = "0.3"

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -1,5 +1,5 @@
 //! REPL for the gluon programming language
-#![doc(html_root_url = "https://docs.rs/gluon_repl/0.4.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_repl/0.13.1")] // # GLUON
 
 #[macro_use]
 extern crate log;

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
 
 LEVEL=$1
@@ -9,7 +9,7 @@ if [ -z "$LEVEL" ]; then
 fi
 
 clog --$LEVEL
-if [ -z $(head -1 CHANGELOG.md | grep $VERSION) ]; then
+if [[ -z $(head -1 CHANGELOG.md | grep $VERSION) ]]; then
     git checkout CHANGELOG.md
     echo "Wrong version specified"
     exit 1

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Modified from https://github.com/nikomatsakis/lalrpop/blob/master/version.sh
 #
 # A script to bump the version number on all Cargo.toml files etc in

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -4,7 +4,7 @@
 # A script to bump the version number on all Cargo.toml files etc in
 # an atomic fashion.
 
-set -ex
+set -e
 
 if [ "$1" == "" ]; then
     echo "Usage: version.sh <new-version-number>"
@@ -13,8 +13,8 @@ fi
 
 VERSION=$(
     ls **/Cargo.toml | \
-        xargs grep "# GLUON$" | \
-        perl -p -e 's/.*version = "([0-9.]+)"[^#]+# GLUON$/$1/' |
+        xargs grep "# GLUON" | \
+        perl -p -e 's/.*version = "([0-9.]+)"[^#]+# GLUON/$1/' |
         sort |
         uniq)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! behaviour. For information about how to use this library the best resource currently is the
 //! [tutorial](http://gluon-lang.org/book/index.html) which contains examples
 //! on how to write gluon programs as well as how to run them using this library.
-#![doc(html_root_url = "https://docs.rs/gluon/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon/0.14.0")] // # GLUON
 #![recursion_limit = "128"]
 #[cfg(test)]
 extern crate env_logger;

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_vm"
-version = "0.13.1" # GLUON
+version = "0.14.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 build = "build.rs"
@@ -46,10 +46,10 @@ serde_state = { version = "0.4.0", optional = true }
 serde_derive = { version = "1.0.0", optional = true }
 serde_derive_state = { version = "0.4.8", optional = true }
 
-gluon_base = { path = "../base", version = "0.13.1" } # GLUON
-gluon_check = { path = "../check", version = "0.13.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.13.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.13.1", optional = true } # GLUON
+gluon_base = { path = "../base", version = "0.14.0" } # GLUON
+gluon_check = { path = "../check", version = "0.14.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.14.0" } # GLUON
+gluon_parser = { path = "../parser", version = "0.14.0", optional = true } # GLUON
 
 [build-dependencies]
 lalrpop = { version = "0.17", optional = true }
@@ -67,7 +67,7 @@ lalrpop-util = "0.17"
 regex = "1"
 serde_json = "1.0.0"
 
-gluon_parser = { path = "../parser", version = "0.13.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.14.0" } # GLUON
 
 [features]
 serialization = ["serde", "serde_state", "serde_derive", "serde_derive_state", "serde_json", "gluon_base/serialization", "codespan/serialization"]

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,5 +1,5 @@
 //! Crate which contain the virtual machine which executes gluon programs
-#![doc(html_root_url = "https://docs.rs/gluon_vm/0.13.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_vm/0.14.0")] // # GLUON
 #![recursion_limit = "1024"]
 
 #[macro_use]


### PR DESCRIPTION
## v0.14.0 (2020-04-14)

#### Bug Fixes

*   Rework how hanging lambda/parens are handled ([732f09f](732f09f))
*   Accept filenames that start with `.`/`..` as modules ([01e450b](01e450b))
*   Don't deadlock when collecting and cloning a thread concurrently ([5886f59](5886f59))
* **check:**  Reject programs which misspecifies the number of patterns ([248387d](248387d), closes [#807](#807))
* **doc:**  Correct the style.css path ([4e629ab](4e629ab))
* **format:**  Improve tuple multiline formatting ([5122fe3](5122fe3))

#### Features

*   Add AstClone to clone arena allocated ASTs ([3ee7bd2](3ee7bd2))
*   Compile modules in parallel using salsa-async ([e0ab181](e0ab181))
*   Compile modules in parallel ([57fca16](57fca16))
*   Add Function::call_any ([2c06104](2c06104))
*   Export Array from the prelude ([16eb345](16eb345))
*   Allow serde_json::Value to be marshalled to std.json.Value ([aabdec8](aabdec8))
* **check:**
  *  Avoid propagating errors on lift_io! misuse ([3dbabe5](3dbabe5))
  *  Avoid generating more errors from a type that could not be imported ([752e2bc](752e2bc))

#### Performance

*   Avoid some unnecessary allocations ([089bae4](089bae4))
*   Shrink the size of Pattern ([75fb884](75fb884))
*   Avoid hashing symbols twice ([0cfb52c](0cfb52c))
*   Allocate all temporaries into the same Vec ([af945c4](af945c4))
* **compiler:**  Hoist a remove_alias call out from match alternatives ([c13172e](c13172e))