### PR TITLE
Version 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+<a name="v0.15.0"></a>
+## v0.15.0 (2020-06-06)
+
+
+#### Bug Fixes
+
+*   Allow bitoperations to be deserialized ([ed36ed9c](https://github.com/gluon-lang/gluon/commit/ed36ed9ccc5e423fd872994ffb52edda97c8965d))
+
+#### Performance
+
+*   Strategically inline comment productions ([78e733e7](https://github.com/gluon-lang/gluon/commit/78e733e701abe71ee10048b3de3b550bed927f43))
+*   Shrink the metadata stored in the AST ([842c1080](https://github.com/gluon-lang/gluon/commit/842c1080bb73a7509384064e07a671b2c0f11fb6))
+*   Use T::Generics in AliasData ([4cb575fa](https://github.com/gluon-lang/gluon/commit/4cb575fac5356bbc9a018eb6779c209a3473d3b6))
+*   Shrink the symbol type in the parser ([a8fc8f39](https://github.com/gluon-lang/gluon/commit/a8fc8f39556a2997e359288ec37dfd9bd0932d7d))
+
+#### Features
+
+*   Accept multiple lines on incomplete repl input ([47318399](https://github.com/gluon-lang/gluon/commit/473183995ad793e48eef7d5b3b56c5cf22c325f5), closes [#830](https://github.com/gluon-lang/gluon/issues/830))
+
+
+
 <a name="v0.14.1"></a>
 ### v0.14.1 (2020-04-15)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gluon"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1190,7 +1190,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_base"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anymap",
  "bitflags 1.2.1",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_c-api"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "futures 0.3.4",
  "gluon",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_check"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_codegen"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "env_logger 0.7.1",
  "gluon",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_completion"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "codespan",
  "collect-mac",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_doc"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "cargo-deadlinks",
  "clap",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_format"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "codespan",
  "difference",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_parser"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_repl"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "ansi_term 0.12.1",
  "app_dirs",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_vm"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "bitflags 1.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 keywords = ["script", "scripting", "language"]
 build = "build.rs"
@@ -26,12 +26,12 @@ name = "gluon"
 path = "src/lib.rs"
 
 [dependencies]
-gluon_base = { path = "base", version = "0.14.1" } # GLUON
-gluon_check = { path = "check", version = "0.14.1" } # GLUON
-gluon_parser = { path = "parser", version = "0.14.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.14.1" } # GLUON
-gluon_vm = { path = "vm", version = "0.14.1", default-features = false } # GLUON
-gluon_format = { path = "format", version = "0.14.1", default-features = false } # GLUON
+gluon_base = { path = "base", version = "0.15.0" } # GLUON
+gluon_check = { path = "check", version = "0.15.0" } # GLUON
+gluon_parser = { path = "parser", version = "0.15.0" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.15.0" } # GLUON
+gluon_vm = { path = "vm", version = "0.15.0", default-features = false } # GLUON
+gluon_format = { path = "format", version = "0.15.0", default-features = false } # GLUON
 
 async-trait = "0.1"
 log = "0.4"
@@ -68,7 +68,7 @@ rand = { version = "0.7", optional = true }
 rand_xorshift = { version = "0.2", optional = true }
 
 [build-dependencies]
-gluon_base = { path = "base", version = "0.14.1" } # GLUON
+gluon_base = { path = "base", version = "0.15.0" } # GLUON
 
 itertools = "0.8"
 little-skeptic = { version = "0.15.0", optional = true }
@@ -95,8 +95,8 @@ bincode = "1"
 
 pulldown-cmark = "0.6"
 
-gluon_completion = { path = "completion", version = "0.14.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.14.1" } # GLUON
+gluon_completion = { path = "completion", version = "0.15.0" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.15.0" } # GLUON
 
 [features]
 default = ["regex", "random"]

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Gluon requires a recent Rust compiler to build (1.9.0 or later) and is available
 
 ```toml
 [dependencies]
-gluon = "0.14.1"
+gluon = "0.15.0"
 ```
 
 ### Other languages

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_base"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -33,7 +33,7 @@ either = "1"
 vec_map = "0.8"
 typed-arena = "1"
 
-gluon_codegen = { version = "0.14.1", path = "../codegen" } # GLUON
+gluon_codegen = { version = "0.15.0", path = "../codegen" } # GLUON
 
 serde = { version = "1.0.0", features = ["rc"], optional = true }
 serde_state = { version = "0.4.0", features = ["rc"], optional = true }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/gluon_base/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_base/0.15.0")] // # GLUON
 #![allow(unknown_lints)]
 //! The base crate contains pervasive types used in the compiler such as type representations, the
 //! AST and some basic containers.

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_c-api"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -19,7 +19,7 @@ travis-ci = { repository = "gluon-lang/gluon" }
 crate-type = ["cdylib"]
 
 [dependencies]
-gluon = { version = "0.14.1", path = ".." } # GLUON
+gluon = { version = "0.15.0", path = ".." } # GLUON
 futures = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,5 +1,5 @@
 //! A (WIP) C API allowing use of gluon in other langauges than Rust.
-#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.15.0")] // # GLUON
 
 use std::{slice, str};
 

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_check"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -30,13 +30,13 @@ codespan-reporting = "0.3"
 
 strsim = "0.9.0"
 
-gluon_base = { path = "../base", version = "0.14.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.14.1" } # GLUON
+gluon_base = { path = "../base", version = "0.15.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.15.0" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.7"
 
-gluon_parser = { path = "../parser", version = "0.14.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.15.0" } # GLUON
 gluon_format = { path = "../format", version = ">=0.9" }
 
 collect-mac = "0.1.0"

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -3,7 +3,7 @@
 //! If an AST passes the checks in `Typecheck::typecheck_expr` (which runs all of theses checks
 //! the expression is expected to compile succesfully (if it does not it should be considered an
 //! internal compiler error.
-#![doc(html_root_url = "https://docs.rs/gluon_check/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_check/0.15.0")] // # GLUON
 
 #[macro_use]
 extern crate collect_mac;

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_codegen"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 
 edition = "2018"

--- a/completion/Cargo.toml
+++ b/completion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_completion"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,12 +17,12 @@ itertools = "0.8"
 walkdir = "2"
 codespan = "0.3"
 
-gluon_base = { path = "../base", version = "0.14.1" } # GLUON
+gluon_base = { path = "../base", version = "0.15.0" } # GLUON
 
 [dev-dependencies]
 collect-mac = "0.1.0"
 env_logger = "0.7"
 quick-error = "1"
 
-gluon_check = { path = "../check", version = "0.14.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.14.1" } # GLUON
+gluon_check = { path = "../check", version = "0.15.0" } # GLUON
+gluon_parser = { path = "../parser", version = "0.15.0" } # GLUON

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -1,5 +1,5 @@
 //! Primitive auto completion and type quering on ASTs
-#![doc(html_root_url = "https://docs.rs/gluon_completion/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_completion/0.15.0")] // # GLUON
 
 extern crate codespan;
 extern crate either;

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_doc"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -32,8 +32,8 @@ serde = "1.0.0"
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 
-gluon = { version = "0.14.1", path = ".." } # GLUON
-completion = { package = "gluon_completion", version = "0.14.1", path = "../completion" } # GLUON
+gluon = { version = "0.15.0", path = ".." } # GLUON
+completion = { package = "gluon_completion", version = "0.15.0", path = "../completion" } # GLUON
 
 
 [dev-dependencies]

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_format"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ pretty = "0.10"
 itertools = "0.8"
 codespan = "0.3"
 
-gluon_base = { path = "../base", version = "0.14.1" } # GLUON
+gluon_base = { path = "../base", version = "0.15.0" } # GLUON
 
 [dev-dependencies]
 difference = "2"
@@ -27,7 +27,7 @@ pretty_assertions = "0.6"
 tokio = { version = "0.2", features = ["macros", "rt-core"] }
 walkdir = "2"
 
-gluon_base = { path = "../base", version = "0.14.1" } # GLUON
+gluon_base = { path = "../base", version = "0.15.0" } # GLUON
 gluon = { path = "..", version = ">=0.9" }
 
 tensile = { version = "0.6", features = ["tokio"] }

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,5 +1,5 @@
 //! Code formatter.
-#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.15.0")] // # GLUON
 
 extern crate codespan;
 #[macro_use]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_parser"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -24,7 +24,7 @@ quick-error = "1.0.0"
 lalrpop-util = "0.19"
 log = "0.4"
 pretty = "0.9"
-gluon_base = { path = "../base", version = "0.14.1" } # GLUON
+gluon_base = { path = "../base", version = "0.15.0" } # GLUON
 ordered-float = "1"
 codespan = "0.3"
 codespan-reporting = "0.3"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,7 +1,7 @@
 //! The parser is a bit more complex than it needs to be as it needs to be fully specialized to
 //! avoid a recompilation every time a later part of the compiler is changed. Due to this the
 //! string interner and therefore also garbage collector needs to compiled before the parser.
-#![doc(html_root_url = "https://docs.rs/gluon_parser/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_parser/0.15.0")] // # GLUON
 
 extern crate codespan;
 extern crate codespan_reporting;

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_repl"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -20,12 +20,12 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-gluon = { version = "0.14.1", path = "..", features = ["serialization"] } # GLUON
-gluon_vm = { version = "0.14.1", path = "../vm", features = ["serialization"] } # GLUON
-gluon_completion = { path = "../completion", version = "0.14.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.14.1" } # GLUON
-gluon_format = { version = "0.14.1", path = "../format" } # GLUON
-gluon_doc = { version = "0.14.1", path = "../doc" } # GLUON
+gluon = { version = "0.15.0", path = "..", features = ["serialization"] } # GLUON
+gluon_vm = { version = "0.15.0", path = "../vm", features = ["serialization"] } # GLUON
+gluon_completion = { path = "../completion", version = "0.15.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.15.0" } # GLUON
+gluon_format = { version = "0.15.0", path = "../format" } # GLUON
+gluon_doc = { version = "0.15.0", path = "../doc" } # GLUON
 
 app_dirs = "1.0.0"
 failure = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! behaviour. For information about how to use this library the best resource currently is the
 //! [tutorial](http://gluon-lang.org/book/index.html) which contains examples
 //! on how to write gluon programs as well as how to run them using this library.
-#![doc(html_root_url = "https://docs.rs/gluon/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon/0.15.0")] // # GLUON
 #![recursion_limit = "128"]
 #[cfg(test)]
 extern crate env_logger;

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_vm"
-version = "0.14.1" # GLUON
+version = "0.15.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 build = "build.rs"
@@ -46,10 +46,10 @@ serde_state = { version = "0.4.0", optional = true }
 serde_derive = { version = "1.0.0", optional = true }
 serde_derive_state = { version = "0.4.8", optional = true }
 
-gluon_base = { path = "../base", version = "0.14.1" } # GLUON
-gluon_check = { path = "../check", version = "0.14.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.14.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.14.1", optional = true } # GLUON
+gluon_base = { path = "../base", version = "0.15.0" } # GLUON
+gluon_check = { path = "../check", version = "0.15.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.15.0" } # GLUON
+gluon_parser = { path = "../parser", version = "0.15.0", optional = true } # GLUON
 
 [build-dependencies]
 lalrpop = { version = "0.19", features = ["lexer"], optional = true }
@@ -68,7 +68,7 @@ regex = "1"
 serde_json = "1.0.0"
 tokio = { version = "0.2", features = ["macros"] }
 
-gluon_parser = { path = "../parser", version = "0.14.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.15.0" } # GLUON
 
 [features]
 serialization = ["serde", "serde_state", "serde_derive", "serde_derive_state", "serde_json", "gluon_base/serialization", "codespan/serialization"]

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,5 +1,5 @@
 //! Crate which contain the virtual machine which executes gluon programs
-#![doc(html_root_url = "https://docs.rs/gluon_vm/0.14.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_vm/0.15.0")] // # GLUON
 #![recursion_limit = "1024"]
 
 #[macro_use]


### PR DESCRIPTION
<a name="v0.15.0"></a>
## v0.15.0 (2020-06-06)

#### Bug Fixes

*   Allow bitoperations to be deserialized ([ed36ed9c](https://github.com/gluon-lang/gluon/commit/ed36ed9ccc5e423fd872994ffb52edda97c8965d))

#### Performance

*   Strategically inline comment productions ([78e733e7](https://github.com/gluon-lang/gluon/commit/78e733e701abe71ee10048b3de3b550bed927f43))
*   Shrink the metadata stored in the AST ([842c1080](https://github.com/gluon-lang/gluon/commit/842c1080bb73a7509384064e07a671b2c0f11fb6))
*   Use T::Generics in AliasData ([4cb575fa](https://github.com/gluon-lang/gluon/commit/4cb575fac5356bbc9a018eb6779c209a3473d3b6))
*   Shrink the symbol type in the parser ([a8fc8f39](https://github.com/gluon-lang/gluon/commit/a8fc8f39556a2997e359288ec37dfd9bd0932d7d))

#### Features

*   Accept multiple lines on incomplete repl input ([47318399](https://github.com/gluon-lang/gluon/commit/473183995ad793e48eef7d5b3b56c5cf22c325f5), closes [#830](https://github.com/gluon-lang/gluon/issues/830))