### PR TITLE
Reduce the function call overhead somewhat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
 
 matrix:
   include:
-  - rust: nightly-2020-03-12
+  - rust: nightly-2020-07-26
     #  - rust: beta
   - rust: stable
     env: ARCH=i686

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ dependencies = [
  "either",
  "env_logger 0.7.1",
  "futures 0.3.5",
+ "gluon-salsa",
  "gluon_base",
  "gluon_check",
  "gluon_codegen",
@@ -1186,7 +1187,6 @@ dependencies = [
  "rand 0.7.3",
  "rand_xorshift 0.2.0",
  "regex 1.3.9",
- "salsa",
  "serde",
  "serde_derive",
  "serde_derive_state",
@@ -1200,6 +1200,37 @@ dependencies = [
  "tokio-native-tls",
  "tower-service",
  "walkdir",
+]
+
+[[package]]
+name = "gluon-salsa"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4644d498c04e71e60947f837bf9729379bd922e5b745c36bea5a4ce03e551fe5"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "futures-channel",
+ "futures-util",
+ "gluon-salsa-macros",
+ "indexmap",
+ "lock_api 0.4.0",
+ "log 0.4.8",
+ "oorandom",
+ "parking_lot 0.11.0",
+ "rustc-hash",
+ "smallvec 1.4.0",
+]
+
+[[package]]
+name = "gluon-salsa-macros"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807a2b17a92e21080379cf696063642c70caea95c04b547320d37fd6844b8e0f"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
 ]
 
 [[package]]
@@ -2645,7 +2676,7 @@ dependencies = [
  "rand_isaac",
  "rand_jitter",
  "rand_os",
- "rand_pcg 0.1.2",
+ "rand_pcg",
  "rand_xorshift 0.1.1",
  "winapi 0.3.9",
 ]
@@ -2661,7 +2692,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
- "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -2768,15 +2798,6 @@ checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
  "autocfg 0.1.7",
  "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3049,33 +3070,6 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
-name = "salsa"
-version = "0.15.0"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "futures-channel",
- "futures-util",
- "indexmap",
- "lock_api 0.4.0",
- "log 0.4.8",
- "parking_lot 0.11.0",
- "rand 0.7.3",
- "rustc-hash",
- "salsa-macros",
- "smallvec 1.4.0",
-]
-
-[[package]]
-name = "salsa-macros"
-version = "0.15.0"
-dependencies = [
- "heck",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.33",
-]
 
 [[package]]
 name = "same-file"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,30 +601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils 0.7.2",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,7 +1165,6 @@ dependencies = [
  "either",
  "env_logger 0.7.1",
  "futures 0.3.5",
- "gluon-salsa",
  "gluon_base",
  "gluon_check",
  "gluon_codegen",
@@ -1211,6 +1186,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_xorshift 0.2.0",
  "regex 1.3.9",
+ "salsa",
  "serde",
  "serde_derive",
  "serde_derive_state",
@@ -1224,37 +1200,6 @@ dependencies = [
  "tokio-native-tls",
  "tower-service",
  "walkdir",
-]
-
-[[package]]
-name = "gluon-salsa"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82259f6f7d8f8cf33b4b40bbd3da8119a147827e6563c5a024034482f6e8d28f"
-dependencies = [
- "async-trait",
- "crossbeam",
- "futures 0.3.5",
- "gluon-salsa-macros",
- "indexmap",
- "lock_api 0.4.0",
- "log 0.4.8",
- "parking_lot 0.11.0",
- "rand 0.7.3",
- "rustc-hash",
- "smallvec 1.4.0",
-]
-
-[[package]]
-name = "gluon-salsa-macros"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118ca3427c8528856c15a83b574ee52a95ed2647e4c77cd0191485c2e014ed88"
-dependencies = [
- "heck",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.33",
 ]
 
 [[package]]
@@ -3104,6 +3049,33 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "salsa"
+version = "0.15.0"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "lock_api 0.4.0",
+ "log 0.4.8",
+ "parking_lot 0.11.0",
+ "rand 0.7.3",
+ "rustc-hash",
+ "salsa-macros",
+ "smallvec 1.4.0",
+]
+
+[[package]]
+name = "salsa-macros"
+version = "0.15.0"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.33",
+]
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,8 +145,8 @@ path = "examples/lisp/main.rs"
 [package.metadata.docs.rs]
 features = ["docs_rs"]
 
-# [profile.bench]
-# debug = 2
-#
-# [profile.release]
-# debug = 2
+[profile.bench]
+debug = 2
+
+[profile.release]
+debug = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ futures = { version = "0.3.1", default-features = false }
 codespan = "0.9"
 codespan-reporting = "0.9"
 pin-project-lite = { version = "0.1", optional = true }
-salsa = { path = "../salsa" }
+salsa = { version = "0.15.2", package = "gluon-salsa" }
 
 serde = { version = "1.0.0", optional = true }
 serde_state = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ futures = { version = "0.3.1", default-features = false }
 codespan = "0.9"
 codespan-reporting = "0.9"
 pin-project-lite = { version = "0.1", optional = true }
-salsa = { version = "0.14.2", package = "gluon-salsa" }
+salsa = { path = "../salsa" }
 
 serde = { version = "1.0.0", optional = true }
 serde_state = { version = "0.4", optional = true }

--- a/base/src/resolve.rs
+++ b/base/src/resolve.rs
@@ -67,7 +67,7 @@ where
 {
     pub fn canonical_alias<'t, F>(
         &mut self,
-        env: &dyn TypeEnv<Type = T>,
+        env: &(dyn TypeEnv<Type = T> + '_),
         interner: &mut impl TypeContext<Symbol, T>,
         typ: &'t T,
         mut canonical: F,
@@ -105,7 +105,7 @@ where
 
     pub fn remove_aliases_to_concrete<'a>(
         &mut self,
-        env: &dyn TypeEnv<Type = T>,
+        env: &(dyn TypeEnv<Type = T> + '_),
         interner: &mut impl TypeContext<Symbol, T>,
         mut typ: T,
     ) -> Result<T, Error> {
@@ -139,7 +139,7 @@ where
 
     pub fn remove_aliases(
         &mut self,
-        env: &dyn TypeEnv<Type = T>,
+        env: &(dyn TypeEnv<Type = T> + '_),
         interner: &mut impl TypeContext<Symbol, T>,
         typ: T,
     ) -> Result<T, Error> {
@@ -148,7 +148,7 @@ where
 
     pub fn remove_aliases_predicate(
         &mut self,
-        env: &dyn TypeEnv<Type = T>,
+        env: &(dyn TypeEnv<Type = T> + '_),
         interner: &mut impl TypeContext<Symbol, T>,
         mut typ: T,
         mut predicate: impl FnMut(&AliasData<Symbol, T>) -> bool,
@@ -163,7 +163,7 @@ where
 
     pub fn remove_alias(
         &mut self,
-        env: &dyn TypeEnv<Type = T>,
+        env: &(dyn TypeEnv<Type = T> + '_),
         interner: &mut impl TypeContext<Symbol, T>,
         typ: &T,
         predicate: impl FnOnce(&AliasData<Symbol, T>) -> bool,
@@ -181,7 +181,7 @@ where
 
     pub fn remove_alias_to_concrete<'a>(
         &mut self,
-        env: &'a dyn TypeEnv<Type = T>,
+        env: &'a (dyn TypeEnv<Type = T> + '_),
         interner: &mut impl TypeContext<Symbol, T>,
         typ: &'a T,
         predicate: impl FnOnce(&AliasData<Symbol, T>) -> bool,
@@ -238,7 +238,7 @@ where
 
 /// Removes type aliases from `typ` until it is an actual type
 pub fn remove_aliases<T>(
-    env: &dyn TypeEnv<Type = T>,
+    env: &(dyn TypeEnv<Type = T> + '_),
     interner: &mut impl TypeContext<Symbol, T>,
     mut typ: T,
 ) -> T
@@ -255,8 +255,7 @@ where
 }
 
 pub fn remove_aliases_cow<'t, T>(
-    env: &dyn TypeEnv<Type = T>,
-
+    env: &(dyn TypeEnv<Type = T> + '_),
     interner: &mut impl TypeContext<Symbol, T>,
     typ: &'t T,
 ) -> Cow<'t, T>
@@ -275,7 +274,7 @@ where
 /// Resolves aliases until `canonical` returns `true` for an alias in which case it returns the
 /// type that directly contains that alias
 pub fn canonical_alias<'t, F, T>(
-    env: &dyn TypeEnv<Type = T>,
+    env: &(dyn TypeEnv<Type = T> + '_),
     interner: &mut impl TypeContext<Symbol, T>,
     typ: &'t T,
     mut canonical: F,
@@ -313,7 +312,7 @@ where
 /// Expand `typ` if it is an alias that can be expanded and return the expanded type.
 /// Returns `None` if the type is not an alias or the alias could not be expanded.
 pub fn remove_alias<T>(
-    env: &dyn TypeEnv<Type = T>,
+    env: &(dyn TypeEnv<Type = T> + '_),
     interner: &mut impl TypeContext<Symbol, T>,
     typ: &T,
 ) -> Result<Option<T>, Error>
@@ -338,7 +337,7 @@ where
 }
 
 pub fn peek_alias<'t, T>(
-    env: &'t dyn TypeEnv<Type = T>,
+    env: &(dyn TypeEnv<Type = T> + '_),
     typ: &'t T,
 ) -> Result<Option<AliasRef<Symbol, T>>, Error>
 where

--- a/benches/function_call.rs
+++ b/benches/function_call.rs
@@ -10,6 +10,21 @@ use gluon::{
 };
 
 // Benchmarks function calls
+
+fn identity(b: &mut Bencher) {
+    let vm = new_vm();
+    let text = r#"
+    let id x = x
+    id
+    "#;
+    vm.load_script("id", text).unwrap();
+    let mut id: FunctionRef<fn(i32) -> i32> = vm.get_global("id").unwrap();
+    b.iter(|| {
+        let result = id.call(20).unwrap();
+        black_box(result)
+    })
+}
+
 fn factorial(b: &mut Bencher) {
     let vm = new_vm();
     let text = r#"
@@ -81,6 +96,7 @@ fn gluon_rust_boundary_overhead(b: &mut Bencher) {
 }
 
 fn function_call_benchmark(c: &mut Criterion) {
+    c.bench_function("identity", identity);
     c.bench_function("factorial", factorial);
     c.bench_function("factorial tail call", factorial_tail_call);
     c.bench_function("gluon rust boundary overhead", gluon_rust_boundary_overhead);

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn glu_push_string(vm: &Thread, s: &u8, len: usize) -> Err
         Ok(s) => s,
         Err(_) => return Error::Unknown,
     };
-    match s.push(&mut vm.current_context()) {
+    match s.vm_push(&mut vm.current_context()) {
         Ok(()) => Error::Ok,
         Err(_) => Error::Unknown,
     }
@@ -166,7 +166,7 @@ pub unsafe extern "C" fn glu_push_string(vm: &Thread, s: &u8, len: usize) -> Err
 #[no_mangle]
 pub unsafe extern "C" fn glu_push_string_unchecked(vm: &Thread, s: &u8, len: usize) -> Error {
     let s = str::from_utf8_unchecked(slice::from_raw_parts(s, len));
-    match s.push(&mut vm.current_context()) {
+    match s.vm_push(&mut vm.current_context()) {
         Ok(()) => Error::Ok,
         Err(_) => Error::Unknown,
     }

--- a/codegen/src/pushable.rs
+++ b/codegen/src/pushable.rs
@@ -47,7 +47,7 @@ fn derive_struct(
         Fields::Unnamed(_) if field_idents.len() == 1 => {
             let ty = &field_types[0];
             let push_impl = quote! {
-                <#ty as _gluon_api::Pushable<'__vm>>::push(self.0, ctx)?;
+                <#ty as _gluon_api::Pushable<'__vm>>::vm_push(self.0, ctx)?;
             };
             return gen_impl(&container, &ident, generics, push_impl);
         }
@@ -163,7 +163,7 @@ fn gen_impl(
             impl #impl_generics _gluon_api::Pushable<'__vm> for #ident #ty_generics
             #where_clause #(#pushable_bounds),*
             {
-                fn push(self, ctx: &mut _gluon_thread::ActiveThread<'__vm>) -> _GluonResult<()> {
+                fn vm_push(self, ctx: &mut _gluon_thread::ActiveThread<'__vm>) -> _GluonResult<()> {
                     #push_impl
                     Ok(())
                 }
@@ -182,7 +182,7 @@ fn gen_push_impl(
     // push each field onto the stack
     let stack_pushes = field_idents.iter().zip(field_types).map(|(ident, ty)| {
         quote! {
-            <#ty as _gluon_api::Pushable<'__vm>>::push(#ident, ctx)?;
+            <#ty as _gluon_api::Pushable<'__vm>>::vm_push(#ident, ctx)?;
         }
     });
 

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -32,7 +32,7 @@ serde = "1.0.0"
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 
-gluon = { version = "0.16.1", path = ".." } # GLUON
+gluon = { version = "0.16.1", default-features = false, path = ".." } # GLUON
 completion = { package = "gluon_completion", version = "0.16.1", path = "../completion" } # GLUON
 
 

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -43,8 +43,8 @@ impl api::VmType for Enum {
 }
 
 impl<'vm, 'value> api::Pushable<'vm> for Enum {
-    fn push(self, context: &mut ActiveThread<'vm>) -> vm::Result<()> {
-        api::ser::Ser(self).push(context)
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> vm::Result<()> {
+        api::ser::Ser(self).vm_push(context)
     }
 }
 
@@ -240,7 +240,7 @@ where
 
         // apply all generic parameters to the type
         let mut vec = AppVec::new();
-        AppVec::push(&mut vec, T::make_type(thread));
+        vec.push(T::make_type(thread));
         Type::app(ty, vec)
     }
 }
@@ -249,13 +249,13 @@ impl<'vm, T> Pushable<'vm> for GluonUser<T>
 where
     T: Pushable<'vm>,
 {
-    fn push(self, ctx: &mut ActiveThread<'vm>) -> vm::Result<()> {
+    fn vm_push(self, ctx: &mut ActiveThread<'vm>) -> vm::Result<()> {
         (record! {
             name => self.inner.name,
             age => self.inner.age,
             data => self.inner.data,
         })
-        .push(ctx)
+        .vm_push(ctx)
     }
 }
 

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -302,8 +302,8 @@ macro_rules! define_vmtype {
 define_vmtype! { ReadlineError }
 
 impl<'vm> Pushable<'vm> for ReadlineError {
-    fn push(self, context: &mut ActiveThread<'vm>) -> VMResult<()> {
-        gluon::vm::api::ser::Ser(self).push(context)
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> VMResult<()> {
+        gluon::vm::api::ser::Ser(self).vm_push(context)
     }
 }
 

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -374,6 +374,7 @@ fn eval_line(
 
 async fn eval_line_(vm: RootedThread, line: &str) -> gluon::Result<()> {
     let mut db = vm.get_database();
+    let mut db = gluon::salsa::OwnedDb::<dyn gluon::query::Compilation>::from(&mut db);
     let mut module_compiler = vm.module_compiler(&mut db);
     let mut is_let_binding = false;
     let mut eval_expr = {

--- a/src/import.rs
+++ b/src/import.rs
@@ -18,7 +18,7 @@ use {
         prelude::*,
     },
     itertools::Itertools,
-    salsa::{debug::DebugQueryTable, Database},
+    salsa::debug::DebugQueryTable,
 };
 
 use crate::base::{
@@ -40,7 +40,7 @@ use crate::vm::{
 
 use crate::{
     compiler_pipeline::SalvageResult,
-    query::{Compilation, CompilationMut, CompilerDatabase},
+    query::{AsyncCompilation, Compilation, CompilerDatabase},
     IoError, ModuleCompiler, ThreadExt,
 };
 
@@ -83,7 +83,7 @@ include!(concat!(env!("OUT_DIR"), "/std_modules.rs"));
 pub trait Importer: Any + Clone + Sync + Send {
     async fn import(
         &self,
-        compiler: &mut ModuleCompiler<'_>,
+        compiler: &mut ModuleCompiler<'_, '_>,
         vm: &Thread,
         modulename: &str,
     ) -> SalvageResult<ArcType, crate::Error>;
@@ -95,7 +95,7 @@ pub struct DefaultImporter;
 impl Importer for DefaultImporter {
     async fn import(
         &self,
-        compiler: &mut ModuleCompiler<'_>,
+        compiler: &mut ModuleCompiler<'_, '_>,
         _vm: &Thread,
         modulename: &str,
     ) -> SalvageResult<ArcType> {
@@ -115,9 +115,9 @@ impl Deref for DatabaseSnapshot {
     }
 }
 
-impl DerefMut for DatabaseSnapshot {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.snapshot.as_mut().unwrap()
+impl<'a> From<&'a mut DatabaseSnapshot> for salsa::OwnedDb<'a, dyn Compilation> {
+    fn from(db: &'a mut DatabaseSnapshot) -> Self {
+        salsa::cast_owned_db!(salsa::OwnedDb::<CompilerDatabase>::from(db.snapshot.as_mut().unwrap()) => &mut dyn Compilation)
     }
 }
 
@@ -132,9 +132,9 @@ impl Deref for DatabaseFork {
     }
 }
 
-impl DerefMut for DatabaseFork {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.fork.as_mut().unwrap()
+impl<'a> From<&'a mut DatabaseFork> for salsa::OwnedDb<'a, dyn Compilation> {
+    fn from(db: &'a mut DatabaseFork) -> Self {
+        salsa::cast_owned_db!(salsa::OwnedDb::<CompilerDatabase>::from(db.fork.as_mut().unwrap()) => &mut dyn Compilation)
     }
 }
 
@@ -177,16 +177,12 @@ pub(crate) trait ImportApi: Send + Sync {
     ) -> Result<Cow<'static, str>, Error>;
     async fn load_module(
         &self,
-        compiler: &mut ModuleCompiler<'_>,
+        compiler: &mut ModuleCompiler<'_, '_>,
         vm: &Thread,
         module_id: &Symbol,
     ) -> SalvageResult<ArcType>;
     fn snapshot(&self, thread: RootedThread) -> DatabaseSnapshot;
-    fn fork(
-        &mut self,
-        forker: salsa::ForkState<CompilerDatabase>,
-        thread: RootedThread,
-    ) -> DatabaseFork;
+    fn fork(&mut self, forker: salsa::ForkState, thread: RootedThread) -> DatabaseFork;
 }
 
 #[async_trait]
@@ -204,7 +200,7 @@ where
     }
     async fn load_module(
         &self,
-        compiler: &mut ModuleCompiler<'_>,
+        compiler: &mut ModuleCompiler<'_, '_>,
         vm: &Thread,
         module_id: &Symbol,
     ) -> SalvageResult<ArcType> {
@@ -216,11 +212,7 @@ where
     fn snapshot(&self, thread: RootedThread) -> DatabaseSnapshot {
         Self::snapshot(self, thread)
     }
-    fn fork(
-        &mut self,
-        forker: salsa::ForkState<CompilerDatabase>,
-        thread: RootedThread,
-    ) -> DatabaseFork {
+    fn fork(&mut self, forker: salsa::ForkState, thread: RootedThread) -> DatabaseFork {
         Self::fork(self, forker, thread)
     }
 }
@@ -283,14 +275,13 @@ impl<I> Import<I> {
         *self.paths.write().unwrap() = paths;
     }
 
-    pub fn modules(&self, compiler: &mut ModuleCompiler<'_>) -> Vec<Cow<'static, str>> {
+    pub fn modules(&self, compiler: &mut ModuleCompiler<'_, '_>) -> Vec<Cow<'static, str>> {
         STD_LIBS
             .iter()
             .map(|t| Cow::Borrowed(t.0))
             .chain(
-                compiler
-                    .database
-                    .query(crate::query::ExternLoaderQuery)
+                crate::query::ExternLoaderQuery
+                    .in_db(&*compiler.database)
                     .entries::<Vec<_>>()
                     .into_iter()
                     .map(|entry| Cow::Owned(entry.key)),
@@ -326,11 +317,7 @@ impl<I> Import<I> {
         }
     }
 
-    pub fn fork(
-        &self,
-        forker: salsa::ForkState<CompilerDatabase>,
-        thread: RootedThread,
-    ) -> DatabaseFork {
+    pub fn fork(&self, forker: salsa::ForkState, thread: RootedThread) -> DatabaseFork {
         let fork = self.compiler.lock().unwrap().fork(forker, thread);
 
         DatabaseFork { fork: Some(fork) }
@@ -554,13 +541,14 @@ where
 
         info!("import! {}", modulename);
 
-        let mut db = try_future!(macros
+        let db = try_future!(macros
             .userdata
             .fork(macros.vm.root_thread())
             .downcast::<salsa::Snapshot<CompilerDatabase>>()
             .map_err(|_| MacroError::new(Error::String(
                 "`import` requires a `CompilerDatabase` as user data during macro expansion".into(),
             ))));
+        let mut db = DatabaseFork { fork: Some(*db) };
 
         let span = args[0].span;
 
@@ -571,10 +559,12 @@ where
             let (tx, rx) = tokio::sync::oneshot::channel();
             spawn
                 .spawn(Box::pin(async move {
-                    let result = db
-                        .import(modulename)
-                        .await
-                        .map_err(|err| MacroError::message(err.to_string()));
+                    let result = {
+                        let mut db = salsa::OwnedDb::<dyn Compilation>::from(&mut db);
+                        db.import(modulename)
+                            .await
+                            .map_err(|err| MacroError::message(err.to_string()))
+                    };
                     drop(db); // Drop the database before sending the result, otherwise the forker may drop before the forked database
                     let _ = tx.send(result);
                 }))
@@ -593,6 +583,7 @@ where
         Box::pin(async move {
             Ok(From::from(move || {
                 async move {
+                    let mut db = salsa::OwnedDb::<dyn Compilation>::from(&mut db);
                     db.import(modulename)
                         .await
                         .map_err(|err| MacroError::message(err.to_string()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ extern crate gluon_codegen;
 #[macro_use]
 pub extern crate gluon_vm as vm;
 
+pub use salsa;
+
 macro_rules! try_future {
     ($e:expr) => {
         try_future!($e, Box::pin)
@@ -85,7 +87,7 @@ use crate::vm::{
 use crate::{
     compiler_pipeline::*,
     import::{add_extern_module, add_extern_module_with_deps, DefaultImporter, Import},
-    query::{Compilation, CompilationBase, CompilationMut},
+    query::{AsyncCompilation, Compilation, CompilationBase},
 };
 
 quick_error! {
@@ -303,30 +305,30 @@ impl Default for Settings {
     }
 }
 
-pub struct ModuleCompiler<'a> {
-    pub database: &'a mut query::CompilerDatabase,
+pub struct ModuleCompiler<'a, 'b> {
+    pub database: salsa::OwnedDb<'a, dyn Compilation + 'b>,
     symbols: Symbols,
 }
 
-impl<'a> ModuleCompiler<'a> {
-    fn new(database: &'a mut query::CompilerDatabase) -> Self {
+impl<'a, 'b> ModuleCompiler<'a, 'b> {
+    fn new(database: impl Into<salsa::OwnedDb<'a, dyn Compilation + 'b>>) -> Self {
         Self {
-            database,
+            database: database.into(),
             symbols: Symbols::default(),
         }
     }
 }
 
-impl<'a> std::ops::Deref for ModuleCompiler<'a> {
-    type Target = query::CompilerDatabase;
+impl<'a, 'b> std::ops::Deref for ModuleCompiler<'a, 'b> {
+    type Target = salsa::OwnedDb<'a, dyn Compilation + 'b>;
     fn deref(&self) -> &Self::Target {
-        self.database
+        &self.database
     }
 }
 
-impl<'a> std::ops::DerefMut for ModuleCompiler<'a> {
+impl std::ops::DerefMut for ModuleCompiler<'_, '_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.database
+        &mut self.database
     }
 }
 
@@ -413,10 +415,10 @@ pub trait ThreadExt: Send + Sync {
     #[doc(hidden)]
     fn thread(&self) -> &Thread;
 
-    fn module_compiler<'a>(
+    fn module_compiler<'a, 'b>(
         &'a self,
-        database: &'a mut query::CompilerDatabase,
-    ) -> ModuleCompiler<'a> {
+        database: impl Into<salsa::OwnedDb<'a, dyn Compilation + 'b>>,
+    ) -> ModuleCompiler<'a, 'b> {
         ModuleCompiler::new(database)
     }
 
@@ -488,6 +490,7 @@ pub trait ThreadExt: Send + Sync {
             db.add_module(file.into(), expr_str.into());
         }
         let mut db = vm.get_database();
+        let mut db = salsa::OwnedDb::<dyn Compilation>::from(&mut db);
 
         let TypecheckValue { expr, typ, .. } = db
             .typechecked_source_module(file.into(), expected_type.cloned())
@@ -588,6 +591,8 @@ pub trait ThreadExt: Send + Sync {
         }
 
         let mut db = vm.get_database();
+        let mut db = salsa::OwnedDb::<dyn Compilation>::from(&mut db);
+
         let TypecheckValue {
             expr,
             typ,
@@ -627,6 +632,8 @@ pub trait ThreadExt: Send + Sync {
             db.add_module(module_name.clone(), input.into());
         }
         let mut db = vm.get_database();
+        let mut db = salsa::OwnedDb::<dyn Compilation>::from(&mut db);
+
         db.import(module_name).await.map(|_| ())
     }
 
@@ -807,7 +814,7 @@ fn get_import(vm: &Thread) -> Arc<dyn import::ImportApi> {
         .unwrap_or_else(|| panic!("Missing import macro"))
 }
 
-impl<'a> ModuleCompiler<'a> {
+impl ModuleCompiler<'_, '_> {
     pub fn mut_symbols(&mut self) -> &mut Symbols {
         &mut self.symbols
     }

--- a/src/std_lib/http.rs
+++ b/src/std_lib/http.rs
@@ -72,13 +72,13 @@ impl VmType for Headers {
 }
 
 impl<'vm> Pushable<'vm> for Headers {
-    fn push(self, context: &mut ActiveThread<'vm>) -> vm::Result<()> {
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> vm::Result<()> {
         Collect::new(
             self.0
                 .iter()
                 .map(|(name, value)| (name.as_str(), value.as_bytes())),
         )
-        .push(context)
+        .vm_push(context)
     }
 }
 

--- a/src/std_lib/regex.rs
+++ b/src/std_lib/regex.rs
@@ -2,7 +2,7 @@
 
 extern crate regex;
 
-use crate::vm::{self, api::Collect, thread::Thread, ExternModule};
+use crate::vm::{self, thread::Thread, ExternModule};
 
 #[derive(Debug, Userdata, Trace, VmType)]
 #[gluon(vm_type = "std.regex.Regex")]
@@ -52,14 +52,12 @@ fn find<'a>(re: &Regex, text: &'a str) -> Option<Match<'a>> {
     re.find(text).map(Match::new)
 }
 
-fn captures<'a>(
-    re: &Regex,
-    text: &'a str,
-) -> Option<Collect<impl Iterator<Item = Option<Match<'a>>>>> {
+fn captures<'a>(re: &Regex, text: &'a str) -> Option<Vec<Option<Match<'a>>>> {
     let &Regex(ref re) = re;
     re.captures(text)
         .map(|c| (0..c.len()).map(move |i| c.get(i).map(Match::new)))
-        .map(Collect::new)
+        // FIXME Once rust stops ICEing .map(Collect::new)
+        .map(|i| i.collect())
 }
 
 fn error_to_string(err: &Error) -> String {

--- a/tests/compile-fail/getable-reference-str.rs
+++ b/tests/compile-fail/getable-reference-str.rs
@@ -18,6 +18,6 @@ fn main() {
     let vm = new_vm();
     add_extern_module(&vm, "test", |vm| {
         ExternModule::new(vm, primitive!(1, f))
-        //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
+        //~^ `thread` has lifetime `'thread` but it needs to satisfy a `'static` lifetime requirement
     });
 }

--- a/tests/compile-fail/getable-reference.rs
+++ b/tests/compile-fail/getable-reference.rs
@@ -30,6 +30,6 @@ fn main() {
     let vm = new_vm();
     add_extern_module(&vm, "test", |vm| {
         ExternModule::new(vm, primitive!(1, f))
-        //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
+        //~^ `thread` has lifetime `'thread` but it needs to satisfy a `'static` lifetime requirement
     });
 }

--- a/tests/compile-fail/store-ref.rs
+++ b/tests/compile-fail/store-ref.rs
@@ -41,6 +41,6 @@ fn main() {
     let vm = new_vm();
     add_extern_module(&vm, "test", |vm| {
         ExternModule::new(vm, primitive!(2, f))
-        //~^ cannot infer an appropriate lifetime for lifetime parameter `'vm` due to conflicting requirements
+        //~^ `thread` has lifetime `'thread` but it needs to satisfy a `'static` lifetime requirement
     });
 }

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -1091,3 +1091,15 @@ let tell : Eff [| writer : Writer | r |] () =
 "#,
 ()
 }
+
+test_expr! { issue_863,
+r"
+#[infix(right, 0)]
+let (<|) f x : (a -> b) -> a -> b = f x
+
+let g f x = x
+let f a =
+    g a <| f a
+{ f }
+"
+}

--- a/vm/src/api/function.rs
+++ b/vm/src/api/function.rs
@@ -358,13 +358,13 @@ vm_function_impl!([dyn Fn] $($args),*);
 
 impl <'vm, $($args,)* R: VmType> FunctionType for fn ($($args),*) -> R {
     fn arguments() -> VmIndex {
-        count!($($args),*) + R::extra_args()
+        count!($($args),*) + R::EXTRA_ARGS
     }
 }
 
 impl <'s, $($args,)* R: VmType> FunctionType for dyn Fn($($args),*) -> R + 's {
     fn arguments() -> VmIndex {
-        count!($($args),*) + R::extra_args()
+        count!($($args),*) + R::EXTRA_ARGS
     }
 }
 
@@ -400,10 +400,10 @@ impl<T, $($args,)* R> Function<T, fn($($args),*) -> R>
         $(
             $args.push(&mut context)?;
         )*
-        for _ in 0..R::extra_args() {
+        for _ in 0..R::EXTRA_ARGS {
             0.push(&mut context).unwrap();
         }
-        let args = count!($($args),*) + R::extra_args();
+        let args = count!($($args),*) + R::EXTRA_ARGS;
         let context =  ready!(vm.call_function(cx, context.into_owned(), args))?;
         let mut context = context.unwrap();
         let result = {
@@ -510,12 +510,12 @@ where
         let mut context = vm.current_context();
         context.push(self.value.get_variant());
 
-        let mut arg_count = R::extra_args();
+        let mut arg_count = R::EXTRA_ARGS;
         for arg in args {
             arg_count += 1;
             arg.push(&mut context)?;
         }
-        for _ in 0..R::extra_args() {
+        for _ in 0..R::EXTRA_ARGS {
             0.push(&mut context).unwrap();
         }
         let context = ready!(vm.call_function(cx, context.into_owned(), arg_count))?;
@@ -561,9 +561,7 @@ impl<T: VmType> VmType for TypedBytecode<T> {
         T::make_forall_type(vm)
     }
 
-    fn extra_args() -> VmIndex {
-        T::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = T::EXTRA_ARGS;
 }
 
 impl<'vm, T: VmType> Pushable<'vm> for TypedBytecode<T> {

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -321,9 +321,7 @@ impl<T: VmType> VmType for Unrooted<T> {
         T::make_type(vm)
     }
 
-    fn extra_args() -> VmIndex {
-        T::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = T::EXTRA_ARGS;
 }
 impl<'vm, T: VmType> Pushable<'vm> for Unrooted<T> {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
@@ -460,9 +458,7 @@ pub trait VmType {
     /// How many extra arguments a function returning this type requires.
     /// Used for abstract types which when used in return position should act like they still need
     /// more arguments before they are called
-    fn extra_args() -> VmIndex {
-        0
-    }
+    const EXTRA_ARGS: VmIndex = 0;
 }
 
 /// Trait which allows a possibly asynchronous rust value to be pushed to the virtual machine
@@ -617,9 +613,7 @@ impl<'vm, T: ?Sized + VmType> VmType for PhantomData<T> {
     fn make_type(vm: &Thread) -> ArcType {
         T::make_type(vm)
     }
-    fn extra_args() -> VmIndex {
-        T::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = T::EXTRA_ARGS;
 }
 
 /// Wrapper which extracts a `Userdata` value from gluon
@@ -640,9 +634,7 @@ where
         T::make_forall_type(vm)
     }
 
-    fn extra_args() -> VmIndex {
-        T::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = T::EXTRA_ARGS;
 }
 
 impl<'vm, 'value, T> Getable<'vm, 'value> for UserdataValue<T>
@@ -783,9 +775,7 @@ where
         T::make_type(vm)
     }
 
-    fn extra_args() -> VmIndex {
-        T::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = T::EXTRA_ARGS;
 }
 
 impl<'vm, T> Pushable<'vm> for WithVM<'vm, T>
@@ -1470,9 +1460,7 @@ where
     fn make_type(vm: &Thread) -> ArcType {
         <F::Output>::make_type(vm)
     }
-    fn extra_args() -> VmIndex {
-        <F::Output>::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = F::Output::EXTRA_ARGS;
 }
 
 impl<'vm, F> AsyncPushable<'vm> for FutureResult<F>
@@ -1519,9 +1507,7 @@ impl<T: VmType, E> VmType for RuntimeResult<T, E> {
         T::make_type(vm)
     }
 
-    fn extra_args() -> VmIndex {
-        T::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = T::EXTRA_ARGS;
 }
 impl<'vm, T: Pushable<'vm>, E: fmt::Display> Pushable<'vm> for RuntimeResult<T, E> {
     fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
@@ -1552,9 +1538,8 @@ where
         let alias = env.find_type_info("std.io.IO").unwrap();
         Type::app(alias.into_type(), collect![T::make_type(vm)])
     }
-    fn extra_args() -> VmIndex {
-        1
-    }
+
+    const EXTRA_ARGS: VmIndex = 1;
 }
 
 impl<'vm, 'value, T: Getable<'vm, 'value>> Getable<'vm, 'value> for IO<T> {
@@ -1750,9 +1735,7 @@ impl<T: VmType> VmType for Pushed<T> {
         T::make_forall_type(vm)
     }
 
-    fn extra_args() -> VmIndex {
-        T::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = T::EXTRA_ARGS;
 }
 
 impl<'vm, T: VmType> Pushable<'vm> for Pushed<T> {

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -369,8 +369,8 @@ where
     T: Pushable<'vm>,
     V: ?Sized,
 {
-    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        self.0.push(context)
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+        self.0.vm_push(context)
     }
 }
 

--- a/vm/src/api/opaque.rs
+++ b/vm/src/api/opaque.rs
@@ -361,9 +361,7 @@ where
         V::make_type(vm)
     }
 
-    fn extra_args() -> VmIndex {
-        V::extra_args()
-    }
+    const EXTRA_ARGS: VmIndex = V::EXTRA_ARGS;
 }
 
 impl<'s, 'value, 'vm, T, V> Pushable<'vm> for Opaque<T, V>

--- a/vm/src/api/record.rs
+++ b/vm/src/api/record.rs
@@ -37,7 +37,7 @@ pub trait FieldValues: HList {
 }
 
 pub trait PushableFieldList<'vm>: HList {
-    fn push(
+    fn vm_push(
         self,
         context: &mut ActiveThread<'vm>,
         field_names: &mut Vec<InternedStr>,
@@ -49,7 +49,7 @@ pub trait GetableFieldList<'vm, 'value>: HList + Sized {
 }
 
 impl<'vm> PushableFieldList<'vm> for HNil {
-    fn push(self, _: &mut ActiveThread, _: &mut Vec<InternedStr>) -> Result<()> {
+    fn vm_push(self, _: &mut ActiveThread, _: &mut Vec<InternedStr>) -> Result<()> {
         Ok(())
     }
 }
@@ -166,15 +166,15 @@ impl<'vm, F: Field, H: Pushable<'vm>, T> PushableFieldList<'vm> for HCons<(F, H)
 where
     T: PushableFieldList<'vm>,
 {
-    fn push(
+    fn vm_push(
         self,
         context: &mut ActiveThread<'vm>,
         field_names: &mut Vec<InternedStr>,
     ) -> Result<()> {
         let ((_, head), tail) = self.pluck();
         field_names.push(context.thread().global_env().intern(F::name())?);
-        head.push(context)?;
-        tail.push(context, field_names)
+        head.vm_push(context)?;
+        tail.vm_push(context, field_names)
     }
 }
 
@@ -205,9 +205,9 @@ impl<'vm, T, U> Pushable<'vm> for Record<T, U>
 where
     U: PushableFieldList<'vm>,
 {
-    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
         let mut field_names = Vec::new();
-        self.fields.push(context, &mut field_names)?;
+        self.fields.vm_push(context, &mut field_names)?;
 
         let mut context = context.context();
 

--- a/vm/src/api/scoped.rs
+++ b/vm/src/api/scoped.rs
@@ -39,8 +39,8 @@ impl<'vm, 'a, 'b, T> Pushable<'vm> for &'b mut Ref<'a, T>
 where
     T: VmType + Userdata,
 {
-    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        Scoped::<T, _>::new(self.reference).push(context)?;
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+        Scoped::<T, _>::new(self.reference).vm_push(context)?;
         let value = context.last().unwrap();
         self.gluon_reference = Some(RefGuard {
             gluon_reference: Opaque::from_value(context.thread().root_value(value)),
@@ -83,8 +83,8 @@ impl<'vm, 'a, 'b, T> Pushable<'vm> for &'b mut RefMut<'a, T>
 where
     T: VmType + Userdata,
 {
-    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
-        Scoped::<T, _>::new_mut(self.reference).push(context)?;
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+        Scoped::<T, _>::new_mut(self.reference).vm_push(context)?;
         let value = context.last().unwrap();
         self.gluon_reference = Some(RefGuard {
             gluon_reference: Opaque::from_value(context.thread().root_value(value)),

--- a/vm/src/api/ser.rs
+++ b/vm/src/api/ser.rs
@@ -164,7 +164,7 @@ impl<'vm, T> Pushable<'vm> for Ser<T>
 where
     T: Serialize,
 {
-    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
         let mut serializer = Serializer::new(context);
         self.0.serialize(&mut serializer)
     }
@@ -196,7 +196,7 @@ impl<'a, 't> Serializer<'a, 't> {
     where
         T: Pushable<'t>,
     {
-        value.push(self.context)
+        value.vm_push(self.context)
     }
 
     fn alloc(&mut self, tag: VmTag, values: VmIndex) -> Result<()> {

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -229,7 +229,7 @@ fn spawn_<'vm>(value: WithVM<'vm, Function<&'vm Thread, fn(())>>) -> VmResult<Ro
         };
         value_variant.clone().push(&mut context)?;
         context.push(ValueRepr::Int(0));
-        context.context().stack.enter_scope(1, &*callable);
+        context.context().stack.enter_scope(1, &*callable)?;
     }
     Ok(thread)
 }

--- a/vm/src/channel.rs
+++ b/vm/src/channel.rs
@@ -227,7 +227,7 @@ fn spawn_<'vm>(value: WithVM<'vm, Function<&'vm Thread, fn(())>>) -> VmResult<Ro
             }
             _ => gc::Borrow::from_static(State::Unknown),
         };
-        value_variant.clone().push(&mut context)?;
+        value_variant.clone().vm_push(&mut context)?;
         context.push(ValueRepr::Int(0));
         context.context().stack.enter_scope(1, &*callable)?;
     }
@@ -309,7 +309,7 @@ fn spawn_on<'vm>(
                 + 'static,
             ]
         )
-        .push(context)
+        .vm_push(context)
         .unwrap();
     }
     use crate::value::PartialApplicationDataDef;
@@ -323,7 +323,7 @@ fn spawn_on<'vm>(
 
     push_future_wrapper(&mut context, &future);
 
-    SpawnFuture(future.shared()).push(&mut context).unwrap();
+    SpawnFuture(future.shared()).vm_push(&mut context).unwrap();
 
     let mut context = context.context();
     let callable = match context.stack[context.stack.len() - 2].get_repr() {

--- a/vm/src/lazy.rs
+++ b/vm/src/lazy.rs
@@ -135,7 +135,7 @@ fn force(
                                 *lazy_lock = Lazy_::Value(value.get_variant().unrooted());
                             }
                         }
-                        value.push(&mut vm.current_context()).unwrap();
+                        value.vm_push(&mut vm.current_context()).unwrap();
                         RuntimeResult::Return(Pushed::default())
                     }
                     Err(err) => RuntimeResult::Panic(format!("{}", err).into()),

--- a/vm/src/macros.rs
+++ b/vm/src/macros.rs
@@ -317,7 +317,7 @@ where
     }
 }
 
-pub trait MacroUserdata: Send + Sync {
+pub trait MacroUserdata: Send {
     fn fork(&self, thread: RootedThread) -> Box<dyn Any>;
 }
 
@@ -379,7 +379,7 @@ impl MacroEnv {
     pub async fn run<'ast>(
         &self,
         vm: &Thread,
-        userdata: &(dyn MacroUserdata + '_),
+        userdata: &mut (dyn MacroUserdata + '_),
         spawn: Option<&(dyn Spawn + Send + Sync + '_)>,
         symbols: &mut Symbols,
         arena: ast::OwnedArena<'ast, Symbol>,
@@ -395,7 +395,7 @@ pub struct MacroExpander<'a> {
     pub state: FnvMap<String, Box<dyn Any + Send>>,
     pub vm: &'a Thread,
     pub errors: Errors,
-    pub userdata: &'a (dyn MacroUserdata + 'a),
+    pub userdata: &'a mut (dyn MacroUserdata + 'a),
     pub spawn: Option<&'a (dyn Spawn + Send + Sync + 'a)>,
     macros: &'a MacroEnv,
 }
@@ -403,7 +403,7 @@ pub struct MacroExpander<'a> {
 impl<'a> MacroExpander<'a> {
     pub fn new(
         vm: &'a Thread,
-        userdata: &'a (dyn MacroUserdata + 'a),
+        userdata: &'a mut (dyn MacroUserdata + 'a),
         spawn: Option<&'a (dyn Spawn + Send + Sync + 'a)>,
     ) -> Self {
         MacroExpander {
@@ -416,12 +416,12 @@ impl<'a> MacroExpander<'a> {
         }
     }
 
-    pub fn fork(&self) -> MacroExpander<'a> {
+    pub fn fork(&self, userdata: &'a mut (dyn MacroUserdata + 'a)) -> MacroExpander<'a> {
         MacroExpander {
             vm: self.vm,
             state: FnvMap::default(),
             macros: self.macros,
-            userdata: self.userdata,
+            userdata,
             spawn: self.spawn,
             errors: Errors::new(),
         }

--- a/vm/src/primitives.rs
+++ b/vm/src/primitives.rs
@@ -321,7 +321,7 @@ extern "C" fn discriminant_value(thread: &Thread) -> Status {
             _ => 0,
         }
     };
-    tag.push(&mut context).unwrap();
+    tag.vm_push(&mut context).unwrap();
     Status::Ok
 }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -1815,22 +1815,18 @@ impl<'b> OwnedContext<'b> {
                 }) => {
                     let instruction_index = *instruction_index;
 
-                    if context.stack.stack().get_frames().len() == 0 {
-                        return Ok(Some(self)).into();
-                    } else {
-                        debug!(
-                            "Continue with {}\nAt: {}/{}\n{:?}",
-                            closure.function.name,
-                            instruction_index,
-                            closure.function.instructions.len(),
-                            &context.stack[..]
-                        );
+                    debug!(
+                        "Continue with {}\nAt: {}/{}\n{:?}",
+                        closure.function.name,
+                        instruction_index,
+                        closure.function.instructions.len(),
+                        &context.stack[..]
+                    );
 
-                        let closure_context = context.from_state();
-                        match ready!(closure_context.execute_())? {
-                            Some(new_context) => context = new_context,
-                            None => return Ok(None).into(),
-                        }
+                    let closure_context = context.from_state();
+                    match ready!(closure_context.execute_())? {
+                        Some(new_context) => context = new_context,
+                        None => return Ok(None).into(),
                     }
                 }
             };

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -512,7 +512,7 @@ impl VmType for RootedThread {
 }
 
 impl<'vm> Pushable<'vm> for RootedThread {
-    fn push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
+    fn vm_push(self, context: &mut ActiveThread<'vm>) -> Result<()> {
         context.push(construct_gc!(ValueRepr::Thread(@&self.thread)));
         Ok(())
     }
@@ -932,7 +932,7 @@ impl Thread {
         T: Pushable<'vm>,
     {
         let mut context = self.current_context();
-        v.push(&mut context)
+        v.vm_push(&mut context)
     }
 
     /// Removes the top value from the stack
@@ -1618,7 +1618,7 @@ impl Context {
                 context.stack().release_lock(lock);
                 let context =
                     mem::transmute::<&mut ActiveThread<'_>, &mut ActiveThread<'vm>>(&mut context);
-                value.push(context)
+                value.vm_push(context)
             };
             Poll::Ready(result.map(|()| context.into_owned()))
         });

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -2100,7 +2100,7 @@ impl<'b, 'gc> ExecuteContext<'b, 'gc> {
 
             debug_instruction(&self.stack, instruction_index, instr);
 
-            if self.hook.flags.contains(HookFlags::LINE_FLAG) {
+            if !self.hook.flags.is_empty() && self.hook.flags.contains(HookFlags::LINE_FLAG) {
                 ready!(self.run_hook(&function, instruction_index))?;
             }
 

--- a/vm/src/thread.rs
+++ b/vm/src/thread.rs
@@ -692,7 +692,7 @@ impl RootedThread {
         // Enter the top level scope
         {
             let mut context = vm.context.lock().unwrap();
-            StackFrame::<State>::new_frame(&mut context.stack, 0, State::Unknown);
+            StackFrame::<State>::new_frame(&mut context.stack, 0, State::Unknown).unwrap();
         }
         vm
     }
@@ -758,7 +758,7 @@ impl Thread {
         // Enter the top level scope
         {
             let mut context = vm.owned_context();
-            StackFrame::<State>::new_frame(&mut context.stack, 0, State::Unknown);
+            StackFrame::<State>::new_frame(&mut context.stack, 0, State::Unknown).unwrap();
         }
         let ptr = {
             let mut context = self.context();
@@ -1164,7 +1164,7 @@ impl ThreadInternal for Thread {
                         @closure: gc::Borrow::new(closure),
                         instruction_index: 0,
                     }),
-                );
+                )?;
                 let mut context = match context.execute(cx) {
                     Poll::Pending => {
                         fut = Some(Execute::new(self.root_thread()));
@@ -1198,7 +1198,9 @@ impl ThreadInternal for Thread {
                         .stack
                         .extend(&[Variants::int(0), value.clone(), Variants::int(0)]);
 
-                    context.borrow_mut().enter_scope(2, &State::Unknown, false);
+                    context
+                        .borrow_mut()
+                        .enter_scope(2, &State::Unknown, false)?;
                     context = match self.call_function(cx, context, 1) {
                         Poll::Pending => {
                             fut = Some(Execute::new(self.root_thread()));
@@ -1497,7 +1499,6 @@ pub struct Context {
     pub(crate) gc: Gc,
     #[cfg_attr(feature = "serde_derive", serde(skip))]
     hook: Hook,
-    max_stack_size: VmIndex,
 
     /// Stack of polling functions used for extern functions returning futures
     #[cfg_attr(feature = "serde_derive", serde(skip))]
@@ -1514,7 +1515,6 @@ impl Context {
                 flags: HookFlags::empty(),
                 previous_instruction_index: usize::max_value(),
             },
-            max_stack_size: VmIndex::max_value(),
             poll_fns: Vec::new(),
         }
     }
@@ -1590,7 +1590,7 @@ impl Context {
     }
 
     pub fn set_max_stack_size(&mut self, limit: VmIndex) {
-        self.max_stack_size = limit;
+        self.stack.set_max_stack_size(limit);
     }
 
     pub fn stacktrace(&self, frame_level: usize) -> crate::stack::Stacktrace {
@@ -1813,16 +1813,7 @@ impl<'b> OwnedContext<'b> {
                     closure,
                     instruction_index,
                 }) => {
-                    let max_stack_size = context.max_stack_size;
                     let instruction_index = *instruction_index;
-                    let function_size = closure.function.max_stack_size;
-
-                    // Before entering a function check that the stack cannot exceed `max_stack_size`
-                    if instruction_index == 0
-                        && context.stack.stack().len() + function_size > max_stack_size
-                    {
-                        return Err(Error::StackOverflow(max_stack_size)).into();
-                    }
 
                     if context.stack.stack().get_frames().len() == 0 {
                         return Ok(Some(self)).into();
@@ -1988,7 +1979,6 @@ impl<'b> OwnedContext<'b> {
             gc: &mut context.gc,
             stack: StackFrame::current(&mut context.stack),
             hook: &mut context.hook,
-            max_stack_size: context.max_stack_size,
             poll_fns: &context.poll_fns,
         }
     }
@@ -2023,7 +2013,6 @@ pub struct ExecuteContext<'b, 'gc, S: StackState = ClosureState> {
     pub stack: StackFrame<'b, S>,
     pub gc: &'gc mut Gc,
     hook: &'b mut Hook,
-    max_stack_size: VmIndex,
     poll_fns: &'b [PollFn],
 }
 
@@ -2561,7 +2550,6 @@ impl<'b, 'gc> ExecuteContext<'b, 'gc, State> {
             stack: self.stack.from_state(),
             gc: self.gc,
             hook: self.hook,
-            max_stack_size: self.max_stack_size,
             poll_fns: self.poll_fns,
         }
     }
@@ -2577,25 +2565,28 @@ where
             stack: self.stack.to_state(),
             gc: self.gc,
             hook: self.hook,
-            max_stack_size: self.max_stack_size,
             poll_fns: self.poll_fns,
         }
     }
 
-    fn enter_scope<T>(self, args: VmIndex, state: &T, excess: bool) -> ExecuteContext<'b, 'gc, T>
+    fn enter_scope<T>(
+        self,
+        args: VmIndex,
+        state: &T,
+        excess: bool,
+    ) -> Result<ExecuteContext<'b, 'gc, T>>
     where
         T: StackState,
     {
-        let stack = self.stack.enter_scope_excess(args, state.clone(), excess);
+        let stack = self.stack.enter_scope_excess(args, state.clone(), excess)?;
         self.hook.previous_instruction_index = usize::max_value();
-        ExecuteContext {
+        Ok(ExecuteContext {
             thread: self.thread,
             stack,
             gc: self.gc,
             hook: self.hook,
-            max_stack_size: self.max_stack_size,
             poll_fns: self.poll_fns,
-        }
+        })
     }
 
     fn exit_scope(
@@ -2616,7 +2607,6 @@ where
                     stack,
                     gc: self.gc,
                     hook: self.hook,
-                    max_stack_size: self.max_stack_size,
                     poll_fns: self.poll_fns,
                 })
             }
@@ -2625,7 +2615,6 @@ where
                 stack: StackFrame::current(stack),
                 gc: self.gc,
                 hook: self.hook,
-                max_stack_size: self.max_stack_size,
                 poll_fns: self.poll_fns,
             }),
         }
@@ -2635,28 +2624,30 @@ where
         self,
         closure: &GcPtr<ClosureData>,
         excess: bool,
-    ) -> ExecuteContext<'b, 'gc, State> {
+    ) -> Result<ExecuteContext<'b, 'gc, State>> {
         info!("Call {} {:?}", closure.function.name, &self.stack[..]);
-        self.enter_scope(
-            closure.function.args,
-            &*construct_gc!(ClosureState {
-                @closure,
-                instruction_index: 0,
-            }),
-            excess,
-        )
-        .to_state()
+        Ok(self
+            .enter_scope(
+                closure.function.args,
+                &*construct_gc!(ClosureState {
+                    @closure,
+                    instruction_index: 0,
+                }),
+                excess,
+            )?
+            .to_state())
     }
 
     fn enter_extern(
         self,
         ext: &GcPtr<ExternFunction>,
         excess: bool,
-    ) -> ExecuteContext<'b, 'gc, State> {
+    ) -> Result<ExecuteContext<'b, 'gc, State>> {
         assert!(self.stack.len() >= ext.args + 1);
         info!("Call {} {:?}", ext.id, &self.stack[..]);
-        self.enter_scope(ext.args, &*ExternState::new(ext), excess)
-            .to_state()
+        Ok(self
+            .enter_scope(ext.args, &*ExternState::new(ext), excess)?
+            .to_state())
     }
 
     fn call_function_with_upvars(
@@ -2664,14 +2655,14 @@ where
         args: VmIndex,
         required_args: VmIndex,
         callable: &Callable,
-        enter_scope: impl FnOnce(Self, bool) -> ExecuteContext<'b, 'gc, State>,
+        enter_scope: impl FnOnce(Self, bool) -> Result<ExecuteContext<'b, 'gc, State>>,
     ) -> Result<ExecuteContext<'b, 'gc, State>> {
         trace!("cmp {} {} {:?} {:?}", args, required_args, callable, {
             let function_index = self.stack.len() - 1 - args;
             &(*self.stack)[(function_index + 1) as usize..]
         });
         match args.cmp(&required_args) {
-            Ordering::Equal => Ok(enter_scope(self, false)),
+            Ordering::Equal => enter_scope(self, false),
             Ordering::Less => {
                 let app = {
                     let fields = &self.stack[self.stack.len() - args..];
@@ -2707,7 +2698,7 @@ where
                     &(*self.stack)[..],
                     self.stack.stack().get_frames()
                 );
-                Ok(enter_scope(self, true))
+                enter_scope(self, true)
             }
         }
     }
@@ -2908,7 +2899,6 @@ impl<'vm> ActiveThread<'vm> {
             gc: &mut context.gc,
             stack: StackFrame::current(&mut context.stack),
             hook: &mut context.hook,
-            max_stack_size: context.max_stack_size,
             poll_fns: &context.poll_fns,
         }
     }


### PR DESCRIPTION
Took care of some low hanging stuff and then decided to compare against https://github.com/khvzak/mlua . There may be some additional overhead compared to calling lua raw I guess, but we are still in the same ballpark so doing any improvements here seems fairly futile (general vm performance improvements like inlining still needs work though).

cc #858 cc @anvoker

```
identity                time:   [186.46 ns 187.29 ns 188.17 ns]
                        change: [-3.3246% -2.5457% -1.7372%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

identity lua            time:   [179.16 ns 180.01 ns 180.88 ns]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```