### PR TITLE
fix: Handle errors when pushing a BTreeMap

### DIFF
--- a/std/json/de.glu
+++ b/std/json/de.glu
@@ -253,9 +253,6 @@ let run ?de value : [Deserialize a] -> Value -> Result Error a =
     do state = de.deserializer value
     Ok state.value
 
-#[doc(hidden)]
-let insert_string : String -> a -> Map String a -> Map String a = std_map.insert
-
 let bool_deserializer : Deserialize Bool = { deserializer = bool }
 
 let int_deserializer : Deserialize Int = { deserializer = int }
@@ -317,6 +314,4 @@ let map_deserializer : [Deserialize a] -> Deserialize (Map String a) =
     list_deserializer,
     array_deserializer,
     map_deserializer,
-
-    insert_string,
 }

--- a/std/map.glu
+++ b/std/map.glu
@@ -124,6 +124,11 @@ let keys : [Ord k] -> Map k a -> List k = foldr_with_key (\k _ acc -> Cons k acc
 /// Returns a list of all values in the map.
 let values : [Ord k] -> Map k a -> List a = foldr Cons Nil
 
+
+
+#[doc(hidden)]
+let insert_string : String -> a -> Map String a -> Map String a = insert
+
 {
     Map,
 
@@ -146,4 +151,6 @@ let values : [Ord k] -> Map k a -> List a = foldr Cons Nil
     to_list,
     keys,
     values,
+
+    insert_string,
 }


### PR DESCRIPTION
Also move the insert_string hack into std.map so std.json.de does not
need to be imported

Fixes #847