### PR TITLE
Don't insert a duplicate trailing comma in `gluon_codegen`

### DIFF
--- a/codegen/src/shared.rs
+++ b/codegen/src/shared.rs
@@ -51,7 +51,13 @@ pub fn split_for_impl<'a>(
     let (_, ty_generics, where_clause) = generics.split_for_impl();
     let ty_generics = ty_generics.clone();
     let where_clause = where_clause
-        .map(|clause| quote! { #clause, })
+        .map(|clause| {
+            if clause.predicates.empty_or_trailing() {
+                quote! { #clause }
+            } else {
+                quote! { #clause, }
+            }
+        })
         .unwrap_or(quote! { where });
 
     // generate the generic params for the impl block


### PR DESCRIPTION
Currently, `gluon_codegen` unconditionall inserts a comma after the
user-provided `where` clause. However, the `where` clause may already
have a trailing comma, which will result in an unparsable `TokenStream`
being generated.

The `AliasRef` struct would be affected by this bug, but a rustc bug
causes the exact parsed `TokenStream` to be lost in some cases
(see https://github.com/rust-lang/rust/issues/43081) - in this case, due
to the presence of `#[cfg_attr]`.

When PR https://github.com/rust-lang/rust/pull/76130 is merged, the
exact parsed `TokenStream` will be passed to proc-macros in more cases,
exposing this bug.