### PR TITLE
fix: Allow bitoperations to be deserialized

### DIFF
--- a/tests/serialization.rs
+++ b/tests/serialization.rs
@@ -208,6 +208,16 @@ fn roundtrip_lazy() {
 }
 
 #[test]
+fn roundtrip_list() {
+    let thread = new_vm();
+    let expr = r#" import! std.list "#;
+    let (value, _) = thread
+        .run_expr::<OpaqueValue<&Thread, Hole>>("test", &expr)
+        .unwrap_or_else(|err| panic!("{}", err));
+    roundtrip(&thread, &value);
+}
+
+#[test]
 fn roundtrip_std_thread() {
     let thread = new_vm();
     let expr = r#" import! std.thread "#;


### PR DESCRIPTION
The name generated for the function must match the path that they exist
atm otherwise they can't be looked up during deserialization.

cc @omegablitz