### PR TITLE
Version 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+<a name="v0.18.0"></a>
+## v0.18.0 (2021-10-03)
+
+
+#### Performance
+
+*   Avoid recreating the vm for each formatted file ([0335733e](https://github.com/gluon-lang/gluon/commit/0335733e7f4b5b0588b6adbdde32765126e6b12f))
+
+#### Breaking Changes
+
+*   Make channels and reference require IO ([c9041898](https://github.com/gluon-lang/gluon/commit/c904189834a2548af1781f68d2e35b5b9e3ac2c8), breaks [#](https://github.com/gluon-lang/gluon/issues/))
+
+#### Features
+
+*   Make channels and reference require IO ([c9041898](https://github.com/gluon-lang/gluon/commit/c904189834a2548af1781f68d2e35b5b9e3ac2c8), breaks [#](https://github.com/gluon-lang/gluon/issues/))
+*   Allow specifying type signatures in do bindings ([fac08dcf](https://github.com/gluon-lang/gluon/commit/fac08dcff7a019440dd8d0a886abdb18baa58198))
+*   Allow macros to refer to symbols in scope at the expansion site ([1a5489c6](https://github.com/gluon-lang/gluon/commit/1a5489c61db82af64104e01e359217154efd0d24), closes [#895](https://github.com/gluon-lang/gluon/issues/895))
+*   Allow the http module to be used without a tcp listener ([c45353d2](https://github.com/gluon-lang/gluon/commit/c45353d2ceb10d98dbeca7e7dce1f658b875eb3a))
+*   Format seq expressions without seq ([5c0cec2d](https://github.com/gluon-lang/gluon/commit/5c0cec2d29a0580a8e171e040f13427b282c4c1f))
+*   Compile block expressions as monadic sequences ([bce59737](https://github.com/gluon-lang/gluon/commit/bce5973719cdb24849671f5b11e980e5d9cefc31), closes [#884](https://github.com/gluon-lang/gluon/issues/884))
+* **std:**
+  *  add Option assertions to std.test ([28e5053f](https://github.com/gluon-lang/gluon/commit/28e5053f1e56f7304d8b94eead3174ccfa4077c6))
+  *  add modulo functions to int and float ([92f188ab](https://github.com/gluon-lang/gluon/commit/92f188ab24b599d0d0ef004c996f5fbefbfe1786))
+
+#### Bug Fixes
+
+*   Allow the repl to compile concurrently ([2118f4d2](https://github.com/gluon-lang/gluon/commit/2118f4d2816ba400dd2024356cd05a40d6cf2366))
+*   Don't use the empty span in derive macros ([d05f1ca8](https://github.com/gluon-lang/gluon/commit/d05f1ca86bff843baf26dc15b6ee9820c35d4b94))
+*   Provide the type of imported modules with errors ([d3bfc598](https://github.com/gluon-lang/gluon/commit/d3bfc598d6aecad942e1d5ab44e49e5616a90b28))
+*   Don't refine already refined skolems ([f39b3965](https://github.com/gluon-lang/gluon/commit/f39b39658d9b01c7e503a1a519ce5f134127b1bd), closes [#842](https://github.com/gluon-lang/gluon/issues/842))
+*   Recognize raw string literals without any `#` ([4d66fbb3](https://github.com/gluon-lang/gluon/commit/4d66fbb37f5acae81c28fe3af715b8d1c04a2ab5), closes [#885](https://github.com/gluon-lang/gluon/issues/885))
+*   Prevent zero-argument functions from being created in Rust ([e91ea06d](https://github.com/gluon-lang/gluon/commit/e91ea06d447fea4f9e5699ada6f38e742526ebc7), closes [#873](https://github.com/gluon-lang/gluon/issues/873))
+*   Give tuple fields a span ([2a1c2c71](https://github.com/gluon-lang/gluon/commit/2a1c2c711408372eed71812696776ee93fde3c0a))
+*   xor_shift_new inconsistent description ([591b64b3](https://github.com/gluon-lang/gluon/commit/591b64b359d98948ca379fd2f17e8d34982d12b2))
+
+
+
 <a name="v0.17.2"></a>
 ### v0.17.2 (2020-10-25)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,11 @@ To build and run all(*) tests for Gluon you can call `cargo test --features test
 
 Once you have made some changes, you will need to file a pull request to get your changes merged into the main repository. If the code is still a work in progress, it can still be a good idea to submit a PR. That will let other contributors see your progress and provide assistance (you may prefix the PR message with [WIP] to make it explicit that the PR is incomplete).
 
-You may see that some of the [commits][] follow the [commit message convention of Angular][]. Following this convention is optional but if you enjoy using it, feel free to do so! 
+You may see that some of the [commits][] follow the [commit message convention of Angular][]. Following this convention is optional but if you enjoy using it, feel free to do so!
 
 [commits]:https://github.com/gluon-lang/gluon/commit/9b36d699c63e482969239ed9f84779f7cd1ad2f3
 [commit message convention of Angular]:https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
+
+## Releases
+
+Releases are done by running `./scripts/release.sh <patch|minor|major> <new-version>` on a branch and making a PR. After the PR is merged and has passed CI `git push --tags` will make CI publish the new version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gluon"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_base"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anymap",
  "bitflags",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_c-api"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "futures 0.3.17",
  "gluon",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_check"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_codegen"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "env_logger 0.9.0",
  "gluon",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_completion"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "codespan",
  "collect-mac",
@@ -1270,7 +1270,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_doc"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "cargo-deadlinks",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_format"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "codespan",
  "difference",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_parser"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_repl"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "gluon_vm"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 keywords = ["script", "scripting", "language"]
 build = "build.rs"
@@ -26,12 +26,12 @@ name = "gluon"
 path = "src/lib.rs"
 
 [dependencies]
-gluon_base = { path = "base", version = "0.17.2" } # GLUON
-gluon_check = { path = "check", version = "0.17.2" } # GLUON
-gluon_parser = { path = "parser", version = "0.17.2" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.17.2" } # GLUON
-gluon_vm = { path = "vm", version = "0.17.2", default-features = false } # GLUON
-gluon_format = { path = "format", version = "0.17.2", default-features = false } # GLUON
+gluon_base = { path = "base", version = "0.18.0" } # GLUON
+gluon_check = { path = "check", version = "0.18.0" } # GLUON
+gluon_parser = { path = "parser", version = "0.18.0" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.18.0" } # GLUON
+gluon_vm = { path = "vm", version = "0.18.0", default-features = false } # GLUON
+gluon_format = { path = "format", version = "0.18.0", default-features = false } # GLUON
 
 async-trait = "0.1.51"
 log = "0.4.14"
@@ -69,7 +69,7 @@ rand = { version = "0.8.4", optional = true }
 rand_xorshift = { version = "0.3.0", optional = true }
 
 [build-dependencies]
-gluon_base = { path = "base", version = "0.17.2" } # GLUON
+gluon_base = { path = "base", version = "0.18.0" } # GLUON
 
 itertools = "0.10.1"
 little-skeptic = { version = "0.15.2", optional = true }
@@ -98,8 +98,8 @@ bincode = "1.3.3"
 
 pulldown-cmark = "0.8.0"
 
-gluon_completion = { path = "completion", version = "0.17.2" } # GLUON
-gluon_codegen = { path = "codegen", version = "0.17.2" } # GLUON
+gluon_completion = { path = "completion", version = "0.18.0" } # GLUON
+gluon_codegen = { path = "codegen", version = "0.18.0" } # GLUON
 
 [features]
 default = ["async", "regex", "random"]

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Gluon requires a recent Rust compiler to build (1.9.0 or later) and is available
 
 ```toml
 [dependencies]
-gluon = "0.17.2"
+gluon = "0.18.0"
 ```
 
 ### Other languages

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_base"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -33,7 +33,7 @@ either = "1.6.1"
 vec_map = "0.8.2"
 typed-arena = "2.0.1"
 
-gluon_codegen = { version = "0.17.2", path = "../codegen" } # GLUON
+gluon_codegen = { version = "0.18.0", path = "../codegen" } # GLUON
 
 serde = { version = "1.0.130", features = ["rc"], optional = true }
 serde_state = { version = "0.4.8", features = ["rc"], optional = true }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/gluon_base/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_base/0.18.0")] // # GLUON
 #![allow(unknown_lints)]
 //! The base crate contains pervasive types used in the compiler such as type representations, the
 //! AST and some basic containers.

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_c-api"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -19,7 +19,7 @@ travis-ci = { repository = "gluon-lang/gluon" }
 crate-type = ["cdylib"]
 
 [dependencies]
-gluon = { version = "0.17.2", path = ".." } # GLUON
+gluon = { version = "0.18.0", path = ".." } # GLUON
 futures = "0.3.17"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -1,5 +1,5 @@
 //! A (WIP) C API allowing use of gluon in other langauges than Rust.
-#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_c-api/0.18.0")] // # GLUON
 
 use std::{slice, str};
 

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_check"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -30,14 +30,14 @@ codespan-reporting = "0.11.1"
 
 strsim = "0.10.0"
 
-gluon_base = { path = "../base", version = "0.17.2" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.17.2" } # GLUON
+gluon_base = { path = "../base", version = "0.18.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.18.0" } # GLUON
 
 [dev-dependencies]
 env_logger = "0.9.0"
 insta = "1.8.0"
 
-gluon_parser = { path = "../parser", version = "0.17.2" } # GLUON
+gluon_parser = { path = "../parser", version = "0.18.0" } # GLUON
 gluon_format = { path = "../format", version = ">=0.9" }
 
 collect-mac = "0.1.0"

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -3,7 +3,7 @@
 //! If an AST passes the checks in `Typecheck::typecheck_expr` (which runs all of theses checks
 //! the expression is expected to compile succesfully (if it does not it should be considered an
 //! internal compiler error.
-#![doc(html_root_url = "https://docs.rs/gluon_check/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_check/0.18.0")] // # GLUON
 
 #[macro_use]
 extern crate collect_mac;

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_codegen"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 
 edition = "2018"

--- a/completion/Cargo.toml
+++ b/completion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_completion"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ itertools = "0.10.1"
 walkdir = "2.3.2"
 codespan = "0.11.1"
 
-gluon_base = { path = "../base", version = "0.17.2" } # GLUON
+gluon_base = { path = "../base", version = "0.18.0" } # GLUON
 
 [dev-dependencies]
 collect-mac = "0.1.0"
@@ -25,5 +25,5 @@ env_logger = "0.9.0"
 pretty_assertions = "1.0.0"
 quick-error = "2.0.1"
 
-gluon_check = { path = "../check", version = "0.17.2" } # GLUON
-gluon_parser = { path = "../parser", version = "0.17.2" } # GLUON
+gluon_check = { path = "../check", version = "0.18.0" } # GLUON
+gluon_parser = { path = "../parser", version = "0.18.0" } # GLUON

--- a/completion/src/lib.rs
+++ b/completion/src/lib.rs
@@ -1,5 +1,5 @@
 //! Primitive auto completion and type quering on ASTs
-#![doc(html_root_url = "https://docs.rs/gluon_completion/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_completion/0.18.0")] // # GLUON
 
 extern crate gluon_base as base;
 

--- a/doc/Cargo.toml
+++ b/doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_doc"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -32,8 +32,8 @@ serde = "1.0.130"
 serde_derive = "1.0.130"
 serde_json = "1.0.68"
 
-gluon = { version = "0.17.2", default-features = false, path = ".." } # GLUON
-completion = { package = "gluon_completion", version = "0.17.2", path = "../completion" } # GLUON
+gluon = { version = "0.18.0", default-features = false, path = ".." } # GLUON
+completion = { package = "gluon_completion", version = "0.18.0", path = "../completion" } # GLUON
 
 
 [dev-dependencies]

--- a/format/Cargo.toml
+++ b/format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_format"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ pretty = "0.10.0"
 itertools = "0.10.1"
 codespan = "0.11.1"
 
-gluon_base = { path = "../base", version = "0.17.2" } # GLUON
+gluon_base = { path = "../base", version = "0.18.0" } # GLUON
 
 [dev-dependencies]
 difference = "2.0.0"
@@ -28,7 +28,7 @@ pretty_assertions = "1.0.0"
 tokio = { version = "1.12.0", features = ["macros"] }
 walkdir = "2.3.2"
 
-gluon_base = { path = "../base", version = "0.17.2" } # GLUON
+gluon_base = { path = "../base", version = "0.18.0" } # GLUON
 gluon = { path = "..", version = ">=0.9" }
 
 tensile = { version = "0.7", features = ["tokio"] }

--- a/format/src/lib.rs
+++ b/format/src/lib.rs
@@ -1,5 +1,5 @@
 //! Code formatter.
-#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_formatter/0.18.0")] // # GLUON
 
 extern crate codespan;
 #[macro_use]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_parser"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -23,7 +23,7 @@ itertools = "0.10.1"
 quick-error = "2.0.1"
 lalrpop-util = "0.19.6"
 log = "0.4.14"
-gluon_base = { path = "../base", version = "0.17.2" } # GLUON
+gluon_base = { path = "../base", version = "0.18.0" } # GLUON
 ordered-float = "2.8.0"
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,7 +1,7 @@
 //! The parser is a bit more complex than it needs to be as it needs to be fully specialized to
 //! avoid a recompilation every time a later part of the compiler is changed. Due to this the
 //! string interner and therefore also garbage collector needs to compiled before the parser.
-#![doc(html_root_url = "https://docs.rs/gluon_parser/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_parser/0.18.0")] // # GLUON
 
 extern crate gluon_base as base;
 #[macro_use]

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_repl"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus Westerlind <marwes91@gmail.com>"]
 edition = "2018"
 
@@ -20,12 +20,12 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-gluon = { version = "0.17.2", path = "..", features = ["serialization"] } # GLUON
-gluon_vm = { version = "0.17.2", path = "../vm", features = ["serialization"] } # GLUON
-gluon_completion = { path = "../completion", version = "0.17.2" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.17.2" } # GLUON
-gluon_format = { version = "0.17.2", path = "../format" } # GLUON
-gluon_doc = { version = "0.17.2", path = "../doc" } # GLUON
+gluon = { version = "0.18.0", path = "..", features = ["serialization"] } # GLUON
+gluon_vm = { version = "0.18.0", path = "../vm", features = ["serialization"] } # GLUON
+gluon_completion = { path = "../completion", version = "0.18.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.18.0" } # GLUON
+gluon_format = { version = "0.18.0", path = "../format" } # GLUON
+gluon_doc = { version = "0.18.0", path = "../doc" } # GLUON
 
 app_dirs = { package = "app_dirs2", version = "2.3.2" }
 anyhow = "1.0.44"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! behaviour. For information about how to use this library the best resource currently is the
 //! [tutorial](http://gluon-lang.org/book/index.html) which contains examples
 //! on how to write gluon programs as well as how to run them using this library.
-#![doc(html_root_url = "https://docs.rs/gluon/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon/0.18.0")] // # GLUON
 #![recursion_limit = "128"]
 #[cfg(test)]
 extern crate env_logger;

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gluon_vm"
-version = "0.17.2" # GLUON
+version = "0.18.0" # GLUON
 authors = ["Markus <marwes91@gmail.com>"]
 edition = "2018"
 build = "build.rs"
@@ -46,10 +46,10 @@ serde_state = { version = "0.4.8", optional = true }
 serde_derive = { version = "1.0.130", optional = true }
 serde_derive_state = { version = "0.4.10", optional = true }
 
-gluon_base = { path = "../base", version = "0.17.2" } # GLUON
-gluon_check = { path = "../check", version = "0.17.2" } # GLUON
-gluon_codegen = { path = "../codegen", version = "0.17.2" } # GLUON
-gluon_parser = { path = "../parser", version = "0.17.2", optional = true } # GLUON
+gluon_base = { path = "../base", version = "0.18.0" } # GLUON
+gluon_check = { path = "../check", version = "0.18.0" } # GLUON
+gluon_codegen = { path = "../codegen", version = "0.18.0" } # GLUON
+gluon_parser = { path = "../parser", version = "0.18.0", optional = true } # GLUON
 
 [build-dependencies]
 lalrpop = { version = "0.19.6", features = ["lexer"], optional = true }
@@ -68,7 +68,7 @@ regex = "1.5.4"
 serde_json = "1.0.68"
 tokio = { version = "1.12.0", features = ["macros"] }
 
-gluon_parser = { path = "../parser", version = "0.17.2" } # GLUON
+gluon_parser = { path = "../parser", version = "0.18.0" } # GLUON
 
 [features]
 serialization = ["serde", "serde_state", "serde_derive", "serde_derive_state", "serde_json", "gluon_base/serialization", "codespan/serialization"]

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,5 +1,5 @@
 //! Crate which contain the virtual machine which executes gluon programs
-#![doc(html_root_url = "https://docs.rs/gluon_vm/0.17.2")] // # GLUON
+#![doc(html_root_url = "https://docs.rs/gluon_vm/0.18.0")] // # GLUON
 #![recursion_limit = "1024"]
 
 #[macro_use]


### PR DESCRIPTION
<a name="v0.18.0"></a>
## v0.18.0 (2021-10-03)

#### Performance

*   Avoid recreating the vm for each formatted file ([0335733](0335733))

#### Breaking Changes

*   Make channels and reference require IO ([c904189](c904189), breaks [#](https://github.com/gluon-lang/gluon/issues/))

#### Features

*   Make channels and reference require IO ([c904189](c904189), breaks [#](https://github.com/gluon-lang/gluon/issues/))
*   Allow specifying type signatures in do bindings ([fac08dc](fac08dc))
*   Allow macros to refer to symbols in scope at the expansion site ([1a5489c](1a5489c), closes [#895](#895))
*   Allow the http module to be used without a tcp listener ([c45353d](c45353d))
*   Format seq expressions without seq ([5c0cec2](5c0cec2))
*   Compile block expressions as monadic sequences ([bce5973](bce5973), closes [#884](#884))
* **std:**
  *  add Option assertions to std.test ([28e5053](28e5053))
  *  add modulo functions to int and float ([92f188a](92f188a))

#### Bug Fixes

*   Allow the repl to compile concurrently ([2118f4d](2118f4d))
*   Don't use the empty span in derive macros ([d05f1ca](d05f1ca))
*   Provide the type of imported modules with errors ([d3bfc59](d3bfc59))
*   Don't refine already refined skolems ([f39b396](f39b396), closes [#842](#842))
*   Recognize raw string literals without any `#` ([4d66fbb](4d66fbb), closes [#885](#885))
*   Prevent zero-argument functions from being created in Rust ([e91ea06](e91ea06), closes [#873](#873))
*   Give tuple fields a span ([2a1c2c7](2a1c2c7))
*   xor_shift_new inconsistent description ([591b64b](591b64b))