### PR TITLE
 feat: Compile block expressions as monadic sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "expect-test"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceb96f3eaa0d4e8769c52dacfd4eb60183b817ed2f176171b3c691d5022b0f2e"
+dependencies = [
+ "difference",
+ "once_cell",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1302,7 @@ dependencies = [
  "codespan",
  "difference",
  "env_logger 0.7.1",
+ "expect-test",
  "futures 0.3.5",
  "gluon",
  "gluon_base",

--- a/benches/function_call.rs
+++ b/benches/function_call.rs
@@ -71,16 +71,16 @@ fn gluon_rust_boundary_overhead(b: &mut Bencher) {
         if n #Int== 0 then
             ()
         else
-            f n
-            f n
-            f n
-            f n
-            f n
-            f n
-            f n
-            f n
-            f n
-            f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
+            let _ = f n
             for (n #Int- 10) f
     for
     "#;

--- a/book/src/metadata.md
+++ b/book/src/metadata.md
@@ -83,8 +83,8 @@ type Tree a = | Tip a | Branch (Tree a) (Tree a)
 
 let tree = Branch (Tip 1) (Branch (Tip 2) (Tip 3))
 
-show tree
-tree == Tip 1
+let tree_str = show tree // "Branch (Tip 1) (Branch (Tip 2) (Tip 3))"
+tree == Tip 1 // False
 ```
 
 ### #[doc(hidden)]

--- a/book/src/syntax-and-semantics.md
+++ b/book/src/syntax-and-semantics.md
@@ -340,19 +340,21 @@ Sequence expressions work just like `do` expressions, only they do not have a bi
 
 ```f#,rust
 let io @ { ? } = import! std.io
+seq io.print "Hello"
+seq io.print " "
+io.println "world!"
+```
+
+The `seq` keyword can also be omitted.
+
+```f#,rust
+let io @ { ? } = import! std.io
 io.print "Hello"
 io.print " "
 io.println "world!"
 ```
 
-For backwards compatibility it is also possible to write (`seq`) before each expression.
-
-```f#,rust
-let io @ { ? } = import! std.io
-seq io.print "Hello"
-seq io.print " "
-io.println "world!"
-```
+(In the future one of these ways are likely to be deprecated with only one way remaining, the formatter will be able to update the code in any case).
 
 ### Indentation
 

--- a/book/src/syntax-and-semantics.md
+++ b/book/src/syntax-and-semantics.md
@@ -8,7 +8,7 @@ If, on the other hand, you are familiar with functional languages you will be ri
 
 ### Identifiers and Literals
 
-The simplest syntactical elements in Gluon are identifiers and literals and none of them should be especially surprising if you are experienced in programming. 
+The simplest syntactical elements in Gluon are identifiers and literals and none of them should be especially surprising if you are experienced in programming.
 
 Identifiers are a sequence of alphanumeric characters including underscore ("\_") which are required to start with either a letter or an underscore. Literals come in four different forms - integer, float, string and character literals.
 
@@ -37,7 +37,7 @@ r###" "## "###
 
 ### Comments
 
-Comments should be immediately familiar if you are accustomed to C-like languages. 
+Comments should be immediately familiar if you are accustomed to C-like languages.
 
 `//` starts a line comment which is ended by a newline
 
@@ -206,7 +206,9 @@ Here, we write out a pattern for each of the variant's constructors and the valu
 ```f#,rust
 match { x = 1.0, pi = 3.14 } with
 | { x = y, pi } -> y + pi
+```
 
+```f#,rust
 // Patterns can be nested as well
 match { x = Some (Some 123) } with
 | { x = Some None } -> 0
@@ -270,6 +272,9 @@ While we have seen that functions can be defined in let expressions it is often 
 ```f#,rust
 // \(<identifier)* -> <expr>
 \x y -> x + y - 10
+```
+
+```f#,rust
 // Equivalent to
 let f x y = x + y - 10 in f
 ```
@@ -386,7 +391,7 @@ module.id module.pi
 
 ## Typesystem
 
-In gluon, identifiers starting with an uppercase letter is a type whereas identifiers starting with a lowercase letter are type variables. 
+In gluon, identifiers starting with an uppercase letter is a type whereas identifiers starting with a lowercase letter are type variables.
 
 ### Function types
 

--- a/book/src/syntax-and-semantics.md
+++ b/book/src/syntax-and-semantics.md
@@ -334,9 +334,18 @@ do { y } = Some { y = "" }
 Some y
 ```
 
-### Seq expressions
+### Sequence expressions
 
-`seq` expressions work just like `do` expressions, only they do not have a binding.
+Sequence expressions work just like `do` expressions, only they do not have a binding.
+
+```f#,rust
+let io @ { ? } = import! std.io
+io.print "Hello"
+io.print " "
+io.println "world!"
+```
+
+For backwards compatibility it is also possible to write (`seq`) before each expression.
 
 ```f#,rust
 let io @ { ? } = import! std.io

--- a/check/tests/effect.rs
+++ b/check/tests/effect.rs
@@ -23,7 +23,7 @@ test_check! {
 test_check_err! {
     not_variant_effect,
     r#"
-    convert_effect! ()
+    let _ = convert_effect! ()
     convert_effect! 1
     "#,
     TypeError::Message(_),

--- a/check/tests/forall.rs
+++ b/check/tests/forall.rs
@@ -967,7 +967,7 @@ let show : Show a -> Show (List a) = \d ->
     }
 let list@{ } = { show }
 
-list.show string_show
+let _ = list.show string_show
 list.show int_show
 "#;
     let result = support::typecheck(text);
@@ -997,7 +997,7 @@ let semigroup : Semigroup (List a) =
 
 let { append } = semigroup
 
-append (Cons 1 Nil) Nil
+let _ = append (Cons 1 Nil) Nil
 append (Cons "" Nil) Nil
 "#;
     let result = support::typecheck(text);

--- a/check/tests/implicits.rs
+++ b/check/tests/implicits.rs
@@ -135,8 +135,8 @@ let f ?eq l r: [a -> a -> Bool] -> a -> a -> Bool = eq l r
 let eq_int l r : Int -> Int -> Bool = True
 #[implicit]
 let eq_string l r : String -> String -> Bool = True
-f 1 2
-f "" ""
+let _ = f 1 2
+let _ = f "" ""
 ()
 "#;
     let result = support::typecheck(text);
@@ -194,8 +194,8 @@ let eq_string @ { ? } =
     #[implicit]
     let eq l r : String -> String -> Bool = True
     { eq }
-f 1 2
-f "" ""
+let _ = f 1 2
+let _ = f "" ""
 ()
 "#;
     let result = support::typecheck(text);
@@ -348,7 +348,7 @@ type Test a = | Test a
 let f ?x y : [Test a] -> () -> Test a = x
 let g ?x y : [Test a] -> a -> Test a = f ()
 let i = Test 1
-g 2
+let _ = g 2
 ()
 "#;
     let (expr, result) = support::typecheck_expr(text);
@@ -522,7 +522,6 @@ let applicative : Applicative Test = {
 }
 
 \_ -> wrap 123
-()
 "#;
     let (_expr, result) = support::typecheck_expr(text);
     assert_err!(result, TypeError::UnableToResolveImplicit(..));
@@ -712,7 +711,7 @@ let put value : s -> State s () = any ()
 
 let get : State s s = any ()
 
-(put 1 *> get)
+let _ = (put 1 *> get)
 (put "hello" *> get)
 "#;
     let result = support::typecheck(text);

--- a/check/tests/row_polymorphism.rs
+++ b/check/tests/row_polymorphism.rs
@@ -91,8 +91,8 @@ fn equality_of_records_with_differing_fields() {
     let text = r#"
 let eq x y : a -> a -> () = ()
 let f v1 v2 =
-    v1.x
-    v2.y
+    let _ = v1.x
+    let _ = v2.y
     eq v1 v2
 ()
 "#;

--- a/codegen/tests/derive_getable.rs
+++ b/codegen/tests/derive_getable.rs
@@ -59,9 +59,9 @@ fn enum_tuple_variants() {
         let { tuple_enum_to_str } = import! functions
         let { assert } = import! std.test
 
-        assert (tuple_enum_to_str Variant == "Variant")
-        assert (tuple_enum_to_str OtherVariant == "OtherVariant")
-        assert (tuple_enum_to_str (One 1) == "One(1)")
+        let _ = assert (tuple_enum_to_str Variant == "Variant")
+        let _ = assert (tuple_enum_to_str OtherVariant == "OtherVariant")
+        let _ = assert (tuple_enum_to_str (One 1) == "One(1)")
         assert (tuple_enum_to_str (LotsOfTupleThings 42 "Text" 0.0) == "LotsOfTupleThings(42, \"Text\", 0.0)")
     "#;
 
@@ -103,7 +103,7 @@ fn enum_struct_variants() {
         let { struct_enum_to_str } = import! functions
         let { assert } = import! std.test
 
-        assert (struct_enum_to_str (OneField { field = 1337 }) == "OneField { field: 1337 }")
+        let _ = assert (struct_enum_to_str (OneField { field = 1337 }) == "OneField { field: 1337 }")
         assert (struct_enum_to_str (TwoFields { name = "Pi", val = 3.14 }) == "TwoFields { name: \"Pi\", val: 3.14 }")
     "#;
 
@@ -158,11 +158,11 @@ fn enum_generic_variants() {
         let { assert } = import! std.test
 
         let l: Either Int Float  = Left 42
-        assert (left l == Some 42)
+        let _ = assert (left l == Some 42)
         let r: Either Int Float  = Right 0.0
-        assert (left r == None)
+        let _ = assert (left r == None)
 
-        assert (extract_str (Left "left") == "left")
+        let _ = assert (extract_str (Left "left") == "left")
         assert (extract_str (Right "right") == "right")
     "#;
 
@@ -193,7 +193,7 @@ fn derive_generates_same_type_as_gluon_define() {
 
         type Enum = | TestVariant | TestVariant2 Int
 
-        test TestVariant
+        let _ = test TestVariant
         test (TestVariant2 123)
     "#;
 

--- a/codegen/tests/derive_pushable.rs
+++ b/codegen/tests/derive_pushable.rs
@@ -62,14 +62,14 @@ fn normal_struct() {
         let { new_struct } = import! functions
         let { assert } = import! std.test
         let { index, len } = import! std.array
-        
+
         let { string, number, vec } = new_struct ()
 
-        assert (string == "hello")
-        assert (number == 1)
-        assert (len vec == 3)
-        assert (index vec 0 == 1.0)
-        assert (index vec 1 == 2.0)
+        let _ = assert (string == "hello")
+        let _ = assert (number == 1)
+        let _ = assert (len vec == 3)
+        let _ = assert (index vec 0 == 1.0)
+        let _ = assert (index vec 1 == 2.0)
         assert (index vec 2 == 3.0)
     "#;
 
@@ -121,12 +121,12 @@ fn generic_struct() {
 
         let { generic, other } = new_generic_struct "hi rust"
 
-        assert (generic == "hi rust")
-        assert (other == 2012)
+        let _ = assert (generic == "hi rust")
+        let _ = assert (other == 2012)
 
         let { generic, other } = new_generic_struct 3.14
 
-        assert (generic == 3.14)
+        let _ = assert (generic == 3.14)
         assert (other == 2012)
     "#;
 
@@ -177,7 +177,7 @@ fn lifetime_struct() {
 
         let { string, other } = new_lifetime_struct ()
 
-        assert (string == "I'm borrowed")
+        let _ = assert (string == "I'm borrowed")
         assert (other == 6.6)
     "#;
 
@@ -231,18 +231,18 @@ fn normal_enum() {
                 match enum with
                 | Nothing -> 0
                 | Tuple x y ->
-                    assert (x == 1920)
-                    assert (y == 1080)
+                    let _ = assert (x == 1920)
+                    let _ = assert (y == 1080)
                     1
                 | Struct { key, value } ->
-                    assert (key == "under the doormat")
-                    assert (value == "lots of gold")
+                    let _ = assert (key == "under the doormat")
+                    let _ = assert (value == "lots of gold")
                     2
-            
+
             assert (tag == actual_tag)
-        
-        assert_enum (new_enum 0) 0
-        assert_enum (new_enum 1) 1
+
+        let _ = assert_enum (new_enum 0) 0
+        let _ = assert_enum (new_enum 1) 1
         assert_enum (new_enum 2) 2
     "#;
 

--- a/codegen/tests/derive_userdata.rs
+++ b/codegen/tests/derive_userdata.rs
@@ -59,10 +59,10 @@ fn userdata() {
     let script = r#"
         let { assert } = import! std.test
         let { create_hwnd, id, metadata } = import! hwnd
-        
+
         let hwnd = create_hwnd 0 "Window1"
 
-        assert (id hwnd == 0)
+        let _ = assert (id hwnd == 0)
         assert (metadata hwnd == "Window1")
     "#;
 

--- a/completion/tests/completion.rs
+++ b/completion/tests/completion.rs
@@ -170,8 +170,8 @@ fn binop() {
     let text = r#"
 #[infix(left, 4)]
 let (++) l r =
-    l #Int+ 1
-    r #Float+ 1.0
+    let _ = l #Int+ 1
+    let _ = r #Float+ 1.0
     l
 1 ++ 2.0
 "#;

--- a/completion/tests/metadata.rs
+++ b/completion/tests/metadata.rs
@@ -64,17 +64,17 @@ fn metadata_at_variable() {
 /// test
 let abc = 1
 let abb = 2
-abb
+let _ = abb
 abc
 "#;
-    let result = get_metadata(text, BytePos::from(37));
+    let result = get_metadata(text, BytePos::from(45));
 
     let expected = Some(Metadata {
         ..Metadata::default()
     });
     assert_eq!(result, expected);
 
-    let result = get_metadata(text, BytePos::from(41));
+    let result = get_metadata(text, BytePos::from(49));
 
     let expected = Some(Metadata {
         comment: Some(line_comment("test".to_string())),

--- a/completion/tests/suggest.rs
+++ b/completion/tests/suggest.rs
@@ -129,10 +129,10 @@ fn suggest_after_unrelated_type_error() {
     let result = suggest(
         r#"
 let record = { aa = 1, ab = 2, c = "" }
-1.0 #Int+ 2
+let _ = 1.0 #Int+ 2
 record.a
 "#,
-        BytePos::from(104),
+        BytePos::from(112),
     );
     let expected = Ok(vec!["aa".into(), "ab".into()]);
 
@@ -289,16 +289,16 @@ fn suggest_between_expressions() {
     let text = r#"
 let abc = 1
 let abb = 2
-test  test1
+let _ = test  test1
 ""  123
 "#;
-    let result = suggest(text, loc(text, 3, 5));
+    let result = suggest(text, loc(text, 3, 13));
     let expected = Ok(vec!["abb".into(), "abc".into()]);
 
     assert_eq!(result, expected);
 
     let result = suggest(text, loc(text, 4, 3));
-    let expected = Ok(vec!["abb".into(), "abc".into()]);
+    let expected = Ok(vec!["_".into(), "abb".into(), "abc".into()]);
 
     assert_eq!(result, expected);
 }

--- a/examples/marshalling.rs
+++ b/examples/marshalling.rs
@@ -311,8 +311,8 @@ fn marshal_wrapper(thread: &Thread) -> Result<()> {
         let actual = { name = "Bob", age = 11, data = True }
         let expected = roundtrip actual
 
-        assert (actual.name == expected.name)
-        assert (actual.age == expected.age)
+        let _  = assert (actual.name == expected.name)
+        let _  = assert (actual.age == expected.age)
         assert (actual.data == expected.data)
     "#;
 
@@ -369,8 +369,8 @@ fn marshal_userdata(thread: &Thread) -> Result<()> {
         let { assert } = import! std.test
         let { WindowHandle, create_hwnd, id, metadata } = import! hwnd
         let hwnd : WindowHandle = create_hwnd 0 "Window1"
-        assert (id hwnd == 0)
-        assert (metadata hwnd == "Window1")
+        let _  = assert (id hwnd == 0)
+        let _  = assert (metadata hwnd == "Window1")
         hwnd
     "#;
 

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -22,6 +22,7 @@ gluon_base = { path = "../base", version = "0.17.1" } # GLUON
 [dev-dependencies]
 difference = "2"
 env_logger = "0.7"
+expect-test = "1"
 futures = "0.3.1"
 pretty_assertions = "0.6"
 tokio = { version = "0.2", features = ["macros", "rt-core"] }

--- a/format/src/pretty_print.rs
+++ b/format/src/pretty_print.rs
@@ -478,29 +478,44 @@ where
                 ref bound,
                 ref body,
                 ..
-            }) => match id {
-                Some(pattern) => {
-                    let from = chain![
-                        arena,
-                        "do",
-                        self.space_before(pattern.span.start()),
-                        self.pretty_pattern(pattern),
-                        self.space_after(pattern.span.end()),
-                        "="
-                    ];
+            }) => {
+                if self.source.src_slice(expr.span).starts_with("seq") {
+                    let from = arena.text("seq");
                     chain![
                         arena,
                         self.hang(from, (self.space_before(bound.span.start()), true), bound),
                         self.pretty_expr_(bound.span.end(), body)
                     ]
-                }
+                } else {
+                    match id {
+                        Some(pattern) => {
+                            let from = chain![
+                                arena,
+                                "do",
+                                self.space_before(pattern.span.start()),
+                                self.pretty_pattern(pattern),
+                                self.space_after(pattern.span.end()),
+                                "="
+                            ];
+                            chain![
+                                arena,
+                                self.hang(
+                                    from,
+                                    (self.space_before(bound.span.start()), true),
+                                    bound
+                                ),
+                                self.pretty_expr_(bound.span.end(), body)
+                            ]
+                        }
 
-                None => chain![
-                    arena,
-                    self.pretty_expr_(bound.span.start(), bound),
-                    self.pretty_expr_(bound.span.end(), body)
-                ],
-            },
+                        None => chain![
+                            arena,
+                            self.pretty_expr_(bound.span.start(), bound),
+                            self.pretty_expr_(bound.span.end(), body)
+                        ],
+                    }
+                }
+            }
             Expr::MacroExpansion { ref original, .. } => {
                 return self.pretty_expr_(previous_end, original);
             }

--- a/format/src/pretty_print.rs
+++ b/format/src/pretty_print.rs
@@ -16,7 +16,7 @@ use base::{
     metadata::Attribute,
     pos::{self, BytePos, HasSpan, Span, Spanned},
     source,
-    types::{self, ArgType, AsId,Prec, Type},
+    types::{self, ArgType, AsId, Prec, Type},
 };
 
 const INDENT: isize = 4;
@@ -478,24 +478,29 @@ where
                 ref bound,
                 ref body,
                 ..
-            }) => {
-                let from = match id {
-                    Some(pattern) => chain![
+            }) => match id {
+                Some(pattern) => {
+                    let from = chain![
                         arena,
                         "do",
                         self.space_before(pattern.span.start()),
                         self.pretty_pattern(pattern),
                         self.space_after(pattern.span.end()),
                         "="
-                    ],
-                    None => arena.text("seq"),
-                };
-                chain![
+                    ];
+                    chain![
+                        arena,
+                        self.hang(from, (self.space_before(bound.span.start()), true), bound),
+                        self.pretty_expr_(bound.span.end(), body)
+                    ]
+                }
+
+                None => chain![
                     arena,
-                    self.hang(from, (self.space_before(bound.span.start()), true), bound),
+                    self.pretty_expr_(bound.span.start(), bound),
                     self.pretty_expr_(bound.span.end(), body)
-                ]
-            }
+                ],
+            },
             Expr::MacroExpansion { ref original, .. } => {
                 return self.pretty_expr_(previous_end, original);
             }

--- a/format/tests/pretty_print.rs
+++ b/format/tests/pretty_print.rs
@@ -393,22 +393,6 @@ let traverse_with_key f m x : [Ord k]
 }
 
 #[test]
-fn comments_in_block_exprs() {
-    let expr = r#"
-// test
-test 123
-
-// test1
-
-// test1
-
-abc ""
-// test2
-"#;
-    assert_diff!(&format_expr(expr).unwrap(), expr, "\n", 0);
-}
-
-#[test]
 fn comments_between_lambda_and_let() {
     let expr = r#"
 \x ->

--- a/format/tests/pretty_print.rs
+++ b/format/tests/pretty_print.rs
@@ -4,7 +4,7 @@ extern crate pretty_assertions;
 extern crate gluon_base as base;
 extern crate gluon_format as format;
 
-use difference::assert_diff;
+use {difference::assert_diff, expect_test::expect};
 
 use gluon::{RootedThread, ThreadExt, VmBuilder};
 
@@ -812,4 +812,27 @@ let assert_success : [Show e]
     run_error >> flat_map assert_ok
 ()
 "#
+}
+
+#[test]
+fn sequence() {
+    let expr = r#"
+// a
+io.print "Hello"
+// b
+io.print " "
+// c
+io.println "World"
+// d
+"#;
+    expect![[r#"
+
+        // a
+        io.print "Hello"
+        // b
+        io.print " "
+        // c
+        io.println "World"
+        // d
+    "#]].assert_eq(&format_expr(expr).unwrap());
 }

--- a/format/tests/pretty_print.rs
+++ b/format/tests/pretty_print.rs
@@ -818,7 +818,7 @@ let assert_success : [Show e]
 fn sequence() {
     let expr = r#"
 // a
-io.print "Hello"
+seq io.print "Hello"
 // b
 io.print " "
 // c
@@ -828,11 +828,12 @@ io.println "World"
     expect![[r#"
 
         // a
-        io.print "Hello"
+        seq io.print "Hello"
         // b
         io.print " "
         // c
         io.println "World"
         // d
-    "#]].assert_eq(&format_expr(expr).unwrap());
+    "#]]
+    .assert_eq(&format_expr(expr).unwrap());
 }

--- a/format/tests/std.rs
+++ b/format/tests/std.rs
@@ -85,6 +85,7 @@ async fn main_() -> Result<(), Error> {
             "fmt",
             files
                 .into_iter()
+                .chain(Some(PathBuf::from("../repl/src/repl.glu")))
                 .map(|file| {
                     let name = file.display().to_string();
                     tensile::test(name.clone(), move || test_format(&name))

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -106,6 +106,17 @@ CommaTemp<Rule>: TempVecStart<Rule> = {
 };
 
 #[inline]
+SepVec1<Rule, Separator>: TempVecStart<Rule> =
+    <start: Many1Vec<(<Rule> Separator)>?> <last: Rule> => {
+        let start = match start {
+            Some(start) => start,
+            None => temp_vecs.start(),
+        };
+        temp_vecs.select().push(last);
+        start
+    };
+
+#[inline]
 SepSlice1<Rule, Separator>: &'ast mut Slice<Rule> =
     <start: Many1Vec<(<Rule> Separator)>?> <last: Rule> => {
         match start {
@@ -617,7 +628,7 @@ Literal: Literal = {
 };
 
 Alternative: () = {
-    "|" <pat: Sp<Pattern>> "->" <expr: Sp<BlockExpr>> => {
+    "|" <pat: Sp<Pattern>> "->" <expr: SpBlockExpr> => {
         temp_vecs.select().push(
             Alternative {
                 pattern: pat,
@@ -903,9 +914,26 @@ DoBinding: Box<(SpannedPattern<'ast, Id>, SpannedExpr<'ast, Id>)> = {
     },
 };
 
+#[inline]
+SpBlockExpr: SpannedExpr<'ast, Id> = {
+    Sp<BlockExpr> => super::shrink_hidden_spans(<>),
+};
+
 BlockExpr: Expr<'ast, Id> = {
-    "block open" <exprs: SepSlice1<SpExpr, "block separator">> "block close" => {
-        Expr::Block(exprs)
+    "block open" <exprs: SepVec1<SpExpr, "block separator">> "block close" => {
+        let mut iter = temp_vecs.drain(exprs).rev();
+        let last = iter.next().unwrap();
+        if iter.size_hint().0 == 0 {
+            Expr::Block(arena.alloc_extend(Some(last)))
+        } else {
+            iter.fold(last, |body, expr| {
+                pos::spanned2(
+                    expr.span.start(),
+                    body.span.end(),
+                    Expr::Do(arena.alloc(Do { id: None, bound: arena.alloc(expr), body: arena.alloc(body), flat_map_id: None })),
+                )
+            }).value
+        }
     },
 };
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -297,14 +297,14 @@ macro_rules! impl_temp_vec {
                 T::select(self)
             }
 
-            fn drain<'a, T>(&'a mut self, start: TempVecStart<T>) -> impl Iterator<Item = T> + 'a
+            fn drain<'a, T>(&'a mut self, start: TempVecStart<T>) -> impl DoubleEndedIterator<Item = T> + 'a
             where
                 T: TempVec<'ast, Id> + 'a,
             {
                 T::select(self).drain(start.0..)
             }
 
-            fn drain_n<'a, T>(&'a mut self, n: usize) -> impl Iterator<Item = T> + 'a
+            fn drain_n<'a, T>(&'a mut self, n: usize) -> impl DoubleEndedIterator<Item = T> + 'a
             where
                 T: TempVec<'ast, Id> + 'a,
             {

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -683,13 +683,15 @@ test
     mk_ast_arena!(arena);
     assert_eq!(
         *e.expr(),
-        no_loc(Expr::Block(arena.alloc_extend(vec![
-            Spanned {
+        no_loc(Expr::Do(arena.alloc(Do {
+            id: None,
+            bound: arena.alloc(Spanned {
                 span: Span::new(BytePos::from(0), BytePos::from(0)),
                 value: Expr::Projection(arena.alloc(id("test")), intern(""), Type::hole()),
-            },
-            id("test"),
-        ])))
+            }),
+            body: arena.alloc(id("test")),
+            flat_map_id: None,
+        })))
     );
 }
 
@@ -740,38 +742,6 @@ fn quote_in_identifier() {
         app(arena, id("f'"), vec![int(1), int(2)]),
     );
     assert_eq!(*e.expr(), a);
-}
-
-// Test that this is `rec let x = 1 in {{ a; b }}` let not `{{ (let x = 1 in a) ; b }}`
-#[test]
-fn block_open_after_let_in() {
-    let _ = ::env_logger::try_init();
-    let text = r#"
-        let x = 1
-        a
-        b
-        "#;
-    let e = parse_zero_index!(text);
-    match e.expr().value {
-        Expr::LetBindings(..) => (),
-        _ => panic!("{:?}", e),
-    }
-}
-
-#[test]
-fn block_open_after_explicit_let_in() {
-    let _ = ::env_logger::try_init();
-    let text = r#"
-        let x = 1
-        in
-        a
-        b
-        "#;
-    let e = parse_zero_index!(text);
-    match e.expr().value {
-        Expr::LetBindings(..) => (),
-        _ => panic!("{:?}", e),
-    }
 }
 
 #[test]

--- a/parser/tests/indentation.rs
+++ b/parser/tests/indentation.rs
@@ -1,4 +1,5 @@
-extern crate env_logger;
+#[macro_use]
+extern crate pretty_assertions;
 
 extern crate gluon_base as base;
 extern crate gluon_parser as parser;
@@ -41,8 +42,7 @@ g ""
 
     match result {
         Ok(expr) => {
-            if let Expr::Block(ref exprs) = expr.expr().value {
-                assert_eq!(exprs.len(), 2);
+            if let Expr::Do(..) = expr.expr().value {
             } else {
                 assert!(false, "Expected block, found {:?}", expr);
             }
@@ -191,7 +191,7 @@ fn close_lambda_on_implicit_statement() {
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
     match &result.as_ref().unwrap().expr().value {
-        Expr::Block(exprs) if exprs.len() == 2 => (),
+        Expr::Do(_) => (),
         expr => assert!(false, "{:?}", expr),
     }
 }
@@ -215,7 +215,7 @@ else
 
     if let Expr::LetBindings(_, ref expr) = result.as_ref().unwrap().expr().value {
         if let Expr::IfElse(_, _, ref if_false) = expr.value {
-            if let Expr::Block(_) = if_false.value {
+            if let Expr::Do(_) = if_false.value {
                 return;
             }
         }
@@ -257,8 +257,7 @@ match True with
 
     assert!(result.is_ok(), "{}", result.unwrap_err());
 
-    if let Expr::Block(ref exprs) = result.as_ref().unwrap().expr().value {
-        assert_eq!(2, exprs.len());
+    if let Expr::Do(..) = result.as_ref().unwrap().expr().value {
         return;
     }
 

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -136,16 +136,15 @@ let commands : Commands =
             alias = "p",
             info = "Sets the prompt",
             action = \prompt ->
-                seq
-                    modify
-                        (\settings ->
-                            // TODO Should be able infer this before the `..` splatting
-                            let settings : Settings = settings
-                            {
-                                prompt,
-                                ..
-                                settings
-                            })
+                modify
+                    (\settings ->
+                        // TODO Should be able infer this before the `..` splatting
+                        let settings : Settings = settings
+                        {
+                            prompt,
+                            ..
+                            settings
+                        })
                 wrap Continue,
         },
         {
@@ -153,19 +152,18 @@ let commands : Commands =
             alias = "c",
             info = "Sets whether to use color in the repl: auto, always, always-ansi, never",
             action = \color ->
-                seq
-                    match repl_prim.parse_color color with
-                    | Ok color ->
-                        modify
-                            (\settings ->
-                                // TODO Should be able infer this before the `..` splatting
-                                let settings : Settings = settings
-                                {
-                                    color,
-                                    ..
-                                    settings
-                                })
-                    | Err msg -> io.println msg
+                match repl_prim.parse_color color with
+                | Ok color ->
+                    modify
+                        (\settings ->
+                            // TODO Should be able infer this before the `..` splatting
+                            let settings : Settings = settings
+                            {
+                                color,
+                                ..
+                                settings
+                            })
+                | Err msg -> io.println msg
                 wrap Continue,
         },
         {
@@ -214,7 +212,7 @@ let cmd_parser : Parser { cmd : String, arg : String } =
     let word = recognize (skip_many1 letter)
     let arg_parser = recognize (skip_many1 any)
 
-    seq token ':'
+    token ':'
     do cmd = word
     do arg = (spaces *> arg_parser) <|> wrap ""
     wrap { cmd, arg }
@@ -251,11 +249,11 @@ let loop _ : () -> Eff (ReplEffect r) () =
         match continue with
         | Continue -> loop ()
         | Quit ->
-            seq lift <| rustyline.save_history repl.editor
+            lift <| rustyline.save_history repl.editor
             wrap ()
 
 let run settings : Settings -> Eff [| lift : Lift IO |] () =
-    seq io.println "gluon (:h for help, :q to quit)"
+    io.println "gluon (:h for help, :q to quit)"
     do editor = lift <| rustyline.new_editor ()
     let repl = { commands, editor }
     run_reader repl (eval_state settings (loop ()))

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -190,7 +190,7 @@ let commands : Commands =
                     *> array.traversable.traverse effect.applicative print_cmd (load commands)
                     *> wrap Continue,
         }]
-    commands <- cmds
+    let _ = commands <- cmds
     foldl
         (\map cmd -> singleton cmd.name cmd <> singleton cmd.alias cmd <> map)
         empty

--- a/repl/tests/basic.rs
+++ b/repl/tests/basic.rs
@@ -8,34 +8,6 @@ use std::path::Path;
 use std::process::{Command, Stdio};
 
 #[test]
-fn fmt_repl() {
-    let source = "src/repl.glu";
-
-    let mut before = String::new();
-    File::open(source)
-        .unwrap()
-        .read_to_string(&mut before)
-        .unwrap();
-
-    let status = Command::new("../target/debug/gluon")
-        .args(&["fmt", source])
-        .env("GLUON_PATH", "..")
-        .spawn()
-        .expect("Could not find gluon executable")
-        .wait()
-        .unwrap();
-    assert!(status.success());
-
-    let mut after = String::new();
-    File::open(source)
-        .unwrap()
-        .read_to_string(&mut after)
-        .unwrap();
-
-    assert_eq!(before, after);
-}
-
-#[test]
 fn issue_365_run_io_from_command_line() {
     if ::std::env::var("GLUON_PATH").is_err() {
         ::std::env::set_var("GLUON_PATH", "..");

--- a/std/effect/st.glu
+++ b/std/effect/st.glu
@@ -49,7 +49,7 @@ let run_state eff : (forall s . Eff [| st : State s | r |] a) -> Eff [| | r |] a
                 let a = load r.__ref
                 loop (f a)
             | Write a r ->
-                r.__ref <- a
+                let _ = r.__ref <- a
                 loop (f ())
             | Call g ->
                 loop (f (g ()))

--- a/std/io/read.glu
+++ b/std/io/read.glu
@@ -69,7 +69,7 @@ type Buffered r = { reader : r, buf : Reference (Array Byte), capacity : Int }
 /// Wraps `reader` in a `Buffered` reader to provide buffering with the specified
 /// buffer capacity.
 let buffered_with_capacity capacity reader : [Read a] -> Int -> a -> Buffered a =
-    assert (capacity > 0)
+    let _ = assert (capacity > 0)
 
     {
         reader,

--- a/std/io/write.glu
+++ b/std/io/write.glu
@@ -68,7 +68,7 @@ type Buffered w = { writer : w, buf : Reference (Array Byte), capacity : Int }
 /// Wraps `writer` in a `Buffered` writer to provide buffering with the specified
 /// buffer capacity.
 let buffered_with_capacity capacity writer : [Write w] -> Int -> w -> Buffered w =
-    assert (capacity > 0)
+    let _ = assert (capacity > 0)
 
     {
         writer,
@@ -102,7 +102,7 @@ let flush_buffer buf_writer : [Write w] -> Buffered w -> IO () =
 let write_buffered : [Write w] -> Write (Buffered w) =
     let buffered_write_slice buf_writer slice start end =
         let slice_len = end - start
-        assert (slice_len >= 0)
+        let _ = assert (slice_len >= 0)
 
         do _ =
             // if the new data would spill the buffer, flush it first

--- a/std/parser.glu
+++ b/std/parser.glu
@@ -218,7 +218,7 @@ rec
 let skip_many p : Parser a -> Parser () = skip_many1 p <|> wrap ()
 /// Parses with `p` one or more times, ignoring the result of the parser
 let skip_many1 p : Parser a -> Parser () =
-    seq p
+    p
     skip_many p
 in
 /// Parses one of the characters of `s`

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate collect_mac;
+#[macro_use]
+extern crate pretty_assertions;
 
 use std::{
     collections::BTreeMap,
@@ -145,7 +147,7 @@ fn line_hook_after_call() {
 
     let expr = r#"
         let id x = x
-        id 0
+        let _ = id 0
         1
     "#;
 
@@ -245,7 +247,7 @@ fn read_variables() {
         let y2 = ""
         ()
 
-    ()
+    let _ = ()
     let z = 1.0
     1
     "#;
@@ -281,6 +283,7 @@ fn read_variables() {
                 vec![
                     ("x".to_string(), Type::int()),
                     ("y".to_string(), Type::unit()),
+                    ("_".to_string(), Type::unit()),
                 ],
             ),
             (
@@ -288,6 +291,7 @@ fn read_variables() {
                 vec![
                     ("x".to_string(), Type::int()),
                     ("y".to_string(), Type::unit()),
+                    ("_".to_string(), Type::unit()),
                     ("z".to_string(), Type::float()),
                 ],
             ),
@@ -380,7 +384,7 @@ fn source_name() {
         let y2 = ""
         ()
 
-    ()
+    let _ = ()
     let z = { x }
     1
     "#;

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -35,9 +35,9 @@ fn read_file() {
         do bytes = io.read_file file 9
         let bytes = unwrap bytes
 
-        assert (array.len bytes == 9)
-        assert (array.index bytes 0 == 91b) // [
-        assert (array.index bytes 1 == 112b) // p
+        let _ = assert (array.len bytes == 9)
+        let _ = assert (array.index bytes 0 == 91b) // [
+        let _ = assert (array.index bytes 1 == 112b) // p
 
         wrap (array.index bytes 8)
         "#;
@@ -65,7 +65,7 @@ fn write_and_flush_file() {
         \path ->
             do file = open_file_with path [Write]
             do bytes_written = write_slice_file file [1b, 2b, 3b, 4b] 0 4
-            assert (bytes_written == 4)
+            let _ = assert (bytes_written == 4)
             flush_file file
     "#;
 
@@ -231,7 +231,7 @@ fn spawn_on_do_action_twice() {
 
         do child = thread.new_thread ()
         let action = thread.spawn_on child (\_ ->
-                counter <- (load counter + 1)
+                let _ = counter <- (load counter + 1)
                 wrap ())
         seq join action
         seq join action
@@ -261,7 +261,7 @@ fn spawn_on_force_action_twice() {
 
         do child = thread.new_thread ()
         do action = thread.spawn_on child (\_ ->
-                counter <- (load counter + 1)
+                let _ = counter <- (load counter + 1)
                 wrap ())
         seq action
         seq action

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -40,8 +40,8 @@ fn parallel_() -> Result<(), Error> {
         let expr = r#"
         let { send } = import! std.channel
         let f sender =
-            send sender 1
-            send sender 2
+            let _ = send sender 1
+            let _ = send sender 2
             ()
         f
         "#;
@@ -59,9 +59,10 @@ fn parallel_() -> Result<(), Error> {
         let { recv } = import! std.channel
 
         let f receiver =
-            match recv receiver with
-            | Ok x -> assert (x == 1)
-            | Err _ -> assert False
+            let _ =
+                match recv receiver with
+                | Ok x -> assert (x == 1)
+                | Err _ -> assert False
             match recv receiver with
             | Ok x -> assert (x == 2)
             | Err _ -> assert False

--- a/tests/pass/buffered_io.glu
+++ b/tests/pass/buffered_io.glu
@@ -31,7 +31,7 @@ let read_cursor : Read Cursor =
         let start = load cursor.pos
         let end = min (array.len cursor.buf) (start + num_bytes)
         let read_bytes = array.slice cursor.buf start end
-        cursor.pos <- (start + array.len read_bytes)
+        let _ = cursor.pos <- (start + array.len read_bytes)
 
         if array.is_empty read_bytes then
             wrap None
@@ -48,7 +48,7 @@ let write_array_ref : Write (Reference (Array Byte)) = {
         let written = array.append (load array_ref) (array.slice buf start end)
         let _ = array_ref <- written
         wrap (end - start),
-        
+
     flush = \_ -> wrap ()
 }
 
@@ -68,7 +68,7 @@ let test_read = [
 
         do bytes = lift <| read reader 9000
         assert_eq (bytes) None,
-    
+
     test "read directly if buffer is empty" <| \_ ->
         let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 2
         do bytes = lift <| read reader 5
@@ -80,7 +80,7 @@ let test_read = [
         do bytes = lift <| read reader 4
         assert_eq bytes (Some [2b]),
 ]
-    
+
 let test_read_to_end = [
     test "read all in one go" <| \_ ->
         let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 5
@@ -109,7 +109,7 @@ let test_write_and_flush = [
         do _ = assert_eq (load written) []
         do _ = lift <| flush writer
         assert_eq (load written) [1b, 2b],
-    
+
     test "flush immediately if buffer is empty and new data wouldn't fit" <| \_ ->
         let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 2
@@ -133,7 +133,7 @@ let test_write_and_flush = [
         do _ = lift <| flush writer
         assert_eq (load written) [1b, 2b, 3b],
 
-    test "flush buffer if new data doesn't fit, then buffer the data" <| \_ -> 
+    test "flush buffer if new data doesn't fit, then buffer the data" <| \_ ->
         let written : Reference (Array Byte) = ref []
         let writer = written |> io_write.buffered_with_capacity 5
 

--- a/tests/pass/channel.glu
+++ b/tests/pass/channel.glu
@@ -12,11 +12,11 @@ let { ? } = import! std.effect
 
 let { sender, receiver } = channel 0
 
-send sender 0
-send sender 1
-send sender 2
+let _ = send sender 0
+let _ = send sender 1
+let _ = send sender 2
 
-let tests : TestEff r () = 
+let tests : TestEff r () =
     assert_eq (recv receiver) (Ok 0)
         *> assert_eq (recv receiver) (Ok 1)
         *> assert_eq (recv receiver) (Ok 2)

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -13,16 +13,17 @@ let _ =
     let { sender, receiver } = channel (lazy (\_ -> 0))
 
     let thread = spawn (\_ ->
-            send sender (lazy (\_ -> 1))
+            let _ = send sender (lazy (\_ -> 1))
             let l = lazy (\_ -> 2)
-            force l
-            send sender l
+            let _ = force l
+            let _ = send sender l
             ())
 
     let _ = resume thread
-    match recv receiver with
-    | Ok x -> assert (force x == 1)
-    | Err e -> error "Receive 1 error"
+    let _ =
+        match recv receiver with
+        | Ok x -> assert (force x == 1)
+        | Err e -> error "Receive 1 error"
     match recv receiver with
     | Ok x -> assert (force x == 2)
     | Err e -> error "Receive 2 error"
@@ -31,7 +32,7 @@ let _ =
     let { sender, receiver } = channel (ref 0)
 
     let thread = spawn (\_ ->
-            send sender (ref 3)
+            let _ = send sender (ref 3)
             ())
 
     let _ = resume thread

--- a/tests/pass/reference.glu
+++ b/tests/pass/reference.glu
@@ -5,12 +5,12 @@ let { Bool } = import! std.bool
 let { ref, (<-), load } = import! std.reference
 
 let ri = ref 0
-assert (0 == load ri)
-ri <- 2
-assert (2 == load ri)
-assert (2 == load ri)
-ri <- 10
-assert (10 == load ri)
+let _ = assert (0 == load ri)
+let _ = ri <- 2
+let _ = assert (2 == load ri)
+let _ = assert (2 == load ri)
+let _ = ri <- 10
+let _ = assert (10 == load ri)
 
 // Dummy test
 group "reference" []

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -25,7 +25,7 @@ let thread = spawn (\_ ->
         let _ = send sender 1
         ()
     )
-resume thread
+let _ = resume thread
 
 let tests : TestEff r () =
     seq assert_eq (recv receiver) (Ok 0)

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -655,7 +655,7 @@ fn opaque_value_type_mismatch() {
 
     let expr = r#"
 let { sender, receiver } = channel 0
-send sender 1
+let _ = send sender 1
 sender
 "#;
     let result = vm.run_expr::<OpaqueValue<&Thread, Sender<f64>>>("<top>", expr);


### PR DESCRIPTION
Rather than removing block expressions entirely, this changes them
to behave as sequence (`seq`) expressions.

```f#
io.println "Hello"
io.println "World"

// Is now equivalent to
seq io.println "Hello"
io.println "World"
```