### PR TITLE
fix: Recognize raw string literals without any `#`

### DIFF
--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -360,6 +360,14 @@ test_parse! {
     }
 }
 
+test_parse! {
+    raw_string_literal,
+    r##"  r"asdf" "##,
+    |_arena| {
+        string("asdf")
+    }
+}
+
 #[test]
 fn span_identifier() {
     let _ = ::env_logger::try_init();

--- a/parser/tests/support/mod.rs
+++ b/parser/tests/support/mod.rs
@@ -6,8 +6,8 @@ use crate::base::{
     ast::{
         self, walk_mut_alias, walk_mut_ast_type, walk_mut_expr, walk_mut_pattern, Alternative,
         Argument, Array, AstType, DisplayEnv, Do, Expr, ExprField, IdentEnv, Lambda, Literal,
-        MutVisitor, Pattern, RootExpr, SpannedAlias, SpannedAstType, SpannedExpr, SpannedIdent,
-        SpannedPattern, TypeBinding, TypedIdent, ValueBinding,Sp,
+        MutVisitor, Pattern, RootExpr, Sp, SpannedAlias, SpannedAstType, SpannedExpr, SpannedIdent,
+        SpannedPattern, TypeBinding, TypedIdent, ValueBinding,
     },
     error::Errors,
     kind::Kind,
@@ -548,6 +548,7 @@ macro_rules! test_parse {
             let text = $text;
             let e = parse_clear_span!(text);
             mk_ast_arena!(arena);
+            let _: &Arena<String> = &*arena;
             fn call<A, R>(a: A, f: impl FnOnce(A) -> R) -> R {
                 f(a)
             }


### PR DESCRIPTION
Fixes #885