### PR TITLE
Fix compilation error caused by unnecessary lifetime placeholders

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -805,7 +805,7 @@ async fn global(
 use std::cell::RefCell;
 pub struct Env<T>(RefCell<T>);
 
-pub(crate) fn env(env: &(dyn Compilation + '_)) -> Env<&'_ CompilerDatabase> {
+pub(crate) fn env(env: &(dyn Compilation)) -> Env<&CompilerDatabase> {
     Env(RefCell::new(env.compiler()))
 }
 pub(crate) fn snapshot_env<T>(env: T) -> Env<T>


### PR DESCRIPTION
Attempting to install gluon repl from Cargo currently fails:

```
error[E0106]: missing lifetime specifier
   --> /Users/kinrany/.cargo/registry/src/github.com-1ecc6299db9ec823/gluon-0.18.1/src/query.rs:808:57
    |
808 | pub(crate) fn env(env: &(dyn Compilation + '_)) -> Env<&'_ CompilerDatabase> {
    |                        -----------------------          ^^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `env`'s 2 lifetimes it is borrowed from
help: consider introducing a named lifetime parameter
    |
808 | pub(crate) fn env<'a>(env: &'a (dyn Compilation + 'a)) -> Env<&'a CompilerDatabase> {
    |                  ++++       ++                    ~~           ~~
```

System: macOS Monterey 12.1, M1
Rust toolchain: 1.64.0
Gluon repl version: 0.18.0

This PR removes two lifetime placeholders that were preventing the compiler from inferring correct lifetimes.

Note that this makes `dyn Compilation` have a `'static` lifetime.