### PR TITLE
fix: Prevent zero-argument functions from being created in Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ branches:
 
 matrix:
   include:
-  - rust: nightly-2020-07-26
+  - rust: nightly-2020-09-12
     #  - rust: beta
   - rust: stable
     env: ARCH=i686
@@ -29,7 +29,7 @@ matrix:
       - PUBLISH=1
       - TARGET=x86_64-unknown-linux-gnu
 
-  - rust: nightly-2020-03-12
+  - rust: nightly-2020-09-12
     env: WASM=1
 
     # Only for deployment

--- a/base/src/types/mod.rs
+++ b/base/src/types/mod.rs
@@ -3230,7 +3230,7 @@ where
     type Context = NullInterner;
 
     fn context(&mut self) -> &mut Self::Context {
-        &mut NullInterner
+        NullInterner::new()
     }
 
     fn visit(&mut self, typ: &T) -> Option<T>
@@ -3816,13 +3816,15 @@ where
 
 pub type SharedInterner<Id, T> = TypeCache<Id, T>;
 
-pub struct NullInternerInner;
-// Workaround since &mut NullInterner does not get promoted to a `&'static mut NullInterner` but
-// `&mut []` does
-pub type NullInterner = [NullInternerInner; 0];
+#[derive(Default)]
+pub struct NullInterner;
 
-#[allow(non_upper_case_globals)]
-pub const NullInterner: NullInterner = [];
+impl NullInterner {
+    pub fn new() -> &'static mut NullInterner {
+        // SAFETY NullInterner is zero-sized
+        unsafe { &mut *(&mut NullInterner as *mut _) }
+    }
+}
 
 impl<Id, T> TypeContext<Id, T> for NullInterner
 where
@@ -4267,7 +4269,7 @@ where
     type Context = NullInterner;
 
     fn context(&mut self) -> &mut Self::Context {
-        &mut NullInterner
+        NullInterner::new()
     }
 
     fn visit(&mut self, typ: &T) -> Option<T>
@@ -4304,7 +4306,7 @@ where
     type Context = NullInterner;
 
     fn context(&mut self) -> &mut Self::Context {
-        &mut NullInterner
+        NullInterner::new()
     }
 
     fn visit(&mut self, typ: &T) -> Option<T>

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -152,7 +152,8 @@ where
                 self.stack.insert(id.name.clone(), id.typ.clone());
             }
             Pattern::Record { typ, fields, .. } => {
-                let unaliased = resolve::remove_aliases(&self.env, &mut NullInterner, typ.clone());
+                let unaliased =
+                    resolve::remove_aliases(&self.env, NullInterner::new(), typ.clone());
                 for field in &**fields {
                     match field {
                         PatternField::Type { name } => {
@@ -359,7 +360,7 @@ where
                     if ident.span.containment(self.pos) == Ordering::Equal {
                         let record_type = resolve::remove_aliases(
                             &crate::base::ast::EmptyEnv::default(),
-                            &mut NullInterner,
+                            NullInterner::new(),
                             record_type.clone(),
                         );
                         let either = record_type
@@ -1303,7 +1304,7 @@ impl SuggestionQuery {
                         Pattern::Constructor(ref id, _) | Pattern::Ident(ref id) => id.as_ref(),
                         Pattern::Record { ref fields, .. } => {
                             if let Ok(typ) = expr.try_type_of(&env) {
-                                let typ = resolve::remove_aliases(env, &mut NullInterner, typ);
+                                let typ = resolve::remove_aliases(env, NullInterner::new(), typ);
                                 self.suggest_fields_of_type(&mut result, fields, "", &typ);
                             }
                             ""
@@ -1325,7 +1326,7 @@ impl SuggestionQuery {
                     Match::Expr(context) => match context.value {
                         Expr::Projection(ref expr, _, _) => {
                             if let Ok(typ) = expr.try_type_of(&env) {
-                                let typ = resolve::remove_aliases(&env, &mut NullInterner, typ);
+                                let typ = resolve::remove_aliases(&env, NullInterner::new(), typ);
                                 let id = ident.as_ref();
 
                                 let iter = typ
@@ -1368,7 +1369,7 @@ impl SuggestionQuery {
                             },
                         ..
                     }) => {
-                        let typ = resolve::remove_aliases_cow(env, &mut NullInterner, typ);
+                        let typ = resolve::remove_aliases_cow(env, NullInterner::new(), typ);
                         self.suggest_fields_of_type(
                             &mut result,
                             fields,
@@ -1409,7 +1410,7 @@ impl SuggestionQuery {
                 Match::Pattern(pattern) => match pattern.value {
                     Pattern::Record { ref fields, .. } => {
                         if let Ok(typ) = pattern.try_type_of(env) {
-                            let typ = resolve::remove_aliases(env, &mut NullInterner, typ);
+                            let typ = resolve::remove_aliases(env, NullInterner::new(), typ);
                             self.suggest_fields_of_type(&mut result, fields, "", &typ);
                         }
                     }

--- a/tests/compile-fail/run_expr_str_ref.rs
+++ b/tests/compile-fail/run_expr_str_ref.rs
@@ -6,5 +6,5 @@ fn main() {
     let vm = new_vm();
 
     let _ = vm.run_expr::<&str>("", r#" "test" "#);
-    //~^ the trait bound `for<'value> &str: gluon::gluon_vm::api::Getable<'_, 'value>` is not satisfied [E0277]
+    //~^ the trait bound `for<'value> &str: Getable<'_, 'value>` is not satisfied [E0277]
 }


### PR DESCRIPTION
These cannot be called from the gluon side, instead a one argument
function that takes `()` should be used.

bors r+

Fixes #873