### PR TITLE
fix missing code markup in applicative doc

### DIFF
--- a/std/applicative.glu
+++ b/std/applicative.glu
@@ -8,10 +8,10 @@ let { Functor, map } = import! std.functor
 ///
 /// The following laws should hold:
 ///
-/// * wrap id <*> v = v
-/// * wrap (<<) <*> u <*> v <*> w = u <*> (v <*> w)
-/// * wrap f <*> wrap x = wrap (f x)
-/// * u <*> wrap y = wrap (\g -> g x) <*> u
+/// * `wrap id <*> v = v`
+/// * `wrap (<<) <*> u <*> v <*> w = u <*> (v <*> w)`
+/// * `wrap f <*> wrap x = wrap (f x)`
+/// * `u <*> wrap y = wrap (\g -> g x) <*> u`
 #[implicit]
 type Applicative (f : Type -> Type) = {
     functor : Functor f,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2196156/90028542-613cf980-dcec-11ea-843d-c26df693d8b3.png)
