### PR TITLE
Re-enable a minimal inliner/AST interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "criterion",
  "either",
  "env_logger 0.7.1",
+ "expect-test",
  "futures 0.3.5",
  "gluon-salsa",
  "gluon_base",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,11 @@ little-skeptic = { version = "0.15.0", optional = true }
 walkdir = "2"
 
 [dev-dependencies]
+anyhow = "1"
 criterion = "0.3"
 collect-mac = "0.1.0"
 env_logger = "0.7"
-anyhow = "1"
+expect-test = "1"
 thiserror = "1"
 insta = "0.16"
 pretty_assertions = "0.6"

--- a/base/src/ast.rs
+++ b/base/src/ast.rs
@@ -418,6 +418,7 @@ pub struct ExprField<'ast, Id, E> {
 #[derive(Eq, PartialEq, Debug, AstClone)]
 pub struct Do<'ast, Id> {
     pub id: Option<SpannedPattern<'ast, Id>>,
+    pub typ: Option<AstType<'ast, Id>>,
     pub bound: &'ast mut SpannedExpr<'ast, Id>,
     pub body: &'ast mut SpannedExpr<'ast, Id>,
     pub flat_map_id: Option<&'ast mut SpannedExpr<'ast, Id>>,
@@ -872,12 +873,16 @@ pub fn walk_expr<'a, 'ast, V>(v: &mut V, e: &'a $($mut)* SpannedExpr<'ast, V::Id
 
         Expr::Do(Do {
             ref $($mut)* id,
+            ref $($mut)* typ,
             ref $($mut)* bound,
             ref $($mut)* body,
             ref $($mut)* flat_map_id,
         }) => {
             if let Some(id) = id {
                 v.visit_pattern(id);
+            }
+            if let Some(ast_type) = typ {
+                v.visit_ast_type(ast_type)
             }
             v.visit_expr(bound);
             v.visit_expr(body);

--- a/check/tests/fail.rs
+++ b/check/tests/fail.rs
@@ -769,3 +769,16 @@ match Test 0 with
 "#,
 PatternError { .. }
 }
+
+test_check_err! {
+    do_type_signature_error,
+    r#"
+type List a = | Cons a (List a) | Nil
+
+let flat_map f x : (a -> List b) -> List a -> List b = Nil
+
+do writer : Int = Cons "" Nil
+Cons "" Nil
+    "#,
+Unification { .. }
+}

--- a/check/tests/pass.rs
+++ b/check/tests/pass.rs
@@ -1172,3 +1172,16 @@ viewl
     "#,
     "forall a . test.FingerTree a -> test.View a"
 }
+
+test_check! {
+    do_type_signature,
+    r#"
+type List a = | Cons a (List a) | Nil
+
+let flat_map f x : (a -> List b) -> List a -> List b = Nil
+
+do writer : String = Nil
+Cons 0 Nil
+    "#,
+    "test.List Int"
+}

--- a/check/tests/support/mod.rs
+++ b/check/tests/support/mod.rs
@@ -439,13 +439,18 @@ macro_rules! test_check {
 }
 
 macro_rules! test_check_err {
-    ($name:ident, $source:expr, $($id: pat),+) => {
+    ($name:ident, $source:expr, $($id: pat),+ $(,)? $(=> $ty: expr)?) => {
         #[test]
         fn $name() {
             let _ = env_logger::try_init();
             let text = $source;
-            let result = support::typecheck(text);
+            let (expr, result) = support::typecheck_expr(text);
             assert_err!([$source] result, $($id),+);
+            $(
+                use crate::base::ast::Typed;
+                assert_eq!(expr.expr().env_type_of(&crate::base::ast::EmptyEnv::default()).to_string(), $ty);
+            )?
+            let _ = expr;
         }
     };
 }

--- a/parser/src/grammar.lalrpop
+++ b/parser/src/grammar.lalrpop
@@ -889,18 +889,30 @@ Expr: Expr<'ast, Id> = {
 
 DoExpression: Expr<'ast, Id> = {
     "do" <bind: DoBinding> <body: SpExpr> => {
-        let bind = *bind;
-        Expr::Do(arena.alloc(Do { id: Some(bind.0), bound: arena.alloc(bind.1), body: arena.alloc(body), flat_map_id: None }))
+        let (id, typ, bound) = *bind;
+        Expr::Do(arena.alloc(Do {
+            id: Some(id),
+            typ,
+            bound: arena.alloc(bound),
+            body: arena.alloc(body),
+            flat_map_id: None,
+        }))
     },
 
     "seq" <bound: SpExpr> <body: InExpr> => {
-        Expr::Do(arena.alloc(Do { id: None, bound: arena.alloc(bound), body: arena.alloc(body), flat_map_id: None }))
+        Expr::Do(arena.alloc(Do {
+            id: None,
+            typ: None,
+            bound: arena.alloc(bound),
+            body: arena.alloc(body),
+            flat_map_id: None,
+        }))
     },
 };
 
 
-DoBinding: Box<(SpannedPattern<'ast, Id>, SpannedExpr<'ast, Id>)> = {
-    <id: Sp<Pattern>> "=" <bound: SpExpr> "in" => Box::new((id, bound)),
+DoBinding: Box<(SpannedPattern<'ast, Id>, Option<AstType<'ast, Id>>, SpannedExpr<'ast, Id>)> = {
+    <id: Sp<Pattern>> <typ: (":" <Type>)?>  "=" <bound: SpExpr> "in" => Box::new((id, typ, bound)),
 
     // Error recovery
 
@@ -910,7 +922,7 @@ DoBinding: Box<(SpannedPattern<'ast, Id>, SpannedExpr<'ast, Id>)> = {
             token: (span.start(), Token::In, span.end()),
             expected: ["="].iter().map(|s| s.to_string()).collect(),
         });
-        Box::new((id, pos::spanned(span, Expr::Error(None))))
+        Box::new((id, None, pos::spanned(span, Expr::Error(None))))
     },
 };
 
@@ -930,7 +942,7 @@ BlockExpr: Expr<'ast, Id> = {
                 pos::spanned2(
                     expr.span.start(),
                     body.span.end(),
-                    Expr::Do(arena.alloc(Do { id: None, bound: arena.alloc(expr), body: arena.alloc(body), flat_map_id: None })),
+                    Expr::Do(arena.alloc(Do { id: None, typ: None, bound: arena.alloc(expr), body: arena.alloc(body), flat_map_id: None })),
                 )
             }).value
         }

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -693,6 +693,7 @@ test
         *e.expr(),
         no_loc(Expr::Do(arena.alloc(Do {
             id: None,
+            typ: None,
             bound: arena.alloc(Spanned {
                 span: Span::new(BytePos::from(0), BytePos::from(0)),
                 value: Expr::Projection(arena.alloc(id("test")), intern(""), Type::hole()),

--- a/parser/tests/support/mod.rs
+++ b/parser/tests/support/mod.rs
@@ -281,6 +281,7 @@ pub fn do_2<'ast>(
 ) -> SpExpr<'ast> {
     no_loc(Expr::Do(arena.alloc(Do {
         id,
+        typ: None,
         bound: arena.alloc(e),
         body: arena.alloc(b),
         flat_map_id: None,

--- a/repl/src/repl.glu
+++ b/repl/src/repl.glu
@@ -8,7 +8,7 @@ let { Result } = import! std.result
 let string = import! std.string
 let thread = import! std.thread
 let array @ { ? } = import! std.array
-let { ref, load, (<-) } = import! std.reference
+let { ref, load, (<-) } = import! std.effect.reference
 let rustyline @ { Editor } = import! rustyline
 let { ReadlineError } = import! rustyline_types
 let repl_prim @ { Color, Settings } = import! repl.prim
@@ -33,7 +33,7 @@ type Cmd = {
     name : String,
     alias : String,
     info : String,
-    action : String -> Eff (ReplEffect r) ReplAction
+    action : forall r . String -> Eff (ReplEffect r) ReplAction
 }
 type Commands = Map String Cmd
 in
@@ -73,13 +73,13 @@ let run_file filename : String -> Eff (ReplEffect r) () =
     | Ok _ -> io.println ""
     | Err x -> io.println x
 
-let commands : Commands =
+let commands : Eff [| lift : Lift IO |] Commands =
     let print_result result =
         match result with
         | Ok x -> io.println x
         | Err x -> io.println x
 
-    let commands = ref []
+    do commands = ref []
     let cmds : Array Cmd =
         [{
             name = "quit",
@@ -184,15 +184,17 @@ let commands : Commands =
                 let print_cmd cmd : Cmd -> Eff (ReplEffect r) () =
                     io.println ("    :" ++ cmd.name ++ " (" ++ cmd.alias ++ ") " ++ cmd.info)
 
-                print_header
-                    *> array.traversable.traverse effect.applicative print_cmd (load commands)
+                do commands = load commands
+                print_header *> array.traversable.traverse effect.applicative print_cmd commands
                     *> wrap Continue,
         }]
-    let _ = commands <- cmds
-    foldl
-        (\map cmd -> singleton cmd.name cmd <> singleton cmd.alias cmd <> map)
-        empty
-        cmds
+    commands <- cmds
+    let c : Commands =
+        foldl
+            (\map cmd -> singleton cmd.name cmd <> singleton cmd.alias cmd <> map)
+            empty
+            cmds
+    wrap c
 
 let { Parser, parse, ? } = import! std.parser
 
@@ -255,6 +257,7 @@ let loop _ : () -> Eff (ReplEffect r) () =
 let run settings : Settings -> Eff [| lift : Lift IO |] () =
     io.println "gluon (:h for help, :q to quit)"
     do editor = lift <| rustyline.new_editor ()
+    do commands = commands
     let repl = { commands, editor }
     run_reader repl (eval_state settings (loop ()))
 

--- a/repl/tests/basic.rs
+++ b/repl/tests/basic.rs
@@ -2,8 +2,6 @@
 extern crate pretty_assertions;
 
 use std::env;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use std::process::{Command, Stdio};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -872,7 +872,7 @@ pub const PRELUDE: &'static str = r#"
 let __implicit_prelude = import! std.prelude
 let { IO, Num, Eq, Ord, Show, Functor, Applicative, Monad, Option, Bool, ? } = __implicit_prelude
 
-let { (+), (-), (*), (/), negate, (==), (/=), (<), (<=), (>=), (>), (++), show, not, flat_map } = __implicit_prelude
+let { (+), (-), (*), (/), negate, (==), (/=), (<), (<=), (>=), (>), (++), show, not, flat_map, (<|) } = __implicit_prelude
 
 let { ? } = import! std.bool
 
@@ -1001,6 +1001,13 @@ impl VmBuilder {
             "std.path.prim",
             crate::vm::primitives::load_path,
             vec!["std.path.types".into()],
+        );
+
+        add_extern_module_with_deps(
+            &vm,
+            "std.st.reference.prim",
+            crate::vm::reference::st::load,
+            vec!["std.reference".into()],
         );
 
         let deps: &[(_, fn(&Thread) -> _)] = &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -651,7 +651,10 @@ pub trait ThreadExt: Send + Sync {
         }
         let mut db = vm.get_database();
 
-        db.import(module_name).await.map(|_| ())
+        db.import(module_name)
+            .await
+            .map(|_| ())
+            .map_err(|err| err.error)
     }
 
     /// Loads `filename` and compiles and runs its input by calling `load_script`

--- a/std/effect/reference.glu
+++ b/std/effect/reference.glu
@@ -1,0 +1,11 @@
+let { lift } = import! std.effect.lift
+let m = lift_io! lift (import! std.reference)
+
+#[infix(right, 9)]
+let (<-) = m.(<-)
+
+{
+    (<-),
+    ..
+    m
+}

--- a/std/effect/st.glu
+++ b/std/effect/st.glu
@@ -4,16 +4,16 @@ let { Eff, inject_rest, ? } = import! std.effect
 let { map } = import! std.functor
 let { wrap } = import! std.applicative
 let { (<<) } = import! std.function
-let { Reference, ref, (<-), load } = import! std.reference
+let reference @ { Reference, ref, load } = import! std.st.reference.prim
 
-type STRef s a = { __ref : Reference a }
+type STRef s a = Reference a
+
+#[infix(right, 9)]
+let (<-) = reference.(<-)
 
 /// The `State` effect enables the use of mutable state. By branding the state with `s` the mutable
 /// values are prevented from escaping the monad.
 type State s r a =
-    | New : forall b . b -> State s r (STRef s b)
-    | Read : STRef s a -> State s r a
-    | Write : forall b . b -> STRef s b -> State s r ()
     | Call : forall b . (() -> b) -> State s r b
     .. r
 
@@ -24,17 +24,19 @@ let extract_state x : forall s . [| st : State s | r |] a -> State s r a = conve
 let send_state f : forall s . State s r a -> Eff [| st : State s | r |] a =
     Impure (convert_effect! st f) Pure
 
-/// Creates a new mutable reference that contains `a`.
-let new_ref a : forall s . a -> Eff [| st : State s | r |] (STRef s a) = send_state (New a)
-
 let make_call = Call
 
+/// Creates a new mutable reference that contains `a`.
+let new_ref a : forall s . a -> Eff [| st : State s | r |] (STRef s a) =
+    send_state (Call (\_ -> ref a))
+
 /// Reads the values stored in the reference.
-let read_ref ref : forall s . STRef s a -> Eff [| st : State s | r |] a = send_state (Read ref)
+let read_ref ref : forall s . STRef s a -> Eff [| st : State s | r |] a =
+    send_state (Call (\_ -> load ref))
 
 /// Writes a new value into the reference.
 let write_ref a ref : forall s . a -> STRef s a -> Eff [| st : State s | r |] () =
-    send_state (Write a ref)
+    send_state (Call (\_ -> ref <- a))
 
 /// Eliminates the `State` effect
 let run_state eff : (forall s . Eff [| st : State s | r |] a) -> Eff [| | r |] a =
@@ -43,14 +45,6 @@ let run_state eff : (forall s . Eff [| st : State s | r |] a) -> Eff [| | r |] a
         | Pure value -> wrap value
         | Impure e f ->
             match extract_state e with
-            | New a ->
-                loop (f { __ref = ref a })
-            | Read r ->
-                let a = load r.__ref
-                loop (f a)
-            | Write a r ->
-                let _ = r.__ref <- a
-                loop (f ())
             | Call g ->
                 loop (f (g ()))
             | rest ->

--- a/std/io.glu
+++ b/std/io.glu
@@ -5,9 +5,7 @@ let io_prim @ { IO, File } = import! std.io.prim
 let { Read } = import! std.io.read
 let { Write } = import! std.io.write
 let { Disposable } = import! std.disposable
-let { Functor } = import! std.functor
-let { Applicative } = import! std.applicative
-let { Monad } = import! std.monad
+let { functor, applicative, monad } = import! std.io.base
 
 /// Opens the file at `path` in read-only mode. Fails if the file does not
 /// exist.
@@ -20,21 +18,6 @@ let open_file path : String -> IO File =
 let create_file path : String -> IO File =
     let { OpenOptions } = io_prim
     io_prim.open_file_with path [Create, Write, Truncate]
-
-let functor : Functor IO = {
-    map = \f -> io_prim.flat_map (\x -> io_prim.wrap (f x)),
-}
-
-let applicative : Applicative IO =
-    let wrap = io_prim.wrap
-    let apply f x = io_prim.flat_map (\g -> io_prim.flat_map (\y -> wrap (g y)) x) f
-
-    { functor, apply, wrap }
-
-let monad : Monad IO = {
-    applicative = applicative,
-    flat_map = io_prim.flat_map,
-}
 
 let read : Read File = {
     read = io_prim.read_file,

--- a/std/io/base.glu
+++ b/std/io/base.glu
@@ -1,0 +1,23 @@
+let { Functor } = import! std.functor
+let { Applicative } = import! std.applicative
+let { Monad } = import! std.monad
+
+let io_prim @ { IO } = import! std.io.prim
+
+
+let functor : Functor IO = {
+    map = \f -> io_prim.flat_map (\x -> io_prim.wrap (f x)),
+}
+
+let applicative : Applicative IO =
+    let wrap = io_prim.wrap
+    let apply f x = io_prim.flat_map (\g -> io_prim.flat_map (\y -> wrap (g y)) x) f
+
+    { functor, apply, wrap }
+
+let monad : Monad IO = {
+    applicative = applicative,
+    flat_map = io_prim.flat_map,
+}
+
+{ IO, functor, applicative, monad }

--- a/std/io/read.glu
+++ b/std/io/read.glu
@@ -1,7 +1,8 @@
 //@NO-IMPLICIT-PRELUDE
 //! Functions and types for working with `Read`ers.
 
-let { IO, wrap, flat_map, default_buf_len } = import! std.io.prim
+let io @ { IO, wrap, flat_map, default_buf_len } = import! std.io.prim
+let { show } = import! std.show
 let { Option, Bool } = import! std.types
 let { Disposable, dispose, is_disposed } = import! std.disposable
 let { (>), (<=), (>=), min } = import! std.cmp
@@ -68,49 +69,51 @@ type Buffered r = { reader : r, buf : Reference (Array Byte), capacity : Int }
 
 /// Wraps `reader` in a `Buffered` reader to provide buffering with the specified
 /// buffer capacity.
-let buffered_with_capacity capacity reader : [Read a] -> Int -> a -> Buffered a =
+let buffered_with_capacity capacity reader : [Read a] -> Int -> a -> IO (Buffered a) =
     let _ = assert (capacity > 0)
 
-    {
-        reader,
-        buf = ref [],
-        capacity,
-    }
+    do buf = ref []
+    wrap
+        {
+            reader,
+            buf,
+            capacity,
+        }
 
 /// Wraps `reader` in a `Buffered` reader to provide buffering.
-let buffered reader : [Read a] -> a -> Buffered a =
+let buffered reader : [Read a] -> a -> IO (Buffered a) =
     buffered_with_capacity default_buf_len reader
 
 let read_buffered : [Read r] -> Read (Buffered r) =
     let read_from_buf buf_reader num_bytes =
-        let buf = load buf_reader.buf
+        do buf = load buf_reader.buf
         let num_bytes = min (array.len buf) num_bytes
 
         let read_buf = array.slice buf 0 num_bytes
         let rest_buf = array.slice buf num_bytes (array.len buf)
 
-        let _ = buf_reader.buf <- rest_buf
-        Some read_buf
+        buf_reader.buf <- rest_buf
+        wrap (Some read_buf)
 
     let buffered_read buf_reader num_bytes =
-        let buf = load buf_reader.buf
+        do buf = load buf_reader.buf
 
         if num_bytes <= 0 then wrap (Some [])
-        else if not (array.is_empty buf) then wrap (read_from_buf buf_reader num_bytes)
+        else if not (array.is_empty buf) then read_from_buf buf_reader num_bytes
         else if num_bytes >= buf_reader.capacity then read buf_reader.reader num_bytes
         else
             do new_buf = read buf_reader.reader buf_reader.capacity
 
             match new_buf with
             | Some new_buf ->
-                let _ = buf_reader.buf <- new_buf
-                wrap (read_from_buf buf_reader num_bytes)
+                buf_reader.buf <- new_buf
+                read_from_buf buf_reader num_bytes
             | None -> wrap None
 
     let buffered_read_to_end buf_reader =
         do rest = read_to_end buf_reader.reader
-        let buf = load buf_reader.buf
-        let _ = buf_reader.buf <- []
+        do buf = load buf_reader.buf
+        buf_reader.buf <- []
 
         wrap (array.append buf rest)
 
@@ -122,7 +125,7 @@ let read_buffered : [Read r] -> Read (Buffered r) =
 let disposable_buffered : [Disposable r] -> Disposable (Buffered r) =
     {
         dispose = (\buf_reader ->
-            let _ = buf_reader.buf <- []
+            buf_reader.buf <- []
             dispose buf_reader.reader),
         is_disposed = \buf_reader -> is_disposed buf_reader.reader,
     }

--- a/std/io/write.glu
+++ b/std/io/write.glu
@@ -67,22 +67,24 @@ type Buffered w = { writer : w, buf : Reference (Array Byte), capacity : Int }
 
 /// Wraps `writer` in a `Buffered` writer to provide buffering with the specified
 /// buffer capacity.
-let buffered_with_capacity capacity writer : [Write w] -> Int -> w -> Buffered w =
+let buffered_with_capacity capacity writer : [Write w] -> Int -> w -> IO (Buffered w) =
     let _ = assert (capacity > 0)
+    do buf = ref []
 
-    {
-        writer,
-        buf = ref [],
-        capacity,
-    }
+    wrap
+        {
+            writer,
+            buf,
+            capacity,
+        }
 
 /// Wraps `writer` in a `Buffered` writer to provide buffering.
-let buffered writer : [Write w] -> w -> Buffered w =
+let buffered writer : [Write w] -> w -> IO (Buffered w) =
     buffered_with_capacity default_buf_len writer
 
 /// Flushes the buffer of `buf_writer`. If an EOF is encountered, the call will fail.
 let flush_buffer buf_writer : [Write w] -> Buffered w -> IO () =
-    let buf = load buf_writer.buf
+    do buf = load buf_writer.buf
 
     if array.is_empty buf then wrap ()
     else
@@ -96,7 +98,7 @@ let flush_buffer buf_writer : [Write w] -> Buffered w -> IO () =
                 else write_buf (bytes_written + written)
 
         do _ = write_buf 0
-        let _ = buf_writer.buf <- []
+        buf_writer.buf <- []
         wrap ()
 
 let write_buffered : [Write w] -> Write (Buffered w) =
@@ -105,9 +107,9 @@ let write_buffered : [Write w] -> Write (Buffered w) =
         let _ = assert (slice_len >= 0)
 
         do _ =
+            do buf = load buf_writer.buf
             // if the new data would spill the buffer, flush it first
-            if array.len (load buf_writer.buf) + slice_len >= buf_writer.capacity then
-                flush_buffer buf_writer
+            if array.len buf + slice_len >= buf_writer.capacity then flush_buffer buf_writer
             else wrap ()
 
         // if the slice is larger than the max buffer length write it directly;
@@ -116,8 +118,8 @@ let write_buffered : [Write w] -> Write (Buffered w) =
         // necessary
         if slice_len >= buf_writer.capacity then write_slice buf_writer.writer slice start end
         else
-            let _ =
-                buf_writer.buf <- array.append (load buf_writer.buf) (array.slice slice start end)
+            do buf = load buf_writer.buf
+            buf_writer.buf <- array.append buf (array.slice slice start end)
             wrap slice_len
 
     let buffered_flush buf_writer =

--- a/std/prelude.glu
+++ b/std/prelude.glu
@@ -20,6 +20,7 @@ let { Array } = import! std.array
 let { (++) } = import! std.string
 let { error } = import! std.prim
 let { flat_map } = import! std.monad
+let { (<|) } = import! std.function
 
 {
     IO,
@@ -76,4 +77,6 @@ let { flat_map } = import! std.monad
     error,
 
     flat_map,
+
+    (<|),
 }

--- a/std/reference.glu
+++ b/std/reference.glu
@@ -1,11 +1,20 @@
 //! A mutable reference type
 
 let reference @ { Reference } = import! std.reference.prim
+let { flat_map } = import! std.monad
+
+let { IO, ? } = import! std.io.base
+
 #[infix(right, 9)]
 let (<-) = reference.(<-)
+
+let modify r f : Reference a -> (a -> a) -> IO () =
+    do x = reference.load r
+    r <- f x
 {
     Reference,
     (<-),
+    modify,
     ..
     reference
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -159,7 +159,7 @@ fn spawn_on_twice() {
         let thread = import! std.thread
 
         do child = thread.new_thread ()
-        do action = thread.spawn_on child (\_ -> wrap "abc")
+        do action = thread.spawn_on child (wrap "abc")
         action
     "#;
 
@@ -196,7 +196,7 @@ fn spawn_on_runexpr() {
         let thread = import! std.thread
 
         do child = thread.new_thread ()
-        do action = thread.spawn_on child (\_ -> io.run_expr "123")
+        do action = thread.spawn_on child (io.run_expr "123")
         do x = action
         seq io.println x.value
         wrap x.value
@@ -222,20 +222,18 @@ fn spawn_on_do_action_twice() {
 
     let text = r#"
         let { ? } = import! std.io
-        let { ref, (<-), load } = import! std.reference
+        let { ref, modify, load } = import! std.reference
         let thread = import! std.thread
         let { wrap } = import! std.applicative
         let { join } = import! std.monad
 
-        let counter = ref 0
+        do counter = ref 0
 
         do child = thread.new_thread ()
-        let action = thread.spawn_on child (\_ ->
-                let _ = counter <- (load counter + 1)
-                wrap ())
+        let action = thread.spawn_on child (modify counter (\x -> x + 1))
         seq join action
         seq join action
-        wrap (load counter)
+        load counter
     "#;
 
     let mut runtime = Runtime::new().unwrap();
@@ -253,19 +251,17 @@ fn spawn_on_force_action_twice() {
 
     let text = r#"
         let { ? } = import! std.io
-        let { ref, (<-), load } = import! std.reference
+        let { ref, modify, load } = import! std.reference
         let thread = import! std.thread
         let { wrap } = import! std.applicative
 
-        let counter = ref 0
+        do counter = ref 0
 
         do child = thread.new_thread ()
-        do action = thread.spawn_on child (\_ ->
-                let _ = counter <- (load counter + 1)
-                wrap ())
+        do action = thread.spawn_on child (modify counter (\x -> x + 1))
         seq action
         seq action
-        wrap (load counter)
+        load counter
     "#;
 
     let mut runtime = Runtime::new().unwrap();
@@ -290,8 +286,7 @@ fn spawn_on_runexpr_in_catch() {
 
         let action =
             do eval_thread = thread.new_thread ()
-            let f _ = io.run_expr "123"
-            do a = thread.spawn_on eval_thread f
+            do a = thread.spawn_on eval_thread (io.run_expr "123")
             do result = a
             wrap result.value
         (io.catch action wrap >>= io.println) *> wrap "123"

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -6,7 +6,7 @@ use std::thread::spawn;
 use gluon::{
     new_vm,
     vm::{
-        api::{FunctionRef, OpaqueValue},
+        api::{FunctionRef, OpaqueValue, IO},
         channel::{ChannelRecord, Receiver, Sender},
     },
     Error, RootedThread, ThreadExt,
@@ -24,54 +24,64 @@ fn parallel() {
 fn parallel_() -> Result<(), Error> {
     let vm = new_vm();
 
+    vm.get_database_mut().run_io(true);
+
     vm.run_expr::<()>("<top>", " let _ = import! std.channel in () ")?;
 
-    let (value, _) = vm.run_expr(
+    let (value, _) = vm.run_expr::<IO<_>>(
         "<top>",
         " let { channel } = import! std.channel in channel 0 ",
     )?;
     let record_p! { sender, receiver }: ChannelRecord<
         OpaqueValue<RootedThread, Sender<i32>>,
         OpaqueValue<RootedThread, Receiver<i32>>,
-    > = value;
+    > = Result::from(value)?;
 
     let child = vm.new_thread()?;
     let handle1 = spawn(move || -> Result<(), Error> {
         let expr = r#"
+        let { ? } = import! std.io
+        let { wrap } = import! std.applicative
         let { send } = import! std.channel
         let f sender =
-            let _ = send sender 1
-            let _ = send sender 2
-            ()
+            send sender 1
+            send sender 2
+            wrap ()
         f
         "#;
-        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Sender<i32>>)> =
+        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Sender<i32>>) -> IO<()>> =
             child.run_expr("<top>", expr)?.0;
-        Ok(f.call(sender)?)
+        Ok(f.call(sender)
+            .and_then(|io| Result::from(io).map_err(From::from))?)
     });
 
     let child2 = vm.new_thread()?;
     let handle2 = spawn(move || -> Result<(), Error> {
         let expr = r#"
         let { assert }  = import! std.test
+        let { wrap }  = import! std.applicative
+        let { ? } = import! std.io
         let { Bool } = import! std.bool
         let { Result }  = import! std.result
         let { recv } = import! std.channel
 
         let f receiver =
-            let _ =
-                match recv receiver with
-                | Ok x -> assert (x == 1)
-                | Err _ -> assert False
-            match recv receiver with
-            | Ok x -> assert (x == 2)
-            | Err _ -> assert False
+            do x = recv receiver
+            match x with
+            | Ok x -> wrap <| assert (x == 1)
+            | Err _ -> error "Fail 1"
+
+            do x = recv receiver
+            match x with
+            | Ok x -> wrap <| assert (x == 2)
+            | Err _ -> error "Fail 2"
 
         f
         "#;
-        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Receiver<i32>>)> =
+        let mut f: FunctionRef<fn(OpaqueValue<RootedThread, Receiver<i32>>) -> IO<()>> =
             child2.run_expr("<top>", expr)?.0;
-        Ok(f.call(receiver)?)
+        Ok(f.call(receiver)
+            .and_then(|io| Result::from(io).map_err(From::from))?)
     });
 
     // Ensure that both threads stop without any panics (just dropping ignores panics)

--- a/tests/pass/buffered_io.glu
+++ b/tests/pass/buffered_io.glu
@@ -5,6 +5,7 @@
 let { assert_eq }  = import! std.test
 let { wrap, (<*) } = import! std.applicative
 let { (<|), (|>) } = import! std.function
+let { (=<<) } = import! std.monad
 let { ? } = import! std.io
 let io_read @ { Read, default_read_to_end, read, read_to_end, ? } = import! std.io.read
 let io_write @ { Write, write_slice, write, write_all, flush, ? } = import! std.io.write
@@ -21,17 +22,19 @@ type Cursor = {
     buf : Array Byte
 }
 
-let cursor buf : Array Byte -> Cursor = {
-    pos = ref 0,
-    buf,
-}
+let cursor buf : Array Byte -> IO Cursor =
+    do pos = ref 0
+    wrap {
+        pos,
+        buf,
+    }
 
 let read_cursor : Read Cursor =
     let read cursor num_bytes : Cursor -> Int -> IO (Option (Array Byte)) =
-        let start = load cursor.pos
+        do start = load cursor.pos
         let end = min (array.len cursor.buf) (start + num_bytes)
         let read_bytes = array.slice cursor.buf start end
-        let _ = cursor.pos <- (start + array.len read_bytes)
+        cursor.pos <- (start + array.len read_bytes)
 
         if array.is_empty read_bytes then
             wrap None
@@ -45,8 +48,9 @@ let read_cursor : Read Cursor =
 
 let write_array_ref : Write (Reference (Array Byte)) = {
     write_slice = \array_ref buf start end ->
-        let written = array.append (load array_ref) (array.slice buf start end)
-        let _ = array_ref <- written
+        do array_buf = load array_ref
+        let written = array.append array_buf (array.slice buf start end)
+        array_ref <- written
         wrap (end - start),
 
     flush = \_ -> wrap ()
@@ -55,7 +59,9 @@ let write_array_ref : Write (Reference (Array Byte)) = {
 
 let test_read = [
     test "basic" <| \_ ->
-        let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 4
+        do reader = lift (
+            do c = cursor [1b, 2b, 3b, 4b, 5b]
+            io_read.buffered_with_capacity 4 c)
 
         do bytes = lift <| read reader 2
         do _ = assert_eq bytes (Some [1b, 2b])
@@ -70,12 +76,12 @@ let test_read = [
         assert_eq (bytes) None,
 
     test "read directly if buffer is empty" <| \_ ->
-        let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 2
+        do reader =  lift <| io_read.buffered_with_capacity 2 =<< cursor [1b, 2b, 3b, 4b, 5b]
         do bytes = lift <| read reader 5
         assert_eq bytes (Some [1b, 2b, 3b, 4b, 5b]),
 
     test "read rest of buffer if it still holds data" <| \_ ->
-        let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 2
+        do reader = lift <| io_read.buffered_with_capacity 2 =<< cursor [1b, 2b, 3b, 4b, 5b]
         do _ = lift <| read reader 1
         do bytes = lift <| read reader 4
         assert_eq bytes (Some [2b]),
@@ -83,17 +89,17 @@ let test_read = [
 
 let test_read_to_end = [
     test "read all in one go" <| \_ ->
-        let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 5
+        do reader = lift <| io_read.buffered_with_capacity 5 =<< cursor [1b, 2b, 3b, 4b, 5b]
         do bytes = lift <| read_to_end reader
         assert_eq (bytes) [1b, 2b, 3b, 4b, 5b],
 
     test "read with small buffer" <| \_ ->
-        let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 1
+        do reader = lift <| io_read.buffered_with_capacity 1 =<< cursor [1b, 2b, 3b, 4b, 5b]
         do bytes = lift <| read_to_end reader
         assert_eq (bytes) [1b, 2b, 3b, 4b, 5b],
 
     test "read with part of buffer already read" <| \_ ->
-        let reader = cursor [1b, 2b, 3b, 4b, 5b] |> io_read.buffered_with_capacity 2
+        do reader = lift <| io_read.buffered_with_capacity 2 =<< cursor [1b, 2b, 3b, 4b, 5b]
         do _ = lift <| read reader 1
         do bytes = lift <| read_to_end reader
         assert_eq bytes [2b, 3b, 4b, 5b],
@@ -101,93 +107,108 @@ let test_read_to_end = [
 
 let test_write_and_flush = [
     test "buffer all data if it fits" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 5
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift <| io_write.buffered_with_capacity 5 written
 
         do bytes_written = lift <| write writer [1b, 2b]
         do _ = assert_eq bytes_written 2
-        do _ = assert_eq (load written) []
+        do w = lift <| load written
+        do _ = assert_eq w []
         do _ = lift <| flush writer
-        assert_eq (load written) [1b, 2b],
+        do w = lift <| load written
+        assert_eq w [1b, 2b],
 
     test "flush immediately if buffer is empty and new data wouldn't fit" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 2
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift <| io_write.buffered_with_capacity 2 written
 
         do bytes_written = lift <| write writer [1b, 2b, 3b]
         do _ = assert_eq bytes_written 3
-        do _ = assert_eq (load written) [1b, 2b, 3b]
+        do w = lift <| load written
+        do _ = assert_eq w [1b, 2b, 3b]
         do _ = lift <| flush writer
-        assert_eq (load written) [1b, 2b, 3b],
+        do w = lift <| load written
+        assert_eq w [1b, 2b, 3b],
 
     test "flush buffer and then write new data if it wouldn't fit the buffer" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 2
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift <| io_write.buffered_with_capacity 2 written
 
         do bytes_written = lift <| write writer [1b]
         do _ = assert_eq (bytes_written) 1
-        do _ = assert_eq (load written) []
+        do w = lift <| load written
+        do _ = assert_eq w []
         do bytes_written = lift <| write writer [2b, 3b]
         do _ = assert_eq (bytes_written) 2
-        do _ = assert_eq (load written) [1b, 2b, 3b]
+        do w = lift <| load written
+        do _ = assert_eq w [1b, 2b, 3b]
         do _ = lift <| flush writer
-        assert_eq (load written) [1b, 2b, 3b],
+        do w = lift <| load written
+        assert_eq w [1b, 2b, 3b],
 
     test "flush buffer if new data doesn't fit, then buffer the data" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 5
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift <| io_write.buffered_with_capacity 5 written
 
         do bytes_written = lift <| write writer [1b, 2b, 3b]
         do _ = assert_eq (bytes_written) 3
-        do _ = assert_eq (load written) []
+        do w = lift <| load written
+        do _ = assert_eq w []
         do bytes_written = lift <| write writer [4b, 5b, 6b]
         do _ = assert_eq (bytes_written) 3
-        do _ = assert_eq (load written) [1b, 2b, 3b]
+        do w = lift <| load written
+        do _ = assert_eq w [1b, 2b, 3b]
         do _ = lift <| flush writer
-        assert_eq (load written) [1b, 2b, 3b, 4b, 5b, 6b]
+        do w = lift <| load written
+        assert_eq w [1b, 2b, 3b, 4b, 5b, 6b]
 ]
 
 let test_write_slice = [
     test "empty slice" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 5
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift <| io_write.buffered_with_capacity 5 written
         do bytes_written = lift <| write_slice writer [1b, 2b, 3b, 4b] 0 0
         do _ = assert_eq (bytes_written) 0
         do _ = lift <| flush writer
-        assert_eq (load written) [],
+        do w = lift <| load written
+        assert_eq w [],
 
     test "slice partial" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 5
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift (written |> io_write.buffered_with_capacity 5)
         do bytes_written = lift <| write_slice writer [1b, 2b, 3b, 4b] 1 3
         do _ = assert_eq (bytes_written) 2
         do _ = lift <| flush writer
-        assert_eq (load written) [2b, 3b],
+        do w = lift <| load written
+        assert_eq w [2b, 3b],
 
     test "slice everything" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 5
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift (written |> io_write.buffered_with_capacity 5)
         do bytes_written = lift <| write_slice writer [1b, 2b, 3b, 4b] 0 4
         do _ = assert_eq (bytes_written) 4
         do _ = lift <| flush writer
-        assert_eq (load written) [1b, 2b, 3b, 4b],
+        do w = lift <| load written
+        assert_eq w [1b, 2b, 3b, 4b],
 ]
 
 let test_write_all = [
     test "basic" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 1
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift (written |> io_write.buffered_with_capacity 1)
         do _ = lift <| write_all writer [1b, 2b, 3b, 4b]
         do _ = lift <| flush writer
-        assert_eq (load written) [1b, 2b, 3b, 4b],
+        do w = lift <| load written
+        assert_eq w [1b, 2b, 3b, 4b],
 
     test "write the data that's already buffered too" <| \_ ->
-        let written : Reference (Array Byte) = ref []
-        let writer = written |> io_write.buffered_with_capacity 2
+        do written : Reference (Array Byte) = lift <| ref []
+        do writer = lift (written |> io_write.buffered_with_capacity 2)
         do _ = lift <| write writer [1b]
         do _ = lift <| write_all writer [2b, 3b, 4b]
         do _ = lift <| flush writer
-        assert_eq (load written) [1b, 2b, 3b, 4b],
+        do w = lift <| load written
+        assert_eq w [1b, 2b, 3b, 4b],
 ]
 
 group "buffered_io" [

--- a/tests/pass/channel.glu
+++ b/tests/pass/channel.glu
@@ -1,4 +1,5 @@
 let { TestEff, run, assert_eq, test, group, ? }  = import! std.test
+let { lift } = import! std.effect.lift
 let { (<|) } = import! std.function
 let prelude  = import! std.prelude
 let { Applicative, (*>), ? } = import! std.applicative
@@ -10,15 +11,15 @@ let { send, recv, channel } = import! std.channel
 
 let { ? } = import! std.effect
 
-let { sender, receiver } = channel 0
+let assert_recv channel expect : [Eq a] -> [Show a] -> _ -> Result () a -> _ =
+    do x = lift <| recv channel
+    assert_eq x expect
 
-let _ = send sender 0
-let _ = send sender 1
-let _ = send sender 2
-
-let tests : TestEff r () =
-    assert_eq (recv receiver) (Ok 0)
-        *> assert_eq (recv receiver) (Ok 1)
-        *> assert_eq (recv receiver) (Ok 2)
-
-test "channel" <| \_ -> tests
+test "channel" <| \_ ->
+    do { sender, receiver } = lift <| channel 0
+    seq lift <| send sender 0
+    seq lift <| send sender 1
+    seq lift <| send sender 2
+    seq assert_recv receiver (Ok 0)
+    seq assert_recv receiver (Ok 1)
+    assert_recv receiver (Ok 2)

--- a/tests/pass/deep_clone_userdata.glu
+++ b/tests/pass/deep_clone_userdata.glu
@@ -1,44 +1,55 @@
-let { run, assert, group, ? } = import! std.test
+let { run, assert, assert_eq, group, test, ? } = import! std.test
+let { lift } = import! std.effect.lift
+let { ? } = import! std.effect
 let { (<|) } = import! std.function
 let prelude = import! std.prelude
-let { (*>) } = import! std.applicative
+let { wrap, (*>) } = import! std.applicative
 let { Result } = import! std.result
 let { ref, load } = import! std.reference
 let { lazy, force } = import! std.lazy
 let { channel, send, recv } = import! std.channel
 let { resume, spawn } = import! std.thread
-
-
-let _ =
-    let { sender, receiver } = channel (lazy (\_ -> 0))
-
-    let thread = spawn (\_ ->
-            let _ = send sender (lazy (\_ -> 1))
-            let l = lazy (\_ -> 2)
-            let _ = force l
-            let _ = send sender l
-            ())
-
-    let _ = resume thread
-    let _ =
-        match recv receiver with
-        | Ok x -> assert (force x == 1)
-        | Err e -> error "Receive 1 error"
-    match recv receiver with
-    | Ok x -> assert (force x == 2)
-    | Err e -> error "Receive 2 error"
-
-let _ =
-    let { sender, receiver } = channel (ref 0)
-
-    let thread = spawn (\_ ->
-            let _ = send sender (ref 3)
-            ())
-
-    let _ = resume thread
-    match recv receiver with
-    | Ok x -> assert (load x == 3)
-    | Err e -> error "Receive 3 error"
+let { ? } = import! std.io
 
 // Dummy test
-group "deep_clone_userdata" []
+group "deep_clone_userdata" [
+    test "1" <| \_ ->
+        do { sender, receiver } = lift <| channel (lazy (\_ -> 0))
+
+        do thread = lift <| spawn (
+                seq send sender (lazy (\_ -> 1))
+                let l = lazy (\_ -> 2)
+                let _ = force l
+                send sender l
+                wrap ())
+
+        lift <| resume thread
+        do x = lift <| recv receiver
+        match x with
+        | Ok x -> assert_eq (force x) 1
+        | Err e -> error "Receive 1 error"
+        do x = lift <| recv receiver
+        match x with
+        | Ok x -> assert_eq (force x) 2
+        | Err e -> error "Receive 2 error",
+
+    test "2" <| \_ ->
+        do r = lift <| ref 0
+        do { sender, receiver } = lift <| channel r
+
+        do thread = lift <| spawn (
+                do r = ref 3
+                send sender r
+                wrap ())
+
+        do r = lift <| resume thread
+        match r with
+        | Ok () -> wrap ()
+        | Err e -> error e
+        do r = lift <| recv receiver
+        match r with
+        | Ok x ->
+            do x = lift <| load x
+            assert_eq x 3
+        | Err e -> error "Receive 3 error"
+]

--- a/tests/pass/reference.glu
+++ b/tests/pass/reference.glu
@@ -1,16 +1,24 @@
-let { assert, group } = import! std.test
+let { assert_eq, group, test } = import! std.test
 let { (<|) } = import! std.function
+let { ? } = import! std.io
 let int = import! std.int
 let { Bool } = import! std.bool
-let { ref, (<-), load } = import! std.reference
+let { Reference, ref, (<-), load } = import! std.effect.reference
+let { ? } = import! std.effect
+let { lift } = import! std.effect.lift
 
-let ri = ref 0
-let _ = assert (0 == load ri)
-let _ = ri <- 2
-let _ = assert (2 == load ri)
-let _ = assert (2 == load ri)
-let _ = ri <- 10
-let _ = assert (10 == load ri)
+let assert_eq_ref l r : [Show a] -> [Eq a] -> a -> Reference a -> _ =
+    do r = load r
+    assert_eq l r
 
 // Dummy test
-group "reference" []
+group "reference" [
+    test "basic" <| \_ ->
+        do ri = ref 0
+        assert_eq_ref 0 ri
+        ri <- 2
+        assert_eq_ref 2 ri
+        assert_eq_ref 2 ri
+        ri <- 10
+        assert_eq_ref 10 ri
+]

--- a/tests/pass/thread.glu
+++ b/tests/pass/thread.glu
@@ -1,12 +1,14 @@
-let { run, TestEff, assert_eq, test, ? }  = import! std.test
+let { run, assert_eq, test, ? }  = import! std.test
+let { lift } = import! std.effect.lift
 let { (<|) } = import! std.function
 let prelude  = import! std.prelude
 let { Bool } = import! std.bool
 let int = import! std.int
+let { ? } = import! std.io
 let result @ { Result, ? } = import! std.result
 let string = import! std.string
 let unit @ { ? } = import! std.unit
-let { Applicative, (*>) } = import! std.applicative
+let { Applicative, wrap, (*>) } = import! std.applicative
 let { flat_map } = import! std.monad
 let { send, recv, channel } = import! std.channel
 let { spawn, yield, resume } = import! std.thread
@@ -17,24 +19,27 @@ let assert_any_err =
     assert_eq ?(result.show ?string.show ?unit.show)
               ?(result.eq ?{ (==) = \x y -> True } ?unit.eq)
 
-let { sender, receiver } = channel 0
 
-let thread = spawn (\_ ->
-        let _ = send sender 0
-        let _ = yield ()
-        let _ = send sender 1
-        ()
-    )
-let _ = resume thread
+let assert_recv channel expect : [Eq a] -> [Show a] -> _ -> Result () a -> _ =
+    do x = lift <| recv channel
+    assert_eq x expect
 
-let tests : TestEff r () =
-    seq assert_eq (recv receiver) (Ok 0)
+test "thread" <| \_ ->
+    do { sender, receiver } = lift <| channel 0
+    do thread = lift <| spawn (
+            seq send sender 0
+            let _ = yield ()
+            seq send sender 1
+            wrap ()
+        )
+    seq lift <| resume thread
 
-    seq assert_eq (recv receiver) (Err ())
-    let _ = resume thread
-    seq assert_eq (recv receiver) (Ok 1)
+    seq assert_recv receiver (Ok 0)
 
-    seq assert_eq (recv receiver) (Err ())
-    assert_any_err (resume thread) (Err "Any error message here")
+    seq assert_recv receiver (Err ())
+    seq lift <| resume thread
+    seq assert_recv receiver (Ok 1)
 
-test "thread" <| \_ -> tests
+    seq assert_recv receiver (Err ())
+    do x = lift <| resume thread
+    assert_any_err x (Err "Any error message here")

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -1017,7 +1017,7 @@ let { (>>=) } = import! std.monad
 let { id } = import! std.function
 do t = thread.new_thread ()
 
-thread.join (io.println "test" *> wrap 123) (thread.spawn_on t (\_ -> wrap "abc") >>= id)
+thread.join (io.println "test" *> wrap 123) (thread.spawn_on t (wrap "abc") >>= id)
 "#,
 IO::Value((123, "abc".to_string()))
 }

--- a/vm/src/api/mod.rs
+++ b/vm/src/api/mod.rs
@@ -265,7 +265,7 @@ impl VmType for Hole {
 }
 
 /// Type representing gluon's IO type
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum IO<T> {
     Value(T),
     Exception(String),
@@ -277,9 +277,9 @@ impl<T> IO<T> {
     }
 }
 
-impl<T> Into<StdResult<T, String>> for IO<T> {
-    fn into(self) -> StdResult<T, String> {
-        match self {
+impl<T> From<IO<T>> for StdResult<T, String> {
+    fn from(io: IO<T>) -> StdResult<T, String> {
+        match io {
             IO::Value(x) => Ok(x),
             IO::Exception(x) => Err(x),
         }

--- a/vm/src/core/optimize.rs
+++ b/vm/src/core/optimize.rs
@@ -281,8 +281,6 @@ fn optimize_unnecessary_allocation<'a>(
     optimizer.visit_expr(expr).unwrap_or(expr)
 }
 
-const INLINE: bool = false;
-
 pub fn optimize<'a>(
     allocator: &'a Arc<Allocator<'a>>,
     env: &'a dyn OptimizeEnv<Type = ArcType>,
@@ -305,6 +303,7 @@ pub fn optimize<'a>(
             .map(crate::core::interpreter::Binding::from)
     };
 
+    const INLINE: bool = false;
     if INLINE {
         let inlined_global_bindings = Default::default();
         let mut interpreter =

--- a/vm/src/derive/deserialize.rs
+++ b/vm/src/derive/deserialize.rs
@@ -153,6 +153,7 @@ pub fn generate<'ast>(
         typ: Some(binding_type(
             arena,
             symbols,
+            span,
             "Deserialize",
             self_type(),
             bind,

--- a/vm/src/derive/eq.rs
+++ b/vm/src/derive/eq.rs
@@ -220,7 +220,7 @@ pub fn generate<'ast>(
         args: &mut [],
         expr: pos::spanned(span, eq_record_expr),
         metadata: Default::default(),
-        typ: Some(binding_type(arena, symbols, "Eq", self_type(), bind)),
+        typ: Some(binding_type(arena, symbols, span, "Eq", self_type(), bind)),
         resolved_type: Type::hole(),
     })
 }

--- a/vm/src/derive/serialize.rs
+++ b/vm/src/derive/serialize.rs
@@ -222,7 +222,14 @@ pub fn generate<'ast>(
         args: &mut [],
         expr: serializer_record_expr,
         metadata: Default::default(),
-        typ: Some(binding_type(arena, symbols, "Serialize", self_type(), bind)),
+        typ: Some(binding_type(
+            arena,
+            symbols,
+            span,
+            "Serialize",
+            self_type(),
+            bind,
+        )),
         resolved_type: Type::hole(),
     })
 }

--- a/vm/src/derive/show.rs
+++ b/vm/src/derive/show.rs
@@ -204,7 +204,14 @@ pub fn generate<'ast>(
         args: &mut [],
         expr: pos::spanned(span, show_record_expr),
         metadata: Default::default(),
-        typ: Some(binding_type(arena, symbols, "Show", self_type(), bind)),
+        typ: Some(binding_type(
+            arena,
+            symbols,
+            span,
+            "Show",
+            self_type(),
+            bind,
+        )),
         resolved_type: Type::hole(),
     })
 }


### PR DESCRIPTION
The current inliner/conste evalutaor/AST interpreter breaks the code really easily so I stripped away what didn't work (mostly) so it can be re-enabled in a minimal form.