### PR TITLE
mark freeze_expr function as unsafe

### DIFF
--- a/vm/src/core/interpreter.rs
+++ b/vm/src/core/interpreter.rs
@@ -690,15 +690,15 @@ impl<'a, 'e> Compiler<'a, 'e> {
                         key,
                         match value.as_ref().map(|b| &b.bind) {
                             Some(Binding::Expr(Reduced::Local(expr))) => Binding::Expr(
-                                Reduced::Local(crate::core::freeze_expr(allocator, expr)),
+                                Reduced::Local(unsafe { crate::core::freeze_expr(allocator, expr) }),
                             ),
                             Some(Binding::Closure(Reduced::Local(ClosureRef {
                                 id,
                                 args,
                                 body,
-                            }))) => Binding::Closure(Reduced::Local(crate::core::freeze_closure(
+                            }))) => Binding::Closure(Reduced::Local(unsafe { crate::core::freeze_closure(
                                 allocator, id, args, body,
-                            ))),
+                            ) })),
                             Some(Binding::Expr(Reduced::Global(global))) => {
                                 Binding::Expr(Reduced::Global(global.clone()))
                             }

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -790,7 +790,7 @@ pub fn translate(
     expr: &SpannedExpr<'_, Symbol>,
 ) -> CoreExpr {
     with_translator(env, |translator| {
-        freeze_expr(&translator.allocator, translator.translate_alloc(expr))
+        unsafe { freeze_expr(&translator.allocator, translator.translate_alloc(expr)) }
     })
 }
 

--- a/vm/src/core/mod.rs
+++ b/vm/src/core/mod.rs
@@ -599,39 +599,35 @@ mod internal {
         }
     }
 
-    pub fn freeze_expr<'a>(allocator: &'a Arc<Allocator<'a>>, expr: CExpr<'a>) -> CoreExpr {
-        unsafe {
-            // Here we temporarily forget the lifetime of `allocator` so it can be moved into a
-            // `CoreExpr`. After we have it in `CoreExpr` the expression is then guaranteed to live as
-            // long as the `CoreExpr` making it safe again
-            CoreExpr::new(
-                FrozenAllocator(mem::transmute::<Arc<Allocator>, Arc<Allocator<'static>>>(
-                    allocator.clone(),
-                )),
-                mem::transmute::<CExpr, CExpr<'static>>(expr),
-            )
-        }
+    pub unsafe fn freeze_expr<'a>(allocator: &'a Arc<Allocator<'a>>, expr: CExpr<'a>) -> CoreExpr {     
+        // Here we temporarily forget the lifetime of `allocator` so it can be moved into a
+        // `CoreExpr`. After we have it in `CoreExpr` the expression is then guaranteed to live as
+        // long as the `CoreExpr` making it safe again
+        CoreExpr::new(
+            FrozenAllocator(mem::transmute::<Arc<Allocator>, Arc<Allocator<'static>>>(
+                allocator.clone(),
+            )),
+            mem::transmute::<CExpr, CExpr<'static>>(expr),
+        )     
     }
 
-    pub fn freeze_closure<'a>(
+    pub unsafe fn freeze_closure<'a>(
         allocator: &'a Arc<Allocator<'a>>,
         id: &'a TypedIdent<Symbol>,
         args: &'a [TypedIdent<Symbol>],
         expr: CExpr<'a>,
     ) -> CoreClosure {
-        unsafe {
-            // Here we temporarily forget the lifetime of `allocator` so it can be moved into a
-            // `CoreClosure`. After we have it in `CoreClusre` the expression is then guaranteed to live as
-            // long as the `CoreClosure` making it safe again
-            CoreClosure::new(
-                FrozenAllocator(mem::transmute::<Arc<Allocator>, Arc<Allocator<'static>>>(
-                    allocator.clone(),
-                )),
-                mem::transmute::<&TypedIdent<Symbol>, &TypedIdent<Symbol>>(id),
-                mem::transmute::<&[TypedIdent<Symbol>], &[TypedIdent<Symbol>]>(args),
-                mem::transmute::<CExpr, CExpr<'static>>(expr),
-            )
-        }
+        // Here we temporarily forget the lifetime of `allocator` so it can be moved into a
+        // `CoreClosure`. After we have it in `CoreClusre` the expression is then guaranteed to live as
+        // long as the `CoreClosure` making it safe again
+        CoreClosure::new(
+            FrozenAllocator(mem::transmute::<Arc<Allocator>, Arc<Allocator<'static>>>(
+                allocator.clone(),
+            )),
+            mem::transmute::<&TypedIdent<Symbol>, &TypedIdent<Symbol>>(id),
+            mem::transmute::<&[TypedIdent<Symbol>], &[TypedIdent<Symbol>]>(args),
+            mem::transmute::<CExpr, CExpr<'static>>(expr),
+        )
     }
 
     fn assert_sync<T: Sync>() {}


### PR DESCRIPTION
https://github.com/gluon-lang/gluon/blob/27cec6c8ef90de7341d22a2beeade532680aa40c/vm/src/core/mod.rs#L602-L614
https://github.com/gluon-lang/gluon/blob/27cec6c8ef90de7341d22a2beeade532680aa40c/vm/src/core/mod.rs#L616-L635
Hi, it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the freeze_expr function may not notice this safety requirement.

And inside the function body, mem::transmute is used twice, which is an unsafe operation. The first time is to convert the type of allocator.clone() from Arc<Allocator> to Arc<Allocator<'static>>, and the second time is to convert expr of type CExpr to type CExpr<'static>. These operations will make the type system unable to guarantee the type safety of the code, so it is necessary to use the unsafe keyword to mark the function and remind users to use it with caution.

Marking them unsafe also means that callers must make sure they know what they're doing.

