### PR TITLE
Version 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+<a name="v0.17.2"></a>
+### v0.17.2 (2020-10-25)
+
+
+#### Features
+
+*   Allow the http module to be used without a tcp listener ([c45353d2](https://github.com/gluon-lang/gluon/commit/c45353d2ceb10d98dbeca7e7dce1f658b875eb3a))
+*   Format seq expressions without seq ([5c0cec2d](https://github.com/gluon-lang/gluon/commit/5c0cec2d29a0580a8e171e040f13427b282c4c1f))
+*   Compile block expressions as monadic sequences ([bce59737](https://github.com/gluon-lang/gluon/commit/bce5973719cdb24849671f5b11e980e5d9cefc31), closes [#884](https://github.com/gluon-lang/gluon/issues/884))
+* **std:**
+  *  add Option assertions to std.test ([28e5053f](https://github.com/gluon-lang/gluon/commit/28e5053f1e56f7304d8b94eead3174ccfa4077c6))
+  *  add modulo functions to int and float ([92f188ab](https://github.com/gluon-lang/gluon/commit/92f188ab24b599d0d0ef004c996f5fbefbfe1786))
+
+#### Bug Fixes
+
+*   Recognize raw string literals without any `#` ([4d66fbb3](https://github.com/gluon-lang/gluon/commit/4d66fbb37f5acae81c28fe3af715b8d1c04a2ab5), closes [#885](https://github.com/gluon-lang/gluon/issues/885))
+*   Prevent zero-argument functions from being created in Rust ([e91ea06d](https://github.com/gluon-lang/gluon/commit/e91ea06d447fea4f9e5699ada6f38e742526ebc7), closes [#873](https://github.com/gluon-lang/gluon/issues/873))
+*   Give tuple fields a span ([2a1c2c71](https://github.com/gluon-lang/gluon/commit/2a1c2c711408372eed71812696776ee93fde3c0a))
+*   xor_shift_new inconsistent description ([591b64b3](https://github.com/gluon-lang/gluon/commit/591b64b359d98948ca379fd2f17e8d34982d12b2))
+
+
+
 <a name="v0.17.1"></a>
 ### v0.17.1 (2020-08-15)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gluon"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_base"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anymap",
  "bitflags 1.2.1",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_c-api"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "futures 0.3.5",
  "gluon",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_check"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_codegen"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "env_logger 0.7.1",
  "gluon",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_completion"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "codespan",
  "collect-mac",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_doc"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "cargo-deadlinks",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_format"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "codespan",
  "difference",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_parser"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_repl"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_vm"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "async-trait",
  "bitflags 1.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 keywords = ["script", "scripting", "language"]
 build = "build.rs"
@@ -26,12 +26,12 @@ name = "gluon"
 path = "src/lib.rs"
 
 [dependencies]
-gluon_base = { path = "base", version = "0.17.1" } # GLUON
-gluon_check = { path = "check", version = "0.17.1" } # GLUON
-gluon_parser = { path = "parser", version = "0.17.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.17.1" } # GLUON
-gluon_vm = { path = "vm", version = "0.17.1", default-features = false } # GLUON
-gluon_format = { path = "format", version = "0.17.1", default-features = false } # GLUON
+gluon_base = { path = "base", version = "0.17.2" } # GLUON
+gluon_check = { path = "check", version = "0.17.2" } # GLUON
+gluon_parser = { path = "parser", version = "0.17.2" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.17.2" } # GLUON
+gluon_vm = { path = "vm", version = "0.17.2", default-features = false } # GLUON
+gluon_format = { path = "format", version = "0.17.2", default-features = false } # GLUON
 
 async-trait = "0.1"
 log = "0.4"
@@ -68,7 +68,7 @@ rand = { version = "0.7", optional = true }
 rand_xorshift = { version = "0.2", optional = true }
 
 [build-dependencies]
-gluon_base = { path = "base", version = "0.17.1" } # GLUON
+gluon_base = { path = "base", version = "0.17.2" } # GLUON
 
 itertools = "0.9"
 little-skeptic = { version = "0.15.0", optional = true }
@@ -96,8 +96,8 @@ bincode = "1"
 
 pulldown-cmark = "0.7"
 
-gluon_completion = { path = "completion", version = "0.17.1" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.17.1" } # GLUON
+gluon_completion = { path = "completion", version = "0.17.2" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.17.2" } # GLUON
 
 [features]
 default = ["async", "regex", "random"]

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Gluon requires a recent Rust compiler to build (1.9.0 or later) and is available
 
 ```toml
 [dependencies]
-gluon = "0.17.1"
+gluon = "0.17.2"
 ```
 
 ### Other languages

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_base"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -33,7 +33,7 @@ either = "1"
 vec_map = "0.8"
 typed-arena = "2"
 
-gluon_codegen = { version = "0.17.1", path = "../codegen" } # GLUON
+gluon_codegen = { version = "0.17.2", path = "../codegen" } # GLUON
 
 serde = { version = "1.0.0", features = ["rc"], optional = true }
 serde_state = { version = "0.4.0", features = ["rc"], optional = true }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/gluon_base/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_base/0.17.2")] // # GLUON
 #![allow(unknown_lints)]
 //! The base crate contains pervasive types used in the compiler such as type representations, the
 //! AST and some basic containers.

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_c-api"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -19,7 +19,7 @@ travis-ci = { repository = "gluon-lang/gluon" }
 crate-type = ["cdylib"]
 
 [dependencies]
-gluon = { version = "0.17.1", path = ".." } # GLUON
+gluon = { version = "0.17.2", path = ".." } # GLUON
 futures = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,5 +1,5 @@
 //! A (WIP) C API allowing use of gluon in other langauges than Rust.
-#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.17.2")] // # GLUON
 
 use std::{slice, str};
 

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_check"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -30,14 +30,14 @@ codespan-reporting = "0.9"
 
 strsim = "0.10"
 
-gluon_base = { path = "../base", version = "0.17.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.17.1" } # GLUON
+gluon_base = { path = "../base", version = "0.17.2" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.17.2" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.7"
 insta = "0.16"
 
-gluon_parser = { path = "../parser", version = "0.17.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.17.2" } # GLUON
 gluon_format = { path = "../format", version = ">=0.9" }
 
 collect-mac = "0.1.0"

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -3,7 +3,7 @@
 //! If an AST passes the checks in `Typecheck::typecheck_expr` (which runs all of theses checks
 //! the expression is expected to compile succesfully (if it does not it should be considered an
 //! internal compiler error.
-#![doc(html_root_url = "https://docs.rs/gluon_check/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_check/0.17.2")] // # GLUON
 
 #[macro_use]
 extern crate collect_mac;

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_codegen"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 
 edition = "2018"

--- a/completion/Cargo.toml
+++ b/completion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_completion"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ itertools = "0.9"
 walkdir = "2"
 codespan = "0.9"
 
-gluon_base = { path = "../base", version = "0.17.1" } # GLUON
+gluon_base = { path = "../base", version = "0.17.2" } # GLUON
 
 [dev-dependencies]
 collect-mac = "0.1.0"
@@ -25,5 +25,5 @@ env_logger = "0.7"
 pretty_assertions = "0.6"
 quick-error = "1"
 
-gluon_check = { path = "../check", version = "0.17.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.17.1" } # GLUON
+gluon_check = { path = "../check", version = "0.17.2" } # GLUON
+gluon_parser = { path = "../parser", version = "0.17.2" } # GLUON

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -1,5 +1,5 @@
 //! Primitive auto completion and type quering on ASTs
-#![doc(html_root_url = "https://docs.rs/gluon_completion/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_completion/0.17.2")] // # GLUON
 
 extern crate gluon_base as base;
 

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_doc"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -32,8 +32,8 @@ serde = "1.0.0"
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 
-gluon = { version = "0.17.1", default-features = false, path = ".." } # GLUON
-completion = { package = "gluon_completion", version = "0.17.1", path = "../completion" } # GLUON
+gluon = { version = "0.17.2", default-features = false, path = ".." } # GLUON
+completion = { package = "gluon_completion", version = "0.17.2", path = "../completion" } # GLUON
 
 
 [dev-dependencies]

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_format"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ pretty = "0.10"
 itertools = "0.9"
 codespan = "0.9"
 
-gluon_base = { path = "../base", version = "0.17.1" } # GLUON
+gluon_base = { path = "../base", version = "0.17.2" } # GLUON
 
 [dev-dependencies]
 difference = "2"
@@ -28,7 +28,7 @@ pretty_assertions = "0.6"
 tokio = { version = "0.2", features = ["macros", "rt-core"] }
 walkdir = "2"
 
-gluon_base = { path = "../base", version = "0.17.1" } # GLUON
+gluon_base = { path = "../base", version = "0.17.2" } # GLUON
 gluon = { path = "..", version = ">=0.9" }
 
 tensile = { version = "0.6", features = ["tokio"] }

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,5 +1,5 @@
 //! Code formatter.
-#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.17.2")] // # GLUON
 
 extern crate codespan;
 #[macro_use]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_parser"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -23,7 +23,7 @@ itertools = "0.9"
 quick-error = "1.0.0"
 lalrpop-util = "0.19"
 log = "0.4"
-gluon_base = { path = "../base", version = "0.17.1" } # GLUON
+gluon_base = { path = "../base", version = "0.17.2" } # GLUON
 ordered-float = "2"
 codespan = "0.9"
 codespan-reporting = "0.9"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,7 +1,7 @@
 //! The parser is a bit more complex than it needs to be as it needs to be fully specialized to
 //! avoid a recompilation every time a later part of the compiler is changed. Due to this the
 //! string interner and therefore also garbage collector needs to compiled before the parser.
-#![doc(html_root_url = "https://docs.rs/gluon_parser/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_parser/0.17.2")] // # GLUON
 
 extern crate gluon_base as base;
 #[macro_use]

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_repl"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -20,12 +20,12 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-gluon = { version = "0.17.1", path = "..", features = ["serialization"] } # GLUON
-gluon_vm = { version = "0.17.1", path = "../vm", features = ["serialization"] } # GLUON
-gluon_completion = { path = "../completion", version = "0.17.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.17.1" } # GLUON
-gluon_format = { version = "0.17.1", path = "../format" } # GLUON
-gluon_doc = { version = "0.17.1", path = "../doc" } # GLUON
+gluon = { version = "0.17.2", path = "..", features = ["serialization"] } # GLUON
+gluon_vm = { version = "0.17.2", path = "../vm", features = ["serialization"] } # GLUON
+gluon_completion = { path = "../completion", version = "0.17.2" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.17.2" } # GLUON
+gluon_format = { version = "0.17.2", path = "../format" } # GLUON
+gluon_doc = { version = "0.17.2", path = "../doc" } # GLUON
 
 app_dirs = "1.0.0"
 anyhow = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! behaviour. For information about how to use this library the best resource currently is the
 //! [tutorial](http://gluon-lang.org/book/index.html) which contains examples
 //! on how to write gluon programs as well as how to run them using this library.
-#![doc(html_root_url = "https://docs.rs/gluon/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon/0.17.2")] // # GLUON
 #![recursion_limit = "128"]
 #[cfg(test)]
 extern crate env_logger;

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_vm"
-version = "0.17.1" # GLUON
+version = "0.17.2" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 build = "build.rs"
@@ -46,10 +46,10 @@ serde_state = { version = "0.4.0", optional = true }
 serde_derive = { version = "1.0.0", optional = true }
 serde_derive_state = { version = "0.4.8", optional = true }
 
-gluon_base = { path = "../base", version = "0.17.1" } # GLUON
-gluon_check = { path = "../check", version = "0.17.1" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.17.1" } # GLUON
-gluon_parser = { path = "../parser", version = "0.17.1", optional = true } # GLUON
+gluon_base = { path = "../base", version = "0.17.2" } # GLUON
+gluon_check = { path = "../check", version = "0.17.2" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.17.2" } # GLUON
+gluon_parser = { path = "../parser", version = "0.17.2", optional = true } # GLUON
 
 [build-dependencies]
 lalrpop = { version = "0.19", features = ["lexer"], optional = true }
@@ -68,7 +68,7 @@ regex = "1"
 serde_json = "1.0.0"
 tokio = { version = "0.2", features = ["macros"] }
 
-gluon_parser = { path = "../parser", version = "0.17.1" } # GLUON
+gluon_parser = { path = "../parser", version = "0.17.2" } # GLUON
 
 [features]
 serialization = ["serde", "serde_state", "serde_derive", "serde_derive_state", "serde_json", "gluon_base/serialization", "codespan/serialization"]

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,5 +1,5 @@
 //! Crate which contain the virtual machine which executes gluon programs
-#![doc(html_root_url = "https://docs.rs/gluon_vm/0.17.1")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_vm/0.17.2")] // # GLUON
 #![recursion_limit = "1024"]
 
 #[macro_use]


### PR DESCRIPTION
<a name="v0.17.2"></a>
### v0.17.2 (2020-10-25)

#### Features

*   Allow the http module to be used without a tcp listener ([c45353d2](https://github.com/gluon-lang/gluon/commit/c45353d2ceb10d98dbeca7e7dce1f658b875eb3a))
*   Format seq expressions without seq ([5c0cec2d](https://github.com/gluon-lang/gluon/commit/5c0cec2d29a0580a8e171e040f13427b282c4c1f))
*   Compile block expressions as monadic sequences ([bce59737](https://github.com/gluon-lang/gluon/commit/bce5973719cdb24849671f5b11e980e5d9cefc31), closes [#884](https://github.com/gluon-lang/gluon/issues/884))
* **std:**
  *  add Option assertions to std.test ([28e5053f](https://github.com/gluon-lang/gluon/commit/28e5053f1e56f7304d8b94eead3174ccfa4077c6))
  *  add modulo functions to int and float ([92f188ab](https://github.com/gluon-lang/gluon/commit/92f188ab24b599d0d0ef004c996f5fbefbfe1786))

#### Bug Fixes

*   Recognize raw string literals without any `#` ([4d66fbb3](https://github.com/gluon-lang/gluon/commit/4d66fbb37f5acae81c28fe3af715b8d1c04a2ab5), closes [#885](https://github.com/gluon-lang/gluon/issues/885))
*   Prevent zero-argument functions from being created in Rust ([e91ea06d](https://github.com/gluon-lang/gluon/commit/e91ea06d447fea4f9e5699ada6f38e742526ebc7), closes [#873](https://github.com/gluon-lang/gluon/issues/873))
*   Give tuple fields a span ([2a1c2c71](https://github.com/gluon-lang/gluon/commit/2a1c2c711408372eed71812696776ee93fde3c0a))
*   xor_shift_new inconsistent description ([591b64b3](https://github.com/gluon-lang/gluon/commit/591b64b359d98948ca379fd2f17e8d34982d12b2))